### PR TITLE
dwarf/descriptions: Remove DW_LANG_Upc

### DIFF
--- a/elftools/dwarf/descriptions.py
+++ b/elftools/dwarf/descriptions.py
@@ -314,7 +314,6 @@ _DESCR_DW_LANG = {
     DW_LANG_D: '(D)',
     DW_LANG_Python: '(Python)',
     DW_LANG_Mips_Assembler: '(MIPS assembler)',
-    DW_LANG_Upc: '(nified Parallel C)',
     DW_LANG_HP_Bliss: '(HP Bliss)',
     DW_LANG_HP_Basic91: '(HP Basic 91)',
     DW_LANG_HP_Pascal91: '(HP Pascal 91)',


### PR DESCRIPTION
The standard defines only `DW_LANG_UPC` (correctly declared above), and this value also contained a typo (missing "U").