### PR TITLE
utilizing package name spaces for convenient imports 

### DIFF
--- a/elftools/common/__init__.py
+++ b/elftools/common/__init__.py
@@ -1,0 +1,4 @@
+from .construct_utils import *
+from .exceptions import *
+from .py3compat import *
+from .utils import *

--- a/elftools/dwarf/__init__.py
+++ b/elftools/dwarf/__init__.py
@@ -1,0 +1,22 @@
+from .abbrevtable import AbbrevTable
+from .aranges import ARanges, ARangeEntry
+from .callframe import CallFrameInfo, CallFrameInstruction, CFARule, CFIEntry, CIE
+from .compileunit import CompileUnit
+from .constants import *
+from .descriptions import *
+from .die import DIE
+from .dwarf_expr import GenericExprVisitor, DW_OP_name2opcode, DW_OP_opcode2name
+from .dwarfinfo import DebugSectionDescriptor, DwarfConfig, DWARFInfo
+from .enums import ENUM_DW_AT, ENUM_DW_CHILDREN, ENUM_DW_FORM, ENUM_DW_TAG, DW_EH_encoding_flags, DW_FORM_raw2name
+from .lineprogram import LineProgram, LineProgramEntry, LineState
+from .locationlists import LocationEntry, LocationLists
+from .namelut import NameLUT, NameLUTEntry
+from .ranges import RangeEntry, RangeLists, BaseAddressEntry
+from .structs import DWARFStructs
+
+__all__ = ("AbbrevTable", "ARanges", "ARangeEntry", "CallFrameInfo", "CallFrameInstruction",
+           "CFARule", "CFIEntry", "CIE", "CompileUnit", "DIE", "GenericExprVisitor", "DW_OP_opcode2name",
+           "DW_OP_name2opcode", "DebugSectionDescriptor", "DwarfConfig", "DWARFInfo",
+           "ENUM_DW_AT", "ENUM_DW_CHILDREN", "ENUM_DW_FORM", "ENUM_DW_TAG", "DW_EH_encoding_flags",
+           "DW_FORM_raw2name", "LineProgram", "LineProgramEntry", "LineState", "LocationLists", "LocationEntry",
+           "NameLUT", "NameLUTEntry", "RangeEntry", "RangeLists", "BaseAddressEntry", "DWARFStructs")

--- a/elftools/elf/__init__.py
+++ b/elftools/elf/__init__.py
@@ -1,0 +1,31 @@
+from .constants import E_FLAGS, E_FLAGS_MASKS, SH_FLAGS, SHN_INDICES, SUNW_SYMINFO_FLAGS, P_FLAGS, VER_FLAGS
+from .descriptions import *
+from .dynamic import Dynamic
+from .elffile import ELFFile
+from .enums import *
+from .gnuversions import Version, VersionAuxiliary
+from .hash import HashSection
+from .notes import iter_notes
+from .relocation import Relocation
+from .sections import ARMAttribute, Section, Symbol
+from .structs import ELFStructs
+
+__all__ = (
+    "ARMAttribute",
+    "Dynamic",
+    "E_FLAGS",
+    "E_FLAGS_MASKS",
+    "ELFFile",
+    "ELFStructs",
+    "HashSection",
+    "Version",
+    "VersionAuxiliary",
+    "Relocation",
+    "Section",
+    "Symbol",
+    "SH_FLAGS",
+    "SHN_INDICES",
+    "SUNW_SYMINFO_FLAGS",
+    "P_FLAGS",
+    "VER_FLAGS"
+)


### PR DESCRIPTION
This PR only introduces changes to `__init__.py` in pyelftools packages. This PR does not introduce any new functionality but potential to import make the tool more usable with other python applications.
Closes #222 