### PR TITLE
dwarf_expr: Add DW_OP_{implicit,stack}_value

### DIFF
--- a/elftools/dwarf/dwarf_expr.py
+++ b/elftools/dwarf/dwarf_expr.py
@@ -68,6 +68,8 @@ DW_OP_name2opcode = dict(
     DW_OP_form_tls_address=0x9b,
     DW_OP_call_frame_cfa=0x9c,
     DW_OP_bit_piece=0x9d,
+    DW_OP_implicit_value=0x9e,
+    DW_OP_stack_value=0x9f,
 )
 
 def _generate_dynamic_values(map, prefix, index_start, index_end, value_start):


### PR DESCRIPTION
Adds `DW_OP_implicit_value` and `DW_OP_stack_value`, which can be found in DWARF v4 2.6.1.1.3:

> An implicit location description represents a piece or all of an object which has no actual
location but whose contents are nonetheless either known or known to be undefined. 
> The following DWARF operations may be used to specify a value that has no location in the
program but is a known constant or is computed from other locations and values in the program. 