### PR TITLE
Add TLS and PowerPC to Machine and Program Headers description tables…

### DIFF
--- a/elftools/elf/descriptions.py
+++ b/elftools/elf/descriptions.py
@@ -262,6 +262,7 @@ _DESCR_E_MACHINE = dict(
     EM_ARM='ARM',
     EM_AARCH64='AArch64',
     EM_BLAFKIN='Analog Devices Blackfin',
+    EM_PPC='PowerPC',
     RESERVED='RESERVED',
 )
 
@@ -281,6 +282,7 @@ _DESCR_P_TYPE = dict(
     PT_ARM_EXIDX='ARM_EXIDX',
     PT_AARCH64_ARCHEXT='AARCH64_ARCHEXT',
     PT_AARCH64_UNWIND='AARCH64_UNWIND',
+    PT_TLS='TLS'
 )
 
 


### PR DESCRIPTION
… to match binutils output

Before:
...
  Machine:                           <unknown>
...
Program Headers:
...
  <unknown>      0x0bcd0c 0x100ccd0c 0x100ccd0c 0x00000 0x00008 R   0x4
...

After:
...
  Machine:                           PowerPC
Program Headers:
...
  TLS            0x0bcd0c 0x100ccd0c 0x100ccd0c 0x00000 0x00008 R   0x4
...

Reproduced and then tested change against statically linked PPC binary produced by MUSL:

https://github.com/mzpqnxow/embedded-toolkit/blob/master/prebuilt_static_bins/gdbserver/gdbserver-7.12-ppc-sysv