### PR TITLE
Emit the full path for filenames.

### DIFF
--- a/elftools/dwarf/die.py
+++ b/elftools/dwarf/die.py
@@ -7,8 +7,9 @@
 # This code is in the public domain
 #-------------------------------------------------------------------------------
 from collections import namedtuple
+import os
 
-from ..common.py3compat import OrderedDict
+from ..common.py3compat import OrderedDict, bytes2str
 from ..common.utils import struct_parse, preserve_stream_pos
 
 
@@ -98,6 +99,28 @@ class DIE(object):
             top-level DIE).
         """
         return self._parent
+
+    def get_filename(self):
+        """Return the filename for the DIE.
+        The filename, which is the join of 'DW_AT_comp_dir' and 'DW_AT_name',
+        either of which may be missing in practice. Note that its value
+        is usually a string taken from the .debug_string section and the
+        returned value will be a string.
+        """
+        comp_dir = ''
+        try:
+            comp_dir_attr = self.attributes['DW_AT_comp_dir']
+            comp_dir = bytes2str(comp_dir_attr.value)
+        except KeyError:
+            pass
+
+        fname = ''
+        try:
+            fname_attr = self.attributes['DW_AT_name']
+            fname = bytes2str(fname_attr.value)
+        except KeyError:
+            pass
+        return os.path.join(comp_dir, fname)
 
     def iter_children(self):
         """ Yield all children of this DIE

--- a/examples/dwarf_die_tree.py
+++ b/examples/dwarf_die_tree.py
@@ -8,14 +8,12 @@
 # This code is in the public domain
 #-------------------------------------------------------------------------------
 from __future__ import print_function
-import os
 import sys
 
 # If pyelftools is not installed, the example can also run from the root or
 # examples/ dir of the source distribution.
 sys.path[0:0] = ['.', '..']
 
-from elftools.common.py3compat import bytes2str
 from elftools.elf.elffile import ELFFile
 
 
@@ -45,28 +43,8 @@ def process_file(filename):
             top_DIE = CU.get_top_DIE()
             print('    Top DIE with tag=%s' % top_DIE.tag)
 
-            # Each DIE holds an OrderedDict of attributes, mapping names to
-            # values. Values are represented by AttributeValue objects in
-            # elftools/dwarf/die.py
-            # We're interested in the filename, which is the join of
-            # 'DW_AT_comp_dir' and 'DW_AT_name', either of which may be
-            # missing in practice. Note that its value
-            # is usually a string taken from the .debug_string section. This
-            # is done transparently by the library, and such a value will be
-            # simply given as a string.
-            try:
-                comp_dir_attr = top_DIE.attributes['DW_AT_comp_dir']
-                comp_dir = bytes2str(comp_dir_attr.value)
-                try:
-                    name_attr = top_DIE.attributes['DW_AT_name']
-                    name = bytes2str(name_attr.value)
-                    name = os.path.join(comp_dir, name)
-                except KeyError as e:
-                    name = comp_dir
-            except KeyError as e:
-                name_attr = top_DIE.attributes['DW_AT_name']
-                name = bytes2str(name_attr.value)
-            print('    name=%s' % name)
+            # We're interested in the filename...
+            print('    name=%s' % top_DIE.get_filename())
 
             # Display DIEs recursively starting with top_DIE
             die_info_rec(top_DIE)

--- a/examples/examine_dwarf_info.py
+++ b/examples/examine_dwarf_info.py
@@ -7,14 +7,12 @@
 # This code is in the public domain
 #-------------------------------------------------------------------------------
 from __future__ import print_function
-import os
 import sys
 
 # If pyelftools is not installed, the example can also run from the root or
 # examples/ dir of the source distribution.
 sys.path[0:0] = ['.', '..']
 
-from elftools.common.py3compat import bytes2str
 from elftools.elf.elffile import ELFFile
 
 
@@ -44,28 +42,8 @@ def process_file(filename):
             top_DIE = CU.get_top_DIE()
             print('    Top DIE with tag=%s' % top_DIE.tag)
 
-            # Each DIE holds an OrderedDict of attributes, mapping names to
-            # values. Values are represented by AttributeValue objects in
-            # elftools/dwarf/die.py
-            # We're interested in the filename, which is the join of
-            # 'DW_AT_comp_dir' and 'DW_AT_name', either of which may be
-            # missing in practice. Note that its value
-            # is usually a string taken from the .debug_string section. This
-            # is done transparently by the library, and such a value will be
-            # simply given as a string.
-            try:
-                comp_dir_attr = top_DIE.attributes['DW_AT_comp_dir']
-                comp_dir = bytes2str(comp_dir_attr.value)
-                try:
-                    name_attr = top_DIE.attributes['DW_AT_name']
-                    name = bytes2str(name_attr.value)
-                    name = os.path.join(comp_dir, name)
-                except KeyError as e:
-                    name = comp_dir
-            except KeyError as e:
-                name_attr = top_DIE.attributes['DW_AT_name']
-                name = bytes2str(name_attr.value)
-            print('    name=%s' % bytes2str(name))
+            # We're interested in the filename...
+            print('    name=%s' % top_DIE.get_filename())
 
 if __name__ == '__main__':
     for filename in sys.argv[1:]:


### PR DESCRIPTION
The full name of a file is the concatenation of DW_AT_comp_dir and DW_AT_name where either can actually be missing. This patch handles all the cases I have seen, notably the exception when DW_AT_name is the missing attribute.
