### PR TITLE
Fix deprecation warning in Python 3.7

### DIFF
--- a/elftools/construct/lib/container.py
+++ b/elftools/construct/lib/container.py
@@ -2,8 +2,8 @@
 Various containers.
 """
 
-from collections import MutableMapping
 from pprint import pformat
+from .py3compat import MutableMapping
 
 def recursion_lock(retval, lock_name = "__recursion_lock__"):
     def decorator(func):

--- a/elftools/construct/lib/py3compat.py
+++ b/elftools/construct/lib/py3compat.py
@@ -6,6 +6,11 @@
 import sys
 PY3 = sys.version_info[0] == 3
 
+try:
+    from collections.abc import MutableMapping  # python >= 3.3
+except ImportError:
+    from collections import MutableMapping  # python < 3.3
+
 
 if PY3:
     import io


### PR DESCRIPTION
```
$SITE_PYTHON/lib/python3.7/site-packages/elftools/construct/lib/container.py:5
 Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
```

This change is compatible with Python 3.3 and up, when the ABCs were moved to collections.abc.