### PR TITLE
Convenientce: Enable opening an ELF file by pathname rather than file()

### DIFF
--- a/elftools/elf/elffile.py
+++ b/elftools/elf/elffile.py
@@ -46,6 +46,9 @@ class ELFFile(object):
                 the raw e_ident field of the header
     """
     def __init__(self, stream):
+        if isinstance(stream, basestring):
+            stream = open(stream, 'rb')
+
         self.stream = stream
         self._identify_file()
         self.structs = ELFStructs(


### PR DESCRIPTION
Just a convenience method.

```
>>> import elftools.elf.elffile
>>> elftools.elf.elffile.ELFFile('/bin/sh').stream.name
'/bin/sh'
```
