### PR TITLE
Also decode strings in _DynamicStringTable.get_string()

### DIFF
--- a/elftools/elf/dynamic.py
+++ b/elftools/elf/dynamic.py
@@ -25,8 +25,8 @@ class _DynamicStringTable(object):
     def get_string(self, offset):
         """ Get the string stored at the given offset in this string table.
         """
-        return parse_cstring_from_stream(self._stream,
-                                         self._table_offset + offset)
+        s = parse_cstring_from_stream(self._stream, self._table_offset + offset)
+        return s.decode('utf-8') if s else ''
 
 
 class DynamicTag(object):

--- a/test/test_dynamic.py
+++ b/test/test_dynamic.py
@@ -49,7 +49,7 @@ class TestDynamic(unittest.TestCase):
 
                 for t in segment.iter_tags():
                     if t.entry.d_tag == 'DT_NEEDED':
-                        libs.append(t.needed.decode('utf-8'))
+                        libs.append(t.needed)
 
         exp = ['libc.so.6']
         self.assertEqual(libs, exp)
@@ -65,7 +65,7 @@ class TestDynamic(unittest.TestCase):
 
                 symbol_names = [x.name for x in segment.iter_symbols()]
 
-        exp = [b'', b'__libc_start_main', b'__gmon_start__', b'abort']
+        exp = ['', '__libc_start_main', '__gmon_start__', 'abort']
         self.assertEqual(symbol_names, exp)
 
     def test_sunw_tags(self):


### PR DESCRIPTION
StringTableSection.get_string() returns an UTF-8 decoded
string (or '' if fetching the string failed) since #182
but the code in _DynamicStringTable was never updated to
decode anything at all so it just returns a bytes sequence
in Python 3.

Let's convert the string there as well to be able to use
both string tables the same way without having to worry
about decoding. Adapt the test cases accordingly.