### PR TITLE
Fix LookupError when testing with tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist = py27,py35
 
 [testenv]
 setenv =
-    LC_ALL = en_US
+    LC_ALL = en_US.utf-8
 commands =
     python test/run_all_unittests.py
     python test/run_examples_test.py


### PR DESCRIPTION
On macOS I'm getting the following error when testing with tox on py27:

```
ERROR: invocation failed (exit code 1), logfile: /devel/pyelftools/.tox/py27/log/py27-33.log
ERROR: actionid: py27
msg: installpkg
cmdargs: ['/devel/pyelftools/.tox/py27/bin/pip', 'install', '-U', '--no-deps', '/devel/pyelftools/.tox/dist/pyelftools-0.25.zip']

DEPRECATION: Python 2.7 will reach the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 won't be maintained after that date. A future version of pip will drop support for Python 2.7.
Processing ./.tox/dist/pyelftools-0.25.zip
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/private/var/folders/qz/XXX/T/pip-req-build-890d2p/setup.py", line 47, in <module>
        scripts=['scripts/readelf.py']
      File "/devel/pyelftools/.tox/py27/lib/python2.7/site-packages/setuptools/__init__.py", line 144, in setup
        _install_setup_requires(attrs)
      File "/devel/pyelftools/.tox/py27/lib/python2.7/site-packages/setuptools/__init__.py", line 137, in _install_setup_requires
        dist.parse_config_files(ignore_option_errors=True)
      File "/devel/pyelftools/.tox/py27/lib/python2.7/site-packages/setuptools/dist.py", line 704, in parse_config_files
        self._parse_config_files(filenames=filenames)
      File "/devel/pyelftools/.tox/py27/lib/python2.7/site-packages/setuptools/dist.py", line 600, in _parse_config_files
        reader = io.TextIOWrapper(fp, encoding=encoding)
    LookupError: unknown encoding:
```

This is due to the specification of LC_ALL as simply `en_US` without an encoding. Python 3.x seems to be fine with this, but Python 2.7 barfs. As a fix, setting `LC_ALL` to `en_US.utf-8` (including an explicit encoding spec) works.