### PR TITLE
made elf/segments.py not choke on unterminated note names

### DIFF
--- a/elftools/elf/segments.py
+++ b/elftools/elf/segments.py
@@ -8,7 +8,7 @@
 #-------------------------------------------------------------------------------
 from ..construct import CString
 from ..common.utils import roundup, struct_parse
-from ..common.py3compat import bytes2str
+from ..common.py3compat import byte2int, bytes2str
 from .constants import SH_FLAGS
 
 
@@ -130,7 +130,7 @@ class NoteSegment(Segment):
                 # and truncate it - but that's what they get for not
                 # following the spec.
                 name_len = note['n_namesz'] - 1
-                if name_bytes[name_len] != 0:
+                if byte2int(name_bytes[name_len]) != 0:
                     name_len = name_len + 1
                 note['n_name'] = bytes2str(name_bytes[0:name_len])
                 offset += disk_namesz


### PR DESCRIPTION
elf/segments.py tries to parse ELF note names as CStrings. This will fail if the note name does not end in a NUL character. It turns out some binaries have note names that are not NUL-terminated. To prevent elftools from choking on such files, we detect when the name is not NUL-terminated and return all its bytes instead of trying to parse it as a CString.
