### PR TITLE
ARMAttribute: fix access to structs, stream and nul

### DIFF
--- a/elftools/elf/sections.py
+++ b/elftools/elf/sections.py
@@ -287,14 +287,12 @@ class ARMAttribute(object):
 
             if self.tag != 'TAG_FILE':
                 self.extra = []
-                s_number = struct_parse(self.structs.Elf_uleb128('s_number'),
-                                        self.stream
-                           )
+                s_number = struct_parse(structs.Elf_uleb128('s_number'), stream)
 
                 while s_number != 0:
                     self.extra.append(s_number)
-                    s_number = struct_parse(self.structs.Elf_uleb128('s_number'),
-                                            self.stream
+                    s_number = struct_parse(structs.Elf_uleb128('s_number'),
+                                            stream
                                )
 
         elif self.tag in ('TAG_CPU_RAW_NAME', 'TAG_CPU_NAME', 'TAG_CONFORMANCE'):
@@ -313,7 +311,7 @@ class ARMAttribute(object):
 
             if type(self.value.value) is not str:
                 nul = struct_parse(structs.Elf_byte('nul'), stream)
-                elf_assert(null_byte == 0, 
+                elf_assert(nul == 0,
                            "Invalid terminating byte %r, expecting NUL." % nul)
 
         else:


### PR DESCRIPTION
The __init__ function of ARMAttribute has two parameters
structs and stream through which the caller can pass in the
relevant objects (ARMAttributesSubsubsection does that after
seeking to the right position in stream).

The accesses for TAG_SECTION and TAG_SYMBOL, however, were
referring to non-existing members instead of the parameters.

Additionally, one assertion tries to access an undefined
'null_byte' variable which should be 'nul' instead.

Unfortunately, I don't have an ARM system to generate a
testcase binary, but maybe somebody else can contribute that.

Fixes: #160 