### PR TITLE
Add ELFFile.map() method to get file offset from memory address

### DIFF
--- a/elftools/elf/elffile.py
+++ b/elftools/elf/elffile.py
@@ -107,6 +107,16 @@ class ELFFile(object):
         """
         for i in range(self.num_segments()):
             yield self.get_segment(i)
+    
+    def address_offsets(self, start, size=1):
+        """ Yield a file offset for each ELF segment matching a memory region
+        """
+        end = start + size
+        for seg in self.iter_segments():
+            if (start >= seg['p_vaddr'] and
+                    end <= seg['p_vaddr'] + seg['p_filesz']):
+                # Region is contained completely within this segment
+                yield start - seg['p_vaddr'] + seg['p_offset']
 
     def has_dwarf_info(self):
         """ Check whether this file appears to have debugging information.

--- a/test/test_elffile.py
+++ b/test/test_elffile.py
@@ -1,0 +1,50 @@
+#-------------------------------------------------------------------------------
+# elftools tests
+#
+# Eli Bendersky (eliben@gmail.com)
+# This code is in the public domain
+#-------------------------------------------------------------------------------
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
+
+from utils import setup_syspath; setup_syspath()
+from elftools.elf.elffile import ELFFile
+
+class TestMap(unittest.TestCase):
+    def runTest(self):
+        class MockELF(ELFFile):
+            __init__ = object.__init__
+            def iter_segments(self):
+                return iter((
+                    dict(p_vaddr=0x10200, p_filesz=0x200, p_offset=0x100),
+                    dict(p_vaddr=0x10100, p_filesz=0x100, p_offset=0x400),
+                ))
+        
+        elf = MockELF()
+        
+        self.assertEqual(tuple(elf.address_offsets(0x10100)), (0x400,))
+        self.assertEqual(tuple(elf.address_offsets(0x10120)), (0x420,))
+        self.assertEqual(tuple(elf.address_offsets(0x101FF)), (0x4FF,))
+        self.assertEqual(tuple(elf.address_offsets(0x10200)), (0x100,))
+        self.assertEqual(tuple(elf.address_offsets(0x100FF)), ())
+        self.assertEqual(tuple(elf.address_offsets(0x10400)), ())
+        
+        self.assertEqual(
+            tuple(elf.address_offsets(0x10100, 0x100)), (0x400,))
+        self.assertEqual(tuple(elf.address_offsets(0x10100, 4)), (0x400,))
+        self.assertEqual(tuple(elf.address_offsets(0x10120, 4)), (0x420,))
+        self.assertEqual(tuple(elf.address_offsets(0x101FC, 4)), (0x4FC,))
+        self.assertEqual(tuple(elf.address_offsets(0x10200, 4)), (0x100,))
+        self.assertEqual(tuple(elf.address_offsets(0x10100, 0x200)), ())
+        self.assertEqual(tuple(elf.address_offsets(0x10000, 0x800)), ())
+        self.assertEqual(tuple(elf.address_offsets(0x100FC, 4)), ())
+        self.assertEqual(tuple(elf.address_offsets(0x100FE, 4)), ())
+        self.assertEqual(tuple(elf.address_offsets(0x101FE, 4)), ())
+        self.assertEqual(tuple(elf.address_offsets(0x103FE, 4)), ())
+        self.assertEqual(tuple(elf.address_offsets(0x10400, 4)), ())
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
There are a few implementations of this floating around (e.g. _string_table() method in Issue #3). My version includes a size parameter so that we can check if a whole region is mapped, rather than just a single byte. It also raises an error for multiple inconsistent mappings. Let me know if you’d rather go for a simpler version of this function without these features.
