### PR TITLE
Add parsing and readelf dumping for .eh_frame

### DIFF
--- a/elftools/common/py3compat.py
+++ b/elftools/common/py3compat.py
@@ -23,6 +23,9 @@ if PY3:
     def str2bytes(s): return s.encode('latin-1')
     def int2byte(i):return bytes((i,))
     def byte2int(b): return b
+    def iterbytes(b):
+        for i in range(len(b)):
+            yield b[i:i+1]
 
     ifilter = filter
 
@@ -39,6 +42,8 @@ else:
     def str2bytes(s): return s
     int2byte = chr
     byte2int = ord
+    def iterbytes(b):
+        return iter(b)
 
     from itertools import ifilter
 

--- a/elftools/dwarf/descriptions.py
+++ b/elftools/dwarf/descriptions.py
@@ -86,7 +86,7 @@ def describe_CFI_instructions(entry):
                         'DW_CFA_advance_loc4', 'DW_CFA_advance_loc'):
             _assert_FDE_instruction(instr)
             factored_offset = instr.args[0] * cie['code_alignment_factor']
-            s += '  %s: %s to %016x\n' % (
+            s += '  %s: %s to %08x\n' % (
                 name, factored_offset, factored_offset + pc)
             pc += factored_offset
         elif name in (  'DW_CFA_remember_state', 'DW_CFA_restore_state',

--- a/elftools/dwarf/enums.py
+++ b/elftools/dwarf/enums.py
@@ -283,3 +283,26 @@ ENUM_DW_FORM = dict(
 # Inverse mapping for ENUM_DW_FORM
 DW_FORM_raw2name = dict((v, k) for k, v in iteritems(ENUM_DW_FORM))
 
+# See http://www.airs.com/blog/archives/460
+DW_EH_encoding_flags = dict(
+    DW_EH_PE_absptr   = 0x00,
+    DW_EH_PE_uleb128  = 0x01,
+    DW_EH_PE_udata2   = 0x02,
+    DW_EH_PE_udata4   = 0x03,
+    DW_EH_PE_udata8   = 0x04,
+
+    DW_EH_PE_signed   = 0x08,
+    DW_EH_PE_sleb128  = 0x09,
+    DW_EH_PE_sdata2   = 0x0a,
+    DW_EH_PE_sdata4   = 0x0b,
+    DW_EH_PE_sdata8   = 0x0c,
+
+    DW_EH_PE_pcrel    = 0x10,
+    DW_EH_PE_textrel  = 0x20,
+    DW_EH_PE_datarel  = 0x30,
+    DW_EH_PE_funcrel  = 0x40,
+    DW_EH_PE_aligned  = 0x50,
+    DW_EH_PE_indirect = 0x80,
+
+    DW_EH_PE_omit     = 0xff,
+)

--- a/elftools/dwarf/structs.py
+++ b/elftools/dwarf/structs.py
@@ -253,6 +253,16 @@ class DWARFStructs(object):
             )
 
     def _create_callframe_entry_headers(self):
+        self.Dwarf_CIE_header = Struct('Dwarf_CIE_header',
+            self.Dwarf_initial_length('length'),
+            self.Dwarf_offset('CIE_id'),
+            self.Dwarf_uint8('version'),
+            CString('augmentation'),
+            self.Dwarf_uleb128('code_alignment_factor'),
+            self.Dwarf_sleb128('data_alignment_factor'),
+            self.Dwarf_uleb128('return_address_register'))
+        self.EH_CIE_header = self.Dwarf_CIE_header
+
         # The CIE header was modified in DWARFv4.
         if self.dwarf_version == 4:
             self.Dwarf_CIE_header = Struct('Dwarf_CIE_header',
@@ -262,15 +272,6 @@ class DWARFStructs(object):
                 CString('augmentation'),
                 self.Dwarf_uint8('address_size'),
                 self.Dwarf_uint8('segment_size'),
-                self.Dwarf_uleb128('code_alignment_factor'),
-                self.Dwarf_sleb128('data_alignment_factor'),
-                self.Dwarf_uleb128('return_address_register'))
-        else:
-            self.Dwarf_CIE_header = Struct('Dwarf_CIE_header',
-                self.Dwarf_initial_length('length'),
-                self.Dwarf_offset('CIE_id'),
-                self.Dwarf_uint8('version'),
-                CString('augmentation'),
                 self.Dwarf_uleb128('code_alignment_factor'),
                 self.Dwarf_sleb128('data_alignment_factor'),
                 self.Dwarf_uleb128('return_address_register'))

--- a/elftools/elf/relocation.py
+++ b/elftools/elf/relocation.py
@@ -240,7 +240,7 @@ class RelocationHandler(object):
         ENUM_RELOC_TYPE_x64['R_X86_64_64']: _RELOCATION_RECIPE_TYPE(
             bytesize=8, has_addend=True, calc_func=_reloc_calc_sym_plus_addend),
         ENUM_RELOC_TYPE_x64['R_X86_64_PC32']: _RELOCATION_RECIPE_TYPE(
-            bytesize=8, has_addend=True,
+            bytesize=4, has_addend=True,
             calc_func=_reloc_calc_sym_plus_addend_pcrel),
         ENUM_RELOC_TYPE_x64['R_X86_64_32']: _RELOCATION_RECIPE_TYPE(
             bytesize=4, has_addend=True, calc_func=_reloc_calc_sym_plus_addend),

--- a/test/run_readelf_tests.py
+++ b/test/run_readelf_tests.py
@@ -107,22 +107,9 @@ def compare_output(s1, s2):
     """
     def prepare_lines(s):
         return [line for line in s.lower().splitlines() if line.strip() != '']
-    def filter_readelf_lines(lines):
-        filter_out = False
-        for line in lines:
-            if 'of the .eh_frame section' in line:
-                filter_out = True
-            elif 'of the .debug_frame section' in line or \
-                'of the .zdebug_frame section' in line:
-                filter_out = False
-            if not filter_out:
-                if not line.startswith('unknown: length'):
-                    yield line
 
     lines1 = prepare_lines(s1)
     lines2 = prepare_lines(s2)
-
-    lines1 = list(filter_readelf_lines(lines1))
 
     flag_after_symtable = False
 

--- a/test/test_callframe.py
+++ b/test/test_callframe.py
@@ -63,7 +63,7 @@ class TestCallFrame(unittest.TestCase):
         s.write(data)
 
         structs = DWARFStructs(little_endian=True, dwarf_format=32, address_size=4)
-        cfi = CallFrameInfo(s, len(data), structs)
+        cfi = CallFrameInfo(s, len(data), 0, structs)
         entries = cfi.get_entries()
 
         self.assertEqual(len(entries), 2)
@@ -137,7 +137,7 @@ class TestCallFrame(unittest.TestCase):
         s = BytesIO(data)
 
         structs = DWARFStructs(little_endian=True, dwarf_format=32, address_size=4)
-        cfi = CallFrameInfo(s, len(data), structs)
+        cfi = CallFrameInfo(s, len(data), 0, structs)
         entries = cfi.get_entries()
 
         set_global_machine_arch('x86')


### PR DESCRIPTION
Hello Eli,

Unlike what I thought on #152, reading and dumping `.eh_frame` is not necessary in order to update the embedded `readelf`.

The diff I got while updating was due to some minor change in output, not to some new dump for `.eh_frame` itself. I noticed that while removing the `.eh_frame` filter in `run_readelf_tests.py`, but by that time I had already implemented most of it, so… here it is, better not throw that away. ;-)