### PR TITLE
Fix - ELFFile#address_offsets should consider PT_LOAD only

### DIFF
--- a/elftools/elf/elffile.py
+++ b/elftools/elf/elffile.py
@@ -136,7 +136,9 @@ class ELFFile(object):
         """
         end = start + size
         for seg in self.iter_segments():
-            if (seg['p_type'] != 'PT_LOAD'): continue
+            # consider LOAD only to prevent same address being yielded twice
+            if seg['p_type'] != 'PT_LOAD':
+                continue
             if (start >= seg['p_vaddr'] and
                 end <= seg['p_vaddr'] + seg['p_filesz']):
                 yield start - seg['p_vaddr'] + seg['p_offset']

--- a/elftools/elf/elffile.py
+++ b/elftools/elf/elffile.py
@@ -136,6 +136,7 @@ class ELFFile(object):
         """
         end = start + size
         for seg in self.iter_segments():
+            if (seg['p_type'] != 'PT_LOAD'): continue
             if (start >= seg['p_vaddr'] and
                 end <= seg['p_vaddr'] + seg['p_filesz']):
                 yield start - seg['p_vaddr'] + seg['p_offset']

--- a/test/test_elffile.py
+++ b/test/test_elffile.py
@@ -15,8 +15,9 @@ class TestMap(unittest.TestCase):
             __init__ = object.__init__
             def iter_segments(self):
                 return iter((
-                    dict(p_vaddr=0x10200, p_filesz=0x200, p_offset=0x100),
-                    dict(p_vaddr=0x10100, p_filesz=0x100, p_offset=0x400),
+                    dict(p_type='PT_PHDR', p_vaddr=0x10100, p_filesz=0x100, p_offset=0x400),
+                    dict(p_type='PT_LOAD', p_vaddr=0x10200, p_filesz=0x200, p_offset=0x100),
+                    dict(p_type='PT_LOAD', p_vaddr=0x10100, p_filesz=0x100, p_offset=0x400),
                 ))
 
         elf = MockELF()


### PR DESCRIPTION
As mentioned in #138 (the second comment)
`ELFFile#address_offsets` should consider PT_LOAD segments only,
otherwise wrong addresses might be yielded.

For example, the readelf output by ```$ readelf -l `which cat` ```:
```
Program Headers:
  Type           Offset             VirtAddr           PhysAddr
                 FileSiz            MemSiz              Flags  Align
  PHDR           0x0000000000000040 0x0000000000000040 0x0000000000000040
                 0x00000000000001f8 0x00000000000001f8  R E    0x8
  INTERP         0x0000000000000238 0x0000000000000238 0x0000000000000238
                 0x000000000000001c 0x000000000000001c  R      0x1
      [Requesting program interpreter: /lib64/ld-linux-x86-64.so.2]
  LOAD           0x0000000000000000 0x0000000000000000 0x0000000000000000
                 0x000000000000787c 0x000000000000787c  R E    0x200000
  LOAD           0x0000000000007a88 0x0000000000207a88 0x0000000000207a88
                 0x0000000000000638 0x00000000000007d8  RW     0x200000
```

and python script:
```python
import elftools.elf.elffile
f = elftools.elf.elffile.ELFFile(open("/bin/cat"))
print(list(f.address_offsets(0x40)))
```
Expect: `[64]`
Output: `[64, 64]`

This is because `address_offsets` take the `PHDR` segment into consideration (shouldn't be).
This pr fixed this behavior.