### PR TITLE
Make sure ELFFile.has_dwarf_info() returns a Boolean.

### DIFF
--- a/elftools/elf/elffile.py
+++ b/elftools/elf/elffile.py
@@ -150,7 +150,7 @@ class ELFFile(object):
             We assume that if it has the .debug_info or .zdebug_info section, it
             has all the other required sections as well.
         """
-        return (self.get_section_by_name('.debug_info') or
+        return bool(self.get_section_by_name('.debug_info') or
             self.get_section_by_name('.zdebug_info') or
             self.get_section_by_name('.eh_frame'))
 


### PR DESCRIPTION
The current implementation of has_dwarf_info() will make it return a Section object if a binary does have one of the sections that are checked. This PR makes it return a Boolean instead.