### PR TITLE
Fix deprecation warning in Python 3.7

### DIFF
--- a/elftools/construct/lib/py3compat.py
+++ b/elftools/construct/lib/py3compat.py
@@ -11,6 +11,11 @@ try:
 except ImportError:
     from collections import MutableMapping  # python < 3.3
 
+try:
+    from collections.abc import Mapping  # python >= 3.3
+except ImportError:
+    from collections import Mapping  # python < 3.3
+
 
 if PY3:
     import io

--- a/elftools/dwarf/namelut.py
+++ b/elftools/dwarf/namelut.py
@@ -13,10 +13,12 @@ from ..common.utils import struct_parse
 from bisect import bisect_right
 import math
 from ..construct import CString, Struct, If
+from ..construct.py3compat import Mapping
 
 NameLUTEntry = collections.namedtuple('NameLUTEntry', 'cu_ofs die_ofs')
 
-class NameLUT(collections.Mapping):
+
+class NameLUT(Mapping):
     """
     A "Name LUT" holds any of the tables specified by .debug_pubtypes or
     .debug_pubnames sections. This is basically a dictionary where the key is


### PR DESCRIPTION
based on the fix from #231 