### PR TITLE
Fix relative import statements for Python 3.x compatibility.

### DIFF
--- a/test/all_tests.py
+++ b/test/all_tests.py
@@ -9,7 +9,7 @@
 #-------------------------------------------------------------------------------
 from __future__ import print_function
 import subprocess, sys
-from utils import is_in_rootdir
+from .utils import is_in_rootdir
 
 def run_test_script(path):
     cmd = [sys.executable, path]

--- a/test/run_readelf_tests.py
+++ b/test/run_readelf_tests.py
@@ -13,8 +13,8 @@ from difflib import SequenceMatcher
 from optparse import OptionParser
 import logging
 import platform
-from utils import setup_syspath; setup_syspath()
-from utils import run_exe, is_in_rootdir, dump_output_to_temp_files
+from .utils import setup_syspath; setup_syspath()
+from .utils import run_exe, is_in_rootdir, dump_output_to_temp_files
 
 
 # Create a global logger object

--- a/test/test_arm_support.py
+++ b/test/test_arm_support.py
@@ -10,7 +10,7 @@ except ImportError:
     import unittest
 import os
 
-from utils import setup_syspath; setup_syspath()
+from .utils import setup_syspath; setup_syspath()
 from elftools.elf.elffile import ELFFile
 
 class TestARMSupport(unittest.TestCase):

--- a/test/test_callframe.py
+++ b/test/test_callframe.py
@@ -9,7 +9,7 @@ try:
 except ImportError:
     import unittest
 
-from utils import setup_syspath; setup_syspath()
+from .utils import setup_syspath; setup_syspath()
 from elftools.common.py3compat import BytesIO
 from elftools.dwarf.callframe import (
     CallFrameInfo, CIE, FDE, instruction_name, CallFrameInstruction,

--- a/test/test_double_dynstr_section.py
+++ b/test/test_double_dynstr_section.py
@@ -10,7 +10,7 @@ except ImportError:
     import unittest
 import os
 
-from utils import setup_syspath; setup_syspath()
+from .utils import setup_syspath; setup_syspath()
 from elftools.elf.elffile import ELFFile
 from elftools.elf.dynamic import DynamicSection, DynamicTag
 

--- a/test/test_dwarf_expr.py
+++ b/test/test_dwarf_expr.py
@@ -9,7 +9,7 @@ try:
 except ImportError:
     import unittest
 
-from utils import setup_syspath; setup_syspath()
+from .utils import setup_syspath; setup_syspath()
 from elftools.dwarf.descriptions import ExprDumper, set_global_machine_arch
 from elftools.dwarf.structs import DWARFStructs
 

--- a/test/test_dwarf_lineprogram.py
+++ b/test/test_dwarf_lineprogram.py
@@ -9,7 +9,7 @@ try:
 except ImportError:
     import unittest
 
-from utils import setup_syspath; setup_syspath()
+from .utils import setup_syspath; setup_syspath()
 from elftools.common.py3compat import BytesIO, iteritems
 from elftools.dwarf.lineprogram import LineProgram, LineState, LineProgramEntry
 from elftools.dwarf.structs import DWARFStructs

--- a/test/test_dwarf_range_lists.py
+++ b/test/test_dwarf_range_lists.py
@@ -10,7 +10,7 @@ except ImportError:
     import unittest
 import os
 
-from utils import setup_syspath; setup_syspath()
+from .utils import setup_syspath; setup_syspath()
 from elftools.elf.elffile import ELFFile
 
 class TestRangeLists(unittest.TestCase):

--- a/test/test_dwarf_structs.py
+++ b/test/test_dwarf_structs.py
@@ -9,7 +9,7 @@ try:
 except ImportError:
     import unittest
 
-from utils import setup_syspath; setup_syspath()
+from .utils import setup_syspath; setup_syspath()
 from elftools.dwarf.structs import DWARFStructs
 
 

--- a/test/test_dynamic.py
+++ b/test/test_dynamic.py
@@ -10,7 +10,7 @@ except ImportError:
     import unittest
 import os
 
-from utils import setup_syspath
+from .utils import setup_syspath
 setup_syspath()
 from elftools.elf.elffile import ELFFile
 from elftools.common.exceptions import ELFError

--- a/test/test_elffile.py
+++ b/test/test_elffile.py
@@ -9,7 +9,7 @@ try:
 except ImportError:
     import unittest
 
-from utils import setup_syspath; setup_syspath()
+from .utils import setup_syspath; setup_syspath()
 from elftools.elf.elffile import ELFFile
 
 class TestMap(unittest.TestCase):

--- a/test/test_gnuversions.py
+++ b/test/test_gnuversions.py
@@ -10,7 +10,7 @@ except ImportError:
     import unittest
 import os
 
-from utils import setup_syspath
+from .utils import setup_syspath
 setup_syspath()
 from elftools.elf.elffile import ELFFile
 from elftools.elf.constants import VER_FLAGS

--- a/test/test_mips_support.py
+++ b/test/test_mips_support.py
@@ -10,7 +10,7 @@ except ImportError:
     import unittest
 import os
 
-from utils import setup_syspath; setup_syspath()
+from .utils import setup_syspath; setup_syspath()
 from elftools.elf.elffile import ELFFile
 
 class TestMIPSSupport(unittest.TestCase):

--- a/test/test_solaris_support.py
+++ b/test/test_solaris_support.py
@@ -11,7 +11,7 @@ except ImportError:
 import os
 import copy
 
-from utils import setup_syspath; setup_syspath()
+from .utils import setup_syspath; setup_syspath()
 from elftools.elf.elffile import ELFFile
 from elftools.elf.constants import SUNW_SYMINFO_FLAGS
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -10,7 +10,7 @@ except ImportError:
     import unittest
 from random import randint
 
-from utils import setup_syspath; setup_syspath()
+from .utils import setup_syspath; setup_syspath()
 from elftools.common.py3compat import int2byte, BytesIO
 from elftools.common.utils import (parse_cstring_from_stream,
         preserve_stream_pos)


### PR DESCRIPTION
When executing: "python3 -m unittest discover" the tests fail.
Python 3 requires a dot in front of the import to make a relative import.

Cheers!