### PR TITLE
 Fix parsing string table

### DIFF
--- a/elftools/elf/sections.py
+++ b/elftools/elf/sections.py
@@ -71,7 +71,7 @@ class StringTableSection(Section):
         """
         table_offset = self['sh_offset']
         s = parse_cstring_from_stream(self.stream, table_offset + offset)
-        return s.decode('ascii')
+        return s.decode('ascii') if s else s
 
 
 class SymbolTableSection(Section):

--- a/elftools/elf/sections.py
+++ b/elftools/elf/sections.py
@@ -71,7 +71,7 @@ class StringTableSection(Section):
         """
         table_offset = self['sh_offset']
         s = parse_cstring_from_stream(self.stream, table_offset + offset)
-        return s.decode('ascii') if s else s
+        return s.decode('ascii') if s else u''
 
 
 class SymbolTableSection(Section):

--- a/elftools/elf/sections.py
+++ b/elftools/elf/sections.py
@@ -71,7 +71,7 @@ class StringTableSection(Section):
         """
         table_offset = self['sh_offset']
         s = parse_cstring_from_stream(self.stream, table_offset + offset)
-        return s.decode('ascii') if s else u''
+        return s.decode('ascii') if s else ''
 
 
 class SymbolTableSection(Section):


### PR DESCRIPTION
If for any reason parse_cstring_from_stream() cannot get a string in the given offset, it'll return None causing the following line raises an exception when it tries to get the decoded ascii string from the None object.