### PR TITLE
Ignore ascii decoding errors when creating special tag attributes.

### DIFF
--- a/elftools/elf/dynamic.py
+++ b/elftools/elf/dynamic.py
@@ -66,7 +66,7 @@ class DynamicTag(object):
         return '<DynamicTag (%s): %r>' % (self.entry.d_tag, self.entry)
 
     def __str__(self):
-        if self.entry.d_tag in self._HANDLED_TAGS:
+        if (self.entry.d_tag in self._HANDLED_TAGS) and (self.entry.d_tag[3:].lower() in dir(self)):
             s = '"%s"' % getattr(self, self.entry.d_tag[3:].lower())
         else:
             s = '%#x' % self.entry.d_ptr

--- a/elftools/elf/dynamic.py
+++ b/elftools/elf/dynamic.py
@@ -47,8 +47,15 @@ class DynamicTag(object):
             raise ELFError('Creating DynamicTag without string table')
         self.entry = entry
         if entry.d_tag in self._HANDLED_TAGS:
-            setattr(self, entry.d_tag[3:].lower(),
-                    stringtable.get_string(self.entry.d_val))
+            # stringtable.get_string() tries to ascii-decode the requested
+            # string from the string table. In some files the string can't
+            # be decoded, resulting in a UnicodeDecodeError. Ignore the
+            # error rather than fail to create the tag.
+            try:
+                setattr(self, entry.d_tag[3:].lower(),
+                        stringtable.get_string(self.entry.d_val))
+            except UnicodeDecodeError:
+                pass
 
     def __getitem__(self, name):
         """ Implement dict-like access to entries


### PR DESCRIPTION
In the DynamicTag constructor, when _HANDLED_TAGS are being processed, stringtable.get_string() tries to ascii-decode the requested string from the string table. In some files the string can't be decoded, resulting in a UnicodeDecodeError. Ignore the error rather than fail to create the tag.

Specifically, I have a file whose DT_SUNW_FILTER tag whose d_val does not map to an ascii string.