### PR TITLE
dwarf_cu: Add DIE lookup through offset

### DIFF
--- a/elftools/dwarf/compileunit.py
+++ b/elftools/dwarf/compileunit.py
@@ -55,6 +55,8 @@ class CompileUnit(object):
 
         # A list of DIEs belonging to this CU. Lazily parsed.
         self._dielist = []
+        # A map of section offsets to corresponding DIEs belonging to this CU
+        self._diemap = {}
 
     def dwarf_format(self):
         """ Get the DWARF format (32 or 64) for this CU
@@ -74,6 +76,12 @@ class CompileUnit(object):
             DW_TAG_partial_unit) of this CU
         """
         return self._get_DIE(0)
+
+    def die_from_offset(self, offset):
+        """ Get the DIE at specified offset within this CU. Raise KeyError if
+            offset does not point to the beginning of a known DIE entry.
+        """
+        return self._diemap[offset]
 
     def iter_DIEs(self):
         """ Iterate over all the DIEs in the CU, in order of their appearance.
@@ -118,6 +126,7 @@ class CompileUnit(object):
                     stream=self.dwarfinfo.debug_info_sec.stream,
                     offset=die_offset)
             self._dielist.append(die)
+            self._diemap[die_offset] = die
             die_offset += die.size
 
         # Second pass - unflatten the DIE tree


### PR DESCRIPTION
This allows for easier lookup of chained DIE entries.

As a motivating example, we can easily retrieve the type information from a variable in the `.debug_info` section.

If part of the section looks like the following (taken from `objdump`), with a variable `z` at offset `<a7>`:

```
Contents of the .debug_info section:

  Compilation Unit @ offset 0x0:
   Length:        0xd0 (32-bit)
   Version:       4
   Abbrev Offset: 0x0
   Pointer Size:  8
 <0><b>: Abbrev Number: 1 (DW_TAG_compile_unit)
...
 <2><a7>: Abbrev Number: 4 (DW_TAG_variable)
    <a8>   DW_AT_location    : 2 byte block: 91 7c      (DW_OP_fbreg: -4)
    <ab>   DW_AT_name        : (indirect string, offset: 0xe0): z
    <af>   DW_AT_decl_file   : 1
    <b0>   DW_AT_decl_line   : 36
    <b1>   DW_AT_type        : <0xb6>
 <2><b5>: Abbrev Number: 0
 <1><b6>: Abbrev Number: 6 (DW_TAG_base_type)
    <b7>   DW_AT_name        : (indirect string, offset: 0xc1): int
    <bb>   DW_AT_encoding    : 5        (signed)
    <bc>   DW_AT_byte_size   : 4
 <1><bd>: Abbrev Number: 7 (DW_TAG_pointer_type)
    <be>   DW_AT_type        : <0xc2>
 <1><c2>: Abbrev Number: 7 (DW_TAG_pointer_type)
    <c3>   DW_AT_type        : <0xc7>
 <1><c7>: Abbrev Number: 8 (DW_TAG_const_type)
    <c8>   DW_AT_type        : <0xcc>
 <1><cc>: Abbrev Number: 6 (DW_TAG_base_type)
    <cd>   DW_AT_name        : (indirect string, offset: 0xd7): char
    <d1>   DW_AT_encoding    : 6        (signed char)
    <d2>   DW_AT_byte_size   : 1
 <1><d3>: Abbrev Number: 0
```

Then, we can, given the DIE entry, `die`, for our variable `z`, execute the following to retrieve type information:

```python
type_entry = die.attributes["DW_AT_type"]
type_die = die.cu.die_from_offset(type_entry.value)
print({
    "name": type_die.attributes["DW_AT_name"].value.decode("utf8"),
    "encoding": type_die.attributes["DW_AT_encoding"].value,
    "byte_size": type_die.attributes["DW_AT_byte_size"].value
})
```

of course, a more robust type-resolution function would have to check the `DW_TAG_*` values and perform lookups until a `DW_TAG_base_type` is reached (or other base tag), or the DIE does not have a `DW_AT_type` attribute.