### PR TITLE
Minor changes to readelf formatting.

### DIFF
--- a/scripts/readelf.py
+++ b/scripts/readelf.py
@@ -873,7 +873,7 @@ class ReadElf(object):
                     # Unknown attribute values are passed-through as integers
                     if isinstance(name, int):
                         name = 'Unknown AT value: %x' % name
-                    self._emitline('    <%2x>   %-18s: %s' % (
+                    self._emitline('    <%x>   %-18s: %s' % (
                         attr.offset,
                         name,
                         describe_attr_value(
@@ -1057,7 +1057,7 @@ class ReadElf(object):
     def _emitline(self, s=''):
         """ Emit an object to output, followed by a newline
         """
-        self.output.write(str(s) + '\n')
+        self.output.write(str(s).rstrip() + '\n')
 
 
 SCRIPT_DESCRIPTION = 'Display information about the contents of ELF format files'


### PR DESCRIPTION
This makes the output more similar to GNU readelf.
It's not identical - in particular there are still a lot of whitespace
differences - but at least gets you within striking distance of no changes when
comparing with "diff -w".