### PR TITLE
Fix for padding encoding in Python 3.

### DIFF
--- a/elftools/construct/adapters.py
+++ b/elftools/construct/adapters.py
@@ -380,12 +380,12 @@ class PaddingAdapter(Adapter):
     
     Parameters:
     * subcon - the subcon to pad
-    * pattern - the padding pattern (character). default is "\x00"
+    * pattern - the padding pattern (character as byte). default is b"\x00"
     * strict - whether or not to verify, during parsing, that the given 
       padding matches the padding pattern. default is False (unstrict)
     """
     __slots__ = ["pattern", "strict"]
-    def __init__(self, subcon, pattern = "\x00", strict = False):
+    def __init__(self, subcon, pattern = b"\x00", strict = False):
         Adapter.__init__(self, subcon)
         self.pattern = pattern
         self.strict = strict

--- a/elftools/construct/macros.py
+++ b/elftools/construct/macros.py
@@ -69,12 +69,12 @@ def BitField(name, length, swapped = False, signed = False, bytesize = 8):
         bytesize=bytesize
     )
 
-def Padding(length, pattern = "\x00", strict = False):
+def Padding(length, pattern = b"\x00", strict = False):
     r"""a padding field (value is discarded)
     * length - the length of the field. the length can be either an integer,
       or a function that takes the context as an argument and returns the
       length
-    * pattern - the padding pattern (character) to use. default is "\x00"
+    * pattern - the padding pattern (character/byte) to use. default is b"\x00"
     * strict - whether or not to raise an exception is the actual padding
       pattern mismatches the desired pattern. default is False.
     """


### PR DESCRIPTION
The padding used a string literal instead of byte literal for the
pattern character, which caused invalid type error in Python 3.

This fix marks the pattern as byte literal, which does nothing on
Python >= 2.7 and creates bytes array instead of str in Python >= 3.