### PR TITLE
elf/constants: Add SHN_XINDEX

### DIFF
--- a/elftools/elf/constants.py
+++ b/elftools/elf/constants.py
@@ -71,6 +71,7 @@ class SHN_INDICES(object):
     SHN_ABS=0xfff1
     SHN_COMMON=0xfff2
     SHN_HIRESERVE=0xffff
+    SHN_XINDEX=0xffff
 
 
 class SH_FLAGS(object):


### PR DESCRIPTION
`SHN_XINDEX` has the same value as `SHN_HIRESERVE` and is used as a sentinel for section indices that are too large to fit in the section header table. Their interpretation is section-dependent.

Reference:
* https://docs.oracle.com/cd/E19683-01/817-3677/chapter6-94076/index.html