### PR TITLE
Cached random access to CUs and DIEs

### DIFF
--- a/elftools/dwarf/die.py
+++ b/elftools/dwarf/die.py
@@ -99,9 +99,11 @@ class DIE(object):
         return self.tag is None
 
     def get_parent(self):
-        """ The parent DIE of this DIE. None if the DIE has no parent (i.e. a
-            top-level DIE).
+        """ Return the parent DIE of this DIE, or None if the DIE has no
+            parent (i.e. is a top-level DIE).
         """
+        if self._parent is None:
+            self._search_ancestor_offspring()
         return self._parent
 
     def get_full_path(self):
@@ -126,8 +128,9 @@ class DIE(object):
     def iter_siblings(self):
         """ Yield all siblings of this DIE
         """
-        if self._parent:
-            for sibling in self._parent.iter_children():
+        parent = self.get_parent()
+        if parent:
+            for sibling in parent.iter_children():
                 if sibling is not self:
                     yield sibling
         else:
@@ -141,6 +144,42 @@ class DIE(object):
         self._parent = die
 
     #------ PRIVATE ------#
+
+    def _search_ancestor_offspring(self):
+        """ Search our ancestors identifying their offspring to find our parent.
+
+            DIEs are stored as a flattened tree.  The top DIE is the ancestor
+            of all DIEs in the unit.  Each parent is guaranteed to be at
+            an offset less than their children.  In each generation of children
+            the sibling with the closest offset not greater than our offset is
+            our ancestor.
+        """
+        # This code is called when get_parent notices that the _parent has
+        # not been identified.  To avoid execution for each sibling record all
+        # the children of any parent iterated.  Assuming get_parent will also be
+        # called for siblings, it is more efficient if siblings references are
+        # provided and no worse than a single walk if they are missing, while
+        # stopping iteration early could result in O(n^2) walks.
+        search = self.cu.get_top_DIE()
+        while search.offset < self.offset:
+            prev = search
+            for child in search.iter_children():
+                child.set_parent(search)
+                if child.offset <= self.offset:
+                    prev = child
+
+            # We also need to check the offset of the terminator DIE
+            if search.has_children and search._terminator.offset <= self.offset:
+                    prev = search._terminator
+
+            # If we didn't find a closer parent, give up, don't loop.
+            # Either we mis-parsed an ancestor or someone created a DIE
+            # by an offset that was not actually the start of a DIE.
+            if prev is search:
+                raise ValueError("offset %s not in CU %s DIE tree" %
+                    (self.offset, self.cu.cu_offset))
+
+            search = prev
 
     def __repr__(self):
         s = 'DIE %s, size=%s, has_children=%s\n' % (

--- a/elftools/dwarf/die.py
+++ b/elftools/dwarf/die.py
@@ -98,6 +98,28 @@ class DIE(object):
         """
         return self.tag is None
 
+    def get_DIE_from_attribute(self, name):
+        """ Return the DIE referenced by the named attribute of this DIE.
+            The attribute must be in the reference attribute class.
+
+            name:
+                The name of the attribute in the reference class.
+        """
+        attr = self.attributes[name]
+        if attr.form in ('DW_FORM_ref1', 'DW_FORM_ref2', 'DW_FORM_ref4',
+                         'DW_FORM_ref8', 'DW_FORM_ref'):
+            refaddr = self.cu.cu_offset + attr.raw_value
+            return self.cu.get_DIE_from_refaddr(refaddr)
+        elif attr.form in ('DW_FORM_refaddr'):
+            return self.cu.dwarfinfo.get_DIE_from_refaddr(attr.raw_value)
+        elif attr.form in ('DW_FORM_ref_sig8'):
+            # Implement search type units for matching signature
+            raise NotImplementedError('%s (type unit by signature)' % attr.form)
+        elif attr.form in ('DW_FORM_ref_sup4', 'DW_FORM_ref_sup8'):
+            raise NotImplementedError('%s to dwo' % attr.form)
+        else:
+            raise DWARFError('%s is not a reference class form attribute' % attr)
+
     def get_parent(self):
         """ Return the parent DIE of this DIE, or None if the DIE has no
             parent (i.e. is a top-level DIE).

--- a/elftools/dwarf/dwarfinfo.py
+++ b/elftools/dwarf/dwarfinfo.py
@@ -118,6 +118,30 @@ class DWARFInfo(object):
         """
         return bool(self.debug_info_sec)
 
