### PR TITLE
    Use correct Python2/3 compatibility iterator.

### DIFF
--- a/elftools/dwarf/die.py
+++ b/elftools/dwarf/die.py
@@ -9,7 +9,7 @@
 from collections import namedtuple
 import os
 
-from ..common.py3compat import OrderedDict, bytes2str
+from ..common.py3compat import OrderedDict, bytes2str, iteritems
 from ..common.utils import struct_parse, preserve_stream_pos
 
 
@@ -143,7 +143,7 @@ class DIE(object):
     def __repr__(self):
         s = 'DIE %s, size=%s, has_chidren=%s\n' % (
             self.tag, self.size, self.has_children)
-        for attrname, attrval in self.attributes.iteritems():
+        for attrname, attrval in iteritems(self.attributes):
             s += '    |%-18s:  %s\n' % (attrname, attrval)
         return s
 


### PR DESCRIPTION
Use an iterator which provides for Python2 and Python3 compatibility. All the unit tests pass, but I have not extended them to test this functionality. If required, a test like the following exercises the change:

$ git diff examples/dwarf_die_tree.py
diff --git a/examples/dwarf_die_tree.py b/examples/dwarf_die_tree.py
index 9dcb6b6..98851f4 100644
--- a/examples/dwarf_die_tree.py
+++ b/examples/dwarf_die_tree.py
@@ -62,7 +62,7 @@ def die_info_rec(die, indent_level='    '):
     """ A recursive function for showing information about a DIE and its
         children.
     """
-    print(indent_level + 'DIE tag=%s' % die.tag)
-    print(indent_level + 'DIE=%s' % die)
   child_indent = indent_level + '  '
   for child in die.iter_children():
       die_info_rec(child, child_indent)
