### PR TITLE
Fixed dynamic symbols iteration in the dynamic segment

### DIFF
--- a/elftools/elf/structs.py
+++ b/elftools/elf/structs.py
@@ -36,6 +36,9 @@ class ELFStructs(object):
             Elf_Sym:
                 Symbol table entry
 
+            Elf_SymHashHdr:
+                Symbol hash table header
+
             Elf_Rel, Elf_Rela:
                 Entries in relocation sections
     """
@@ -71,6 +74,7 @@ class ELFStructs(object):
         self._create_phdr()
         self._create_shdr()
         self._create_sym()
+        self._create_sym_hash_table_header()
         self._create_rel()
         self._create_dyn()
         self._create_sunw_syminfo()
@@ -176,6 +180,12 @@ class ELFStructs(object):
             Enum(self.Elf_sxword('d_tag'), **ENUM_D_TAG),
             self.Elf_xword('d_val'),
             Value('d_ptr', lambda ctx: ctx['d_val']),
+        )
+
+    def _create_sym_hash_table_header(self):
+        self.Elf_SymHashHdr = Struct('Elf_SymHashHdr',
+            self.Elf_word('nbucket'),
+            self.Elf_word('nchain')
         )
 
     def _create_sym(self):


### PR DESCRIPTION
The previous dynamic symbol lookup worked by heuristically determine the end of the dynamic symbol table, because the dynamic segment does not provide the symbol table length, but only a pointer to the first entry. This heuristic attempts to iterate the dynamic segment tags in order to find the nearest higher pointer to the symbol table entry (the end of the table), which supposes to work in most cases. The problem is that not all the tag values in the dynamic segment represent pointers (d_ptr), some of them represent other values (d_val, for example in DT_NEEDED), and the code assumes that all the tag values represent a pointer. That leads to a wrong result and to an iteration on a partial symbol table.

Instead of the above logic, I decided to implement another method to determine the length of the dynamic symbol table: the hash table. The hash table contains an array called "chains", which contains (according to the specification) the same number of entries as the dynamic symbol table, and therefore this number (found in the hash table header) can be used to determine the number of the dynamic symbols in the dynamic symbol table.