### PR TITLE
Lazy parsing

### DIFF
--- a/elftools/dwarf/compileunit.py
+++ b/elftools/dwarf/compileunit.py
@@ -55,6 +55,8 @@ class CompileUnit(object):
 
         # A list of DIEs belonging to this CU. Lazily parsed.
         self._dielist = []
+        # A list of corresponding DIE offsets.
+        self._diemap = []
 
     def dwarf_format(self):
         """ Get the DWARF format (32 or 64) for this CU
@@ -112,12 +114,14 @@ class CompileUnit(object):
 
         # First pass: parse all DIEs and place them into self._dielist
         die_offset = self.cu_die_offset
+        dm = self._diemap
         while die_offset < cu_boundary:
             die = DIE(
                     cu=self,
                     stream=self.dwarfinfo.debug_info_sec.stream,
                     offset=die_offset)
             self._dielist.append(die)
+            dm.append(die_offset)
             die_offset += die.size
 
         # Second pass - unflatten the DIE tree

--- a/elftools/dwarf/compileunit.py
+++ b/elftools/dwarf/compileunit.py
@@ -182,34 +182,3 @@ class CompileUnit(object):
             self._dielist.append(die)
             dm.append(die_offset)
             die_offset += die.size
-
-        # Second pass - unflatten the DIE tree
-        self._unflatten_tree()
-
-    def _unflatten_tree(self):
-        """ "Unflatten" the DIE tree from it serial representation, by setting
-            the child/sibling/parent links of DIEs.
-
-            Assumes self._dielist was already populated by a linear list of DIEs
-            read from the stream section
-        """
-        # the first DIE in the list is the root node
-        root = self._dielist[0]
-        parentstack = [root]
-
-        for die in self._dielist[1:]:
-            if not die.is_null():
-                cur_parent = parentstack[-1]
-                # This DIE is a child of the current parent
-                cur_parent.add_child(die)
-                die.set_parent(cur_parent)
-                if die.has_children:
-                    parentstack.append(die)
-            else:
-                # parentstack should not be really empty here. However, some
-                # compilers generate DWARF that has extra NULLs in the end and
-                # we don't want pyelftools to fail parsing them just because of
-                # this.
-                if len(parentstack) > 0:
-                    # end of children for the current parent
-                    parentstack.pop()

--- a/elftools/dwarf/die.py
+++ b/elftools/dwarf/die.py
@@ -87,6 +87,9 @@ class DIE(object):
         self.abbrev_code = None
         self.size = 0
         self._children = []
+        # Null DIE terminator. It can be used to obtain offset range occupied
+        # by this DIE including its whole subtree.
+        self._terminator = None
         self._parent = None
 
         self._parse_DIE()
@@ -117,9 +120,9 @@ class DIE(object):
         return os.path.join(comp_dir, fname)
 
     def iter_children(self):
-        """ Yield all children of this DIE
+        """ Iterates all children of this DIE
         """
-        return iter(self._children)
+        return self.cu.iter_DIE_children(self)
 
     def iter_siblings(self):
         """ Yield all siblings of this DIE

--- a/elftools/dwarf/die.py
+++ b/elftools/dwarf/die.py
@@ -86,7 +86,6 @@ class DIE(object):
         self.has_children = None
         self.abbrev_code = None
         self.size = 0
-        self._children = []
         # Null DIE terminator. It can be used to obtain offset range occupied
         # by this DIE including its whole subtree.
         self._terminator = None
@@ -137,8 +136,6 @@ class DIE(object):
     # The following methods are used while creating the DIE and should not be
     # interesting to consumers
     #
-    def add_child(self, die):
-        self._children.append(die)
 
     def set_parent(self, die):
         self._parent = die


### PR DESCRIPTION
Recently, I used `pyelftools` in a debugger. During my work I faced a problem.
`pyelftools` parses much of debug info when the debugger just looks for a
few things. E.g. when the debugger looks for a DIE describing a variable,
entire CU (all its DIEs) is parsed. When working with a big binary (like
[Qemu](https://www.qemu.org/) emulator) debugger loading consumes about
5 minutes which is very annoying to a user.

The solution I suggest is lazy parsing. This patch series reworks some internals
of the library so it only parses requested things.

Also, because an ELF file is considered constant, there is no a reason to parse
things twice. So, I also added some caches for parsed entities.