### PR TITLE
NULL termination with IAR Embedded Workbench compiler

### DIFF
--- a/elftools/dwarf/die.py
+++ b/elftools/dwarf/die.py
@@ -191,18 +191,19 @@ class DIE(object):
                 value=value,
                 raw_value=raw_value,
                 offset=attr_offset)
-		
-        # some compilers add a zero termination after the die -> consume the
-        # zero termination to avoid wrong die size calculation
-        zero_term = False
+
+        # count and then consume any null termination bytes to avoid wrong die size calculation
+        zero_term = 0
         with preserve_stream_pos(self.stream):
-            v = self.stream.read(1)
-            if(v[0]==0):
-                zero_term = True
-        
-        if(zero_term):
-            # there was a zero termination -> consume it
-            self.stream.read(1)
+            while True:
+                b = self.stream.read(1)
+                if b == 0:
+                    zero_term += 1
+                else:
+                    break
+        if zero_term > 0:
+            # there was at least one zero termination -> consume all of them
+            self.stream.read(zero_term)
 
         self.size = self.stream.tell() - self.offset
 

--- a/elftools/dwarf/die.py
+++ b/elftools/dwarf/die.py
@@ -191,6 +191,18 @@ class DIE(object):
                 value=value,
                 raw_value=raw_value,
                 offset=attr_offset)
+		
+        # some compilers add a zero termination after the die -> consume the
+        # zero termination to avoid wrong die size calculation
+        zero_term = False
+        with preserve_stream_pos(self.stream):
+            v = self.stream.read(1)
+            if(v[0]==0):
+                zero_term = True
+        
+        if(zero_term):
+            # there was a zero termination -> consume it
+            self.stream.read(1)
 
         self.size = self.stream.tell() - self.offset
 

--- a/elftools/dwarf/structs.py
+++ b/elftools/dwarf/structs.py
@@ -203,7 +203,7 @@ class DWARFStructs(object):
             DW_FORM_flag_present = StaticField('', 0),
             DW_FORM_sec_offset = self.Dwarf_offset(''),
             DW_FORM_exprloc = self._make_block_struct(self.Dwarf_uleb128),
-            DW_FORM_ref_sig8 = self.Dwarf_offset(''),
+            DW_FORM_ref_sig8 = self.Dwarf_uint64(''),
 
             DW_FORM_GNU_strp_alt=self.Dwarf_offset(''),
             DW_FORM_GNU_ref_alt=self.Dwarf_offset(''),


### PR DESCRIPTION
The IAR Embedded Workbench compiler inserts a zero termination byte after some dies (eg after DW_TAG_subrange_type @0x2885 in the attached .elf file). This leads to parsing error of the subsequent die(s), since null is assumed to be the first byte of it.

This workaround consumes all null bytes that follow a complete die.
[iar_ewb.zip](https://github.com/eliben/pyelftools/files/1034393/iar_ewb.zip)