+    def get_DIE_from_lut_entry(self, lut_entry):
+        """ Get the DIE from the pubnames or putbtypes lookup table entry.
+
+            lut_entry:
+                A NameLUTEntry object from a NameLUT instance (see
+                .get_pubmames and .get_pubtypes methods).
+        """
+        cu = self.get_CU_at(lut_entry.cu_ofs)
+        return self.get_DIE_from_refaddr(lut_entry.die_ofs, cu)
+
+    def get_DIE_from_refaddr(self, refaddr, cu=None):
+        """ Given a .debug_info section offset of a DIE, return the DIE.
+
+            refaddr:
+                The refaddr may come from a DW_FORM_ref_addr attribute.
+
+            cu:
+                The compile unit object, if known.  If None a search
+                from the closest offset less than refaddr will be performed.
+        """
+        if cu is None:
+            cu = self.get_CU_containing(refaddr)
+        return cu.get_DIE_from_refaddr(refaddr)
+
     def get_CU_containing(self, refaddr):
         """ Find the CU that includes the given reference address in the
             .debug_info section.

--- a/test/test_dwarf_cu_and_die_cache.py
+++ b/test/test_dwarf_cu_and_die_cache.py
@@ -1,0 +1,58 @@
+#-------------------------------------------------------------------------------
+# elftools tests
+#
+# Eli Bendersky (eliben@gmail.com), Milton Miller <miltonm@us.ibm.com>
+# This code is in the public domain
+#-------------------------------------------------------------------------------
+import os
+import unittest
+
+from elftools.elf.elffile import ELFFile
+from elftools.common.py3compat import bytes2str
+
+class TestCacheLUTandDIEref(unittest.TestCase):
+    def dprint(self, list):
+        if False:
+            self.oprint(list)
+
+    def oprint(self, list):
+        if False:
+            print(list)
+
+    def test_die_from_LUTentry(self):
+        lines = ['']
+        with open(os.path.join('test', 'testfiles_for_unittests',
+                               'lambda.elf'), 'rb') as f:
+            elffile = ELFFile(f)
+            self.assertTrue(elffile.has_dwarf_info())
+
+            dwarf = elffile.get_dwarf_info()
+            pt = dwarf.get_pubnames()
+            for (k, v) in pt.items():
+                ndie = dwarf.get_DIE_from_lut_entry(v)
+                self.dprint(ndie)
+                if not 'DW_AT_type' in ndie.attributes:
+                    continue
+                if not 'DW_AT_name' in ndie.attributes:
+                    continue
+                name = bytes2str(ndie.attributes['DW_AT_name'].value)
+                tlist = []
+                tdie = ndie
+                while True:
+                    tdie = tdie.get_DIE_from_attribute('DW_AT_type')
+                    self.dprint(ndie)
+                    ttag = tdie.tag
+                    if isinstance(ttag, int):
+                        ttag = 'TAG(0x%x)' % ttag
+                    tlist.append(ttag)
+                    if 'DW_AT_name' in tdie.attributes:
+                        break
+                tlist.append(bytes2str(tdie.attributes['DW_AT_name'].value))
+                tname = ' '.join(tlist)
+                line = "%s DIE at %s is of type %s" % (
+                        ndie.tag, ndie.offset, tname)
+                lines.append(line)
+                self.dprint(line)
+
+        self.oprint('\n'.join(lines))
+        self.assertGreater(len(lines), 1)


### PR DESCRIPTION
Here is a series that refactors the DIE cache to cache entries without walking from the top of a CU,
and also one that adds a similar cache to the CU lookup in the DWARFInfo.