### PR TITLE
Improve symbol table handling in DynamicSegment

### DIFF
--- a/elftools/elf/hash.py
+++ b/elftools/elf/hash.py
@@ -1,0 +1,77 @@
+#-------------------------------------------------------------------------------
+# elftools: elf/hash.py
+#
+# ELF hash table sections
+#
+# Andreas Ziegler (andreas.ziegler@fau.de)
+# This code is in the public domain
+#-------------------------------------------------------------------------------
+
+from ..common.utils import struct_parse
+
+
+class HashSection(object):
+    """ Minimal part of an ELF hash section to find the number of symbols in the
+        symbol table - useful for super-stripped binaries without section
+        headers where only the start of the symbol table is known from the
+        dynamic segment. The layout and contents are nicely described at
+        https://flapenguin.me/2017/04/24/elf-lookup-dt-hash/.
+    """
+    def __init__(self, stream, offset, elffile):
+        self._stream = stream
+        self._offset = offset
+        self._elffile = elffile
+        self.params = struct_parse(self._elffile.structs.Elf_Hash,
+                                   self._stream,
+                                   self._offset)
+
+    def get_number_of_symbols(self):
+        """ Get the number of symbols from the hash table parameters.
+        """
+        return self.params['nchains']
+
+
+class GNUHashSection(object):
+    """ Minimal part of a GNU hash section to find the number of symbols in the
+        symbol table - useful for super-stripped binaries without section
+        headers where only the start of the symbol table is known from the
+        dynamic segment. The layout and contents are nicely described at
+        https://flapenguin.me/2017/05/10/elf-lookup-dt-gnu-hash/.
+    """
+    def __init__(self, stream, offset, elffile):
+        self._stream = stream
+        self._offset = offset
+        self._elffile = elffile
+        self.params = struct_parse(self._elffile.structs.Gnu_Hash,
+                                   self._stream,
+                                   self._offset)
+
+    def get_number_of_symbols(self):
+        """ Get the number of symbols in the hash table by finding the bucket
+            with the highest symbol index and walking to the end of its chain.
+        """
+        # Element sizes in the hash table
+        wordsize = self._elffile.structs.Elf_word('').sizeof()
+        xwordsize = self._elffile.structs.Elf_xword('').sizeof()
+
+        # Find highest index in buckets array
+        max_idx = max(self.params['buckets'])
+        if max_idx < self.params['symoffset']:
+            return self.params['symoffset']
+
+        # Position the stream at the start of the corresponding chain
+        chain_pos = self._offset + 4 * wordsize + \
+            self.params['bloom_size'] * xwordsize + \
+            self.params['nbuckets'] * wordsize + \
+            (max_idx - self.params['symoffset']) * wordsize
+
+        # Walk the chain to its end (lowest bit is set)
+        while True:
+            cur_hash = struct_parse(self._elffile.structs.Elf_word('elem'),
+                                    self._stream,
+                                    chain_pos)
+            if cur_hash & 1:
+                return max_idx + 1
+
+            max_idx += 1
+            chain_pos += wordsize

--- a/elftools/elf/structs.py
+++ b/elftools/elf/structs.py
@@ -90,6 +90,8 @@ class ELFStructs(object):
         self._create_note(e_type)
         self._create_stabs()
         self._create_arm_attributes()
+        self._create_elf_hash()
+        self._create_gnu_hash()
 
     #-------------------------------- PRIVATE --------------------------------#
 
@@ -398,3 +400,29 @@ class ELFStructs(object):
                                         Enum(self.Elf_uleb128('tag'),
                                              **ENUM_ATTR_TAG_ARM)
         )
+
+    def _create_elf_hash(self):
+        # Structure of the old SYSV-style hash table header. It is documented
+        # in the Oracle "Linker and Libraries Guide", Part IV ELF Application
+        # Binary Interface, Chapter 14 Object File Format, Section Hash Table
+        # Section:
+        # https://docs.oracle.com/cd/E53394_01/html/E54813/chapter6-48031.html
+
+        self.Elf_Hash = Struct('Elf_Hash',
+                               self.Elf_word('nbuckets'),
+                               self.Elf_word('nchains'),
+                               Array(lambda ctx: ctx['nbuckets'], self.Elf_word('buckets')),
+                               Array(lambda ctx: ctx['nchains'], self.Elf_word('chains')))
+
+    def _create_gnu_hash(self):
+        # Structure of the GNU-style hash table header. Documentation for this
+        # table is mostly in the GLIBC source code, a good explanation of the
+        # format can be found in this blog post:
+        # https://flapenguin.me/2017/05/10/elf-lookup-dt-gnu-hash/
+        self.Gnu_Hash = Struct('Gnu_Hash',
+                               self.Elf_word('nbuckets'),
+                               self.Elf_word('symoffset'),
+                               self.Elf_word('bloom_size'),
+                               self.Elf_word('bloom_shift'),
+                               Array(lambda ctx: ctx['bloom_size'], self.Elf_xword('bloom')),
+                               Array(lambda ctx: ctx['nbuckets'], self.Elf_word('buckets')))

