### PR TITLE
Performance and memory improvements

### DIFF
--- a/elftools/dwarf/compileunit.py
+++ b/elftools/dwarf/compileunit.py
@@ -91,6 +91,10 @@ class CompileUnit(object):
             self._dielist_complete = False
             self._dielist[0].remove_all_children()
 
+    def full_load_DIEs(self):
+        self._parse_DIEs(1 << 64)
+        pass
+
     #------ PRIVATE ------#
 
     def __getitem__(self, name):

--- a/elftools/dwarf/compileunit.py
+++ b/elftools/dwarf/compileunit.py
@@ -55,6 +55,8 @@ class CompileUnit(object):
 
         # A list of DIEs belonging to this CU. Lazily parsed.
         self._dielist = []
+        self._dielist_complete = False
+        self._dielist_next_offset = cu_die_offset
 
     def dwarf_format(self):
         """ Get the DWARF format (32 or 64) for this CU
@@ -79,8 +81,15 @@ class CompileUnit(object):
         """ Iterate over all the DIEs in the CU, in order of their appearance.
             Note that null DIEs will also be returned.
         """
-        self._parse_DIEs()
+        self._parse_DIEs(1 << 64)
         return iter(self._dielist)
+
+    def clear_DIEs(self):
+        if self._dielist:
+            self._dielist[1:] = []
+            self._dielist_next_offset = self._die_offset_after_first
+            self._dielist_complete = False
+            self._dielist[0].remove_all_children()
 
     #------ PRIVATE ------#
 
@@ -92,16 +101,16 @@ class CompileUnit(object):
     def _get_DIE(self, index):
         """ Get the DIE at the given index
         """
-        self._parse_DIEs()
+        self._parse_DIEs(index)
         return self._dielist[index]
 
-    def _parse_DIEs(self):
+    def _parse_DIEs(self, want):
         """ Parse all the DIEs pertaining to this CU from the stream and shove
             them sequentially into self._dielist.
             Also set the child/sibling/parent links in the DIEs according
             (unflattening the prefix-order of the DIE tree).
         """
-        if len(self._dielist) > 0:
+        if self._dielist_complete or len(self._dielist) > want:
             return
 
         # Compute the boundary (one byte past the bounds) of this CU in the
@@ -111,14 +120,21 @@ class CompileUnit(object):
                         self.structs.initial_length_field_size())
 
         # First pass: parse all DIEs and place them into self._dielist
-        die_offset = self.cu_die_offset
-        while die_offset < cu_boundary:
+        die_offset = self._dielist_next_offset
+        while die_offset < cu_boundary and len(self._dielist) <= want:
             die = DIE(
                     cu=self,
                     stream=self.dwarfinfo.debug_info_sec.stream,
                     offset=die_offset)
             self._dielist.append(die)
             die_offset += die.size
+            if len(self._dielist) == 1:
+                self._die_offset_after_first = die_offset
+                pass
+        self._dielist_next_offset = die_offset
+
+        if die_offset >= cu_boundary:
+            self._dielist_complete = True
 
         # Second pass - unflatten the DIE tree
         self._unflatten_tree()
@@ -141,6 +157,7 @@ class CompileUnit(object):
                 cur_parent.add_child(die)
                 die.set_parent(cur_parent)
                 if die.has_children:
+                    die.remove_all_children()
                     parentstack.append(die)
             else:
                 # parentstack should not be really empty here. However, some

--- a/elftools/dwarf/die.py
+++ b/elftools/dwarf/die.py
@@ -117,6 +117,7 @@ class DIE(object):
     def iter_children(self):
         """ Yield all children of this DIE
         """
+        self.cu.full_load_DIEs()
         return iter(self._children)
 
     def iter_siblings(self):

--- a/elftools/dwarf/die.py
+++ b/elftools/dwarf/die.py
@@ -135,6 +135,9 @@ class DIE(object):
     def add_child(self, die):
         self._children.append(die)
 
+    def remove_all_children(self):
+        self._children = []
+
     def set_parent(self, die):
         self._parent = die
 

--- a/elftools/dwarf/dwarfinfo.py
+++ b/elftools/dwarf/dwarfinfo.py
@@ -93,6 +93,9 @@ class DWARFInfo(object):
         # Cache for abbrev tables: a dict keyed by offset
         self._abbrevtable_cache = {}
 
+        self._CU_next_offset = 0
+        self._CU_cache = []
+
     def iter_CUs(self):
         """ Yield all the compile units (CompileUnit objects) in the debug info
         """
@@ -185,16 +188,28 @@ class DWARFInfo(object):
     def _parse_CUs_iter(self):
         """ Parse CU entries from debug_info. Yield CUs in order of appearance.
         """
-        offset = 0
-        while offset < self.debug_info_sec.size:
-            cu = self._parse_CU_at_offset(offset)
+        idx = 0
+        while idx < len(self._CU_cache):
+            yield self._CU_cache[idx]
+            idx = idx + 1
+
+        while self._CU_next_offset < self.debug_info_sec.size:
+            cu = self._parse_CU_at_offset(self._CU_next_offset)
             # Compute the offset of the next CU in the section. The unit_length
             # field of the CU header contains its size not including the length
             # field itself.
-            offset = (  offset +
+            offset = (  self._CU_next_offset +
                         cu['unit_length'] +
                         cu.structs.initial_length_field_size())
+            self._CU_next_offset = offset
+            self._CU_cache.append(cu)
+            last_cache_len = len(self._CU_cache)
             yield cu
+
+            # There are new CUs added to the cache since last yield.
+            while last_cache_len < len(self._CU_cache):
+                yield self._CU_cache[last_cache_len]
+                last_cache_len = last_cache_len + 1
 
     def _parse_CU_at_offset(self, offset):
         """ Parse and return a CU at the given offset in the debug_info stream.


### PR DESCRIPTION
This request includes performance improvement and memory footprint reducing.  I am using pyelftools in my project to parse and analysis runtime information of Gecko.  It is end up to consume a lot of memory and hit some performance problem.   This request includes following changes
 - Parse DIEs increamentally
 - A cache for CUs
 - Optional to use ShiftedIO instead of BytesIO to avoid reading data into the memory until necessary.
