### PR TITLE
Check for header attribute when comparing

### DIFF
--- a/elftools/elf/sections.py
+++ b/elftools/elf/sections.py
@@ -41,7 +41,11 @@ class Section(object):
         return self.header[name]
 
     def __eq__(self, other):
-        return self.header == other.header
+        try:
+            return self.header == other.header
+        except AttributeError:
+            return False
+    
     def __hash__(self):
         return hash(self.header)
 


### PR DESCRIPTION
When checking against None it throws excepiton, while it's quite easy to prevent(and check against None seems quite obvious).