### PR TITLE
Include README.rst instead of README in manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,7 +2,7 @@ recursive-include elftools *.py
 recursive-include scripts *.py
 recursive-include examples *.py *.elf *.out
 recursive-include test *.py *.elf *.arm *.mips *.o
-include README
+include README.rst
 include LICENSE
 include CHANGES
 include tox.ini


### PR DESCRIPTION
`setup.py bdist_wheel` warns about not finding README.