### PR TITLE
Add OrderedDict implementation for seamless Python < 2.7 "support"

### DIFF
--- a/elftools/common/legacy.py
+++ b/elftools/common/legacy.py
@@ -1,0 +1,128 @@
+# Copyright (c) 2009 Raymond Hettinger
+#
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation files
+# (the "Software"), to deal in the Software without restriction,
+# including without limitation the rights to use, copy, modify, merge,
+# publish, distribute, sublicense, and/or sell copies of the Software,
+# and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+#     The above copyright notice and this permission notice shall be
+#     included in all copies or substantial portions of the Software.
+#
+#     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+#     EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+#     OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+#     NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+#     HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+#     WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+#     FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+#     OTHER DEALINGS IN THE SOFTWARE.
+
+from UserDict import DictMixin
+
+
+class OrderedDict(dict, DictMixin):
+
+    def __init__(self, *args, **kwds):
+        if len(args) > 1:
+            raise TypeError('expected at most 1 arguments, got %d' % len(args))
+        try:
+            self.__end
+        except AttributeError:
+            self.clear()
+        self.update(*args, **kwds)
+
+    def clear(self):
+        self.__end = end = []
+        end += [None, end, end]         # sentinel node for doubly linked list
+        self.__map = {}                 # key --> [key, prev, next]
+        dict.clear(self)
+
+    def __setitem__(self, key, value):
+        if key not in self:
+            end = self.__end
+            curr = end[1]
+            curr[2] = end[1] = self.__map[key] = [key, curr, end]
+        dict.__setitem__(self, key, value)
+
+    def __delitem__(self, key):
+        dict.__delitem__(self, key)
+        key, prev, next = self.__map.pop(key)
+        prev[2] = next
+        next[1] = prev
+
+    def __iter__(self):
+        end = self.__end
+        curr = end[2]
+        while curr is not end:
+            yield curr[0]
+            curr = curr[2]
+
+    def __reversed__(self):
+        end = self.__end
+        curr = end[1]
+        while curr is not end:
+            yield curr[0]
+            curr = curr[1]
+
+    def popitem(self, last=True):
+        if not self:
+            raise KeyError('dictionary is empty')
+        if last:
+            key = reversed(self).next()
+        else:
+            key = iter(self).next()
+        value = self.pop(key)
+        return key, value
+
+    def __reduce__(self):
+        items = [[k, self[k]] for k in self]
+        tmp = self.__map, self.__end
+        del self.__map, self.__end
+        inst_dict = vars(self).copy()
+        self.__map, self.__end = tmp
+        if inst_dict:
+            return (self.__class__, (items,), inst_dict)
+        return self.__class__, (items,)
+
+    def keys(self):
+        return list(self)
+
+    setdefault = DictMixin.setdefault
+    update = DictMixin.update
+    pop = DictMixin.pop
+    values = DictMixin.values
+    items = DictMixin.items
+    iterkeys = DictMixin.iterkeys
+    itervalues = DictMixin.itervalues
+    iteritems = DictMixin.iteritems
+
+    def __repr__(self):
+        if not self:
+            return '%s()' % (self.__class__.__name__,)
+        return '%s(%r)' % (self.__class__.__name__, self.items())
+
+    def copy(self):
+        return self.__class__(self)
+
+    @classmethod
+    def fromkeys(cls, iterable, value=None):
+        d = cls()
+        for key in iterable:
+            d[key] = value
+        return d
+
+    def __eq__(self, other):
+        if isinstance(other, OrderedDict):
+            if len(self) != len(other):
+                return False
+            for p, q in zip(self.items(), other.items()):
+                if p != q:
+                    return False
+            return True
+        return dict.__eq__(self, other)
+
+    def __ne__(self, other):
+        return not self == other

--- a/elftools/common/legacy.py
+++ b/elftools/common/legacy.py
@@ -1,3 +1,7 @@
+#
+# Support OrderedDict on Python < 2.7
+#
+
 # Copyright (c) 2009 Raymond Hettinger
 #
 # Permission is hereby granted, free of charge, to any person

--- a/elftools/dwarf/die.py
+++ b/elftools/dwarf/die.py
@@ -5,15 +5,20 @@
 #
 # Eli Bendersky (eliben@gmail.com)
 # This code is in the public domain
-#-------------------------------------------------------------------------------
-from collections import namedtuple, OrderedDict
+# -------------------------------------------------------------------------------
 import os
-
 from ..common.exceptions import DWARFError
 from ..common.py3compat import bytes2str, iteritems
 from ..common.utils import struct_parse, preserve_stream_pos
 from .enums import DW_FORM_raw2name
+from collections import namedtuple
+import sys
 
+# Support OrderedDict on Python < 2.7
+try:
+    from collections import OrderedDict
+except ImportError:
+    from ..common.legacy import OrderedDict
 
 # AttributeValue - describes an attribute value in the DIE:
 #

--- a/elftools/dwarf/die.py
+++ b/elftools/dwarf/die.py
@@ -13,7 +13,12 @@ from ..common.utils import struct_parse, preserve_stream_pos
 from .enums import DW_FORM_raw2name
 from collections import namedtuple
 
-# Support OrderedDict on Python < 2.7
+#
+# NOTE: pyelftools is *not* supported on < 2.7 but
+#       adding an OrderedDict class makes most of
+#       the core functionality work
+#
+
 try:
     from collections import OrderedDict
 except ImportError:

--- a/elftools/dwarf/die.py
+++ b/elftools/dwarf/die.py
@@ -12,7 +12,6 @@ from ..common.py3compat import bytes2str, iteritems
 from ..common.utils import struct_parse, preserve_stream_pos
 from .enums import DW_FORM_raw2name
 from collections import namedtuple
-import sys
 
 # Support OrderedDict on Python < 2.7
 try:


### PR DESCRIPTION
The ```OrderedDict``` class was added to ```collections``` in Python 2.7 which means pyelftools will not work on older versions of Python. My target was 2.6.

By adding this small ```OrderedDict``` implementation, the majority (possibly all?) of pyelftools works on Python 2.6, and possibly earlier versions.

An alternative is to pull in ordereddict from PyPi and have that as a dependency but this seems simpler and shouldn't be burdensome to maintain, should you want to accept it.

Merge this if you'd like, otherwise I will maintain my own fork as I currently need this supported on 2.6

Thanks, I appreciate pyelftools quite a bit. If you'd like anything tested I'd be happy to help