### PR TITLE
Fix Note Type Id decoding.

### DIFF
--- a/elftools/elf/enums.py
+++ b/elftools/elf/enums.py
@@ -598,7 +598,7 @@ ENUM_SUNW_SYMINFO_BOUNDTO = dict(
 )
 
 # PT_NOTE section types
-ENUM_NOTE_N_TYPE = dict(
+ENUM_GNU_NOTE_N_TYPE = dict(
     NT_GNU_ABI_TAG=1,
     NT_GNU_HWCAP=2,
     NT_GNU_BUILD_ID=3,

--- a/elftools/elf/segments.py
+++ b/elftools/elf/segments.py
@@ -121,7 +121,7 @@ class NoteSegment(Segment):
             # n_namesz is 4-byte aligned.
             disk_namesz = roundup(note['n_namesz'], 2)
             # skip parsing truncated notes.
-            if offset+disk_namesz+roundup(note['n_descsz'] > end:
+            if offset+disk_namesz+roundup(note['n_descsz'], 2) > end:
                 break;
             note['n_name'] = bytes2str(
                 CString('').parse(self.stream.read(disk_namesz)))

--- a/elftools/elf/segments.py
+++ b/elftools/elf/segments.py
@@ -124,6 +124,12 @@ class NoteSegment(Segment):
             offset += disk_namesz
 
             desc_data = bytes2str(self.stream.read(note['n_descsz']))
+            if note['n_name'] == 'GNU':                                       
+                for key in ENUM_NOTE_N_TYPE:
+                    if note['n_type'] == ENUM_NOTE_N_TYPE[key] :
+                        note['n_type']=key;
+						break;
+
             if note['n_type'] == 'NT_GNU_ABI_TAG':
                 note['n_desc'] = struct_parse(self._elfstructs.Elf_Nhdr_abi,
                                               self.stream,

--- a/elftools/elf/structs.py
+++ b/elftools/elf/structs.py
@@ -261,7 +261,7 @@ class ELFStructs(object):
         self.Elf_Nhdr = Struct('Elf_Nhdr',
             self.Elf_word('n_namesz'),
             self.Elf_word('n_descsz'),
-            Enum(self.Elf_word('n_type'), **ENUM_NOTE_N_TYPE),
+            self.Elf_word('n_type'),
         )
         self.Elf_Nhdr_abi = Struct('Elf_Nhdr_abi',
             Enum(self.Elf_word('abi_os'), **ENUM_NOTE_ABI_TAG_OS),


### PR DESCRIPTION
The ELF Note TypeId is actually used as a sub type to the Note Name.
That is to say that the enum values currently being used to detect the Note Type are only valid if the Note Name is 'GNU\0'.

This change rectifies that. 
It also handles the case that a segment may be slightly larger than the contained notes.