### PR TITLE
Remove unnecessary 'preserve_stream_pos'

### DIFF
--- a/elftools/dwarf/die.py
+++ b/elftools/dwarf/die.py
@@ -170,9 +170,7 @@ class DIE(object):
             self.size = self.stream.tell() - self.offset
             return
 
-        with preserve_stream_pos(self.stream):
-            abbrev_decl = self.cu.get_abbrev_table().get_abbrev(
-                self.abbrev_code)
+        abbrev_decl = self.cu.get_abbrev_table().get_abbrev(self.abbrev_code)
         self.tag = abbrev_decl['tag']
         self.has_children = abbrev_decl.has_children()
 


### PR DESCRIPTION
The stream position in the .debug_info stream can't change when
reading from the .debug_abbrev stream.