--- a/test/test_dynamic.py
+++ b/test/test_dynamic.py
@@ -64,10 +64,17 @@ class TestDynamic(unittest.TestCase):
                 if segment.header.p_type != 'PT_DYNAMIC':
                     continue
 
+                num_symbols = segment.num_symbols()
                 symbol_names = [x.name for x in segment.iter_symbols()]
+                symbol_at_index_3 = segment.get_symbol(3)
+                symbols_abort = segment.get_symbol_by_name('abort')
 
+        self.assertEqual(num_symbols, 4)
         exp = ['', '__libc_start_main', '__gmon_start__', 'abort']
         self.assertEqual(symbol_names, exp)
+        self.assertEqual(symbol_at_index_3.name, 'abort')
+        self.assertIsNotNone(symbols_abort)
+        self.assertEqual(symbols_abort[0], symbol_at_index_3)
 
     def test_reading_symbols_gnu_hash(self):
         """ Verify we can read symbol table without SymbolTableSection but with

--- a/test/test_hash.py
+++ b/test/test_hash.py
@@ -1,0 +1,47 @@
+#-------------------------------------------------------------------------------
+# elftools tests
+#
+# Andreas Ziegler (andreas.ziegler@fau.de)
+# This code is in the public domain
+#-------------------------------------------------------------------------------
+import unittest
+import os
+
+from elftools.elf.elffile import ELFFile
+from elftools.common.exceptions import ELFError
+from elftools.elf.hash import HashSection, GNUHashSection
+
+class TestELFHash(unittest.TestCase):
+    def test_get_number_of_syms(self):
+        """ Verify we can get get the number of symbols from an ELF hash
+            section.
+        """
+
+        with open(os.path.join('test', 'testfiles_for_unittests',
+                               'aarch64_super_stripped.elf'), 'rb') as f:
+            elf = ELFFile(f)
+            for segment in elf.iter_segments():
+                if segment.header.p_type != 'PT_DYNAMIC':
+                    continue
+
+                _, hash_offset = segment.get_table_offset('DT_HASH')
+            hash_section = HashSection(elf.stream, hash_offset, elf)
+            self.assertEqual(hash_section.get_number_of_symbols(), 4)
+
+
+class TestGNUHash(unittest.TestCase):
+    def test_get_number_of_syms(self):
+        """ Verify we can get get the number of symbols from a GNU hash
+            section.
+        """
+
+        with open(os.path.join('test', 'testfiles_for_unittests',
+                               'lib_versioned64.so.1.elf'), 'rb') as f:
+            elf = ELFFile(f)
+            for segment in elf.iter_segments():
+                if segment.header.p_type != 'PT_DYNAMIC':
+                    continue
+
+                _, hash_offset = segment.get_table_offset('DT_GNU_HASH')
+            hash_section = GNUHashSection(elf.stream, hash_offset, elf)
+            self.assertEqual(hash_section.get_number_of_symbols(), 24)


### PR DESCRIPTION
In ultra-stripped binaries the only information about a (dynamic) symbol table comes from the dynamic segment. The DT_SYMTAB tag holds the base address of the table but no tag exists for the number of symbols in the table. The current approach tries to guess this number by looking for the nearest pointer bigger than the DT_SYMTAB pointer in all dynamic tags. However, some of these entries are size values (DT_STRSZ, DT_RELASZ,...) and the heuristic may wrongly interpret them as pointers, which makes DynamicSegment.iter_symbols() return a too low number of symbols.

This change improves the detection by gathering information from the DT_GNU_HASH or DT_HASH symbol hash tables, relying on the fact that every symbol must have a corresponding hash in order for the dynamic loader to properly resolve symbols during loading. The change is inspired by the code used by https://github.com/chromium/crashpad (introduced in [this change]).

Additionally, DynamicSegment only had the iter_symbols() so far, whereas the regular SymbolTableSection also has access to the number of symbols, a specific symbol by index and lookup for symbols by name. I ported these features to DynamicSegment as well.

I noticed that SymbolTableSection.iter_symbols() deliberately leaves out the first entry of the symbol table (which is a STT_NOTYPE entry anyway) while DynamicSegment.iter_symbols() doesn't... should we make this consistent as well? Or is the risk of breaking existing tools using DynamicSegment too high?

Fixes: #218

[this change]: https://github.com/chromium/crashpad/commit/1f1657d573c789aa36b6022440e34d9ec30d894c