### PR TITLE
Add support for DW_LNE_set_discriminator 

### DIFF
--- a/elftools/dwarf/constants.py
+++ b/elftools/dwarf/constants.py
@@ -157,6 +157,8 @@ DW_LNE_end_sequence = 0x01
 DW_LNE_set_address = 0x02
 DW_LNE_define_file = 0x03
 DW_LNE_set_discriminator = 0x04
+DW_LNE_lo_user = 0x80
+DW_LNE_hi_user = 0xff
 
 
 # Call frame instructions

--- a/elftools/dwarf/constants.py
+++ b/elftools/dwarf/constants.py
@@ -156,6 +156,7 @@ DW_LNS_set_isa = 0x0c
 DW_LNE_end_sequence = 0x01
 DW_LNE_set_address = 0x02
 DW_LNE_define_file = 0x03
+DW_LNE_set_discriminator = 0x04
 
 
 # Call frame instructions

--- a/elftools/dwarf/lineprogram.py
+++ b/elftools/dwarf/lineprogram.py
@@ -131,6 +131,7 @@ class LineProgram(object):
             # After adding, clear some state registers.
             entries.append(LineProgramEntry(
                 cmd, is_extended, args, copy.copy(state)))
+            state.discriminator = 0
             state.basic_block = False
             state.prologue_end = False
             state.epilogue_begin = False

--- a/elftools/dwarf/lineprogram.py
+++ b/elftools/dwarf/lineprogram.py
@@ -64,7 +64,8 @@ class LineState(object):
         a = ['<LineState %x:' % id(self)]
         a.append('  address = 0x%x' % self.address)
         for attr in ('file', 'line', 'column', 'is_stmt', 'basic_block',
-                     'end_sequence', 'prologue_end', 'epilogue_begin', 'isa'):
+                     'end_sequence', 'prologue_end', 'epilogue_begin', 'isa',
+                     'discriminator'):
             a.append('  %s = %s' % (attr, getattr(self, attr)))
         return '\n'.join(a) + '>\n'
 
@@ -194,7 +195,6 @@ class LineProgram(object):
                     operand = struct_parse(self.structs.Dwarf_uleb128(''),
                                            self.stream)
                     state.discriminator = operand
-                    add_entry_old_state(ex_opcode, [operand], is_extended=True)
                 else:
                     # Unknown, but need to roll forward the stream because the
                     # length is specified. Seek forward inst_len - 1 because

--- a/elftools/dwarf/lineprogram.py
+++ b/elftools/dwarf/lineprogram.py
@@ -194,6 +194,7 @@ class LineProgram(object):
                     operand = struct_parse(self.structs.Dwarf_uleb128(''),
                                            self.stream)
                     state.discriminator = operand
+                    add_entry_old_state(ex_opcode, [operand], is_extended=True)
                 else:
                     # Unknown, but need to roll forward the stream because the
                     # length is specified. Seek forward inst_len - 1 because

--- a/elftools/dwarf/lineprogram.py
+++ b/elftools/dwarf/lineprogram.py
@@ -58,6 +58,7 @@ class LineState(object):
         self.prologue_end = False
         self.epilogue_begin = False
         self.isa = 0
+        self.discriminator = 0
 
     def __repr__(self):
         a = ['<LineState %x:' % id(self)]
@@ -188,6 +189,10 @@ class LineProgram(object):
                         self.structs.Dwarf_lineprog_file_entry, self.stream)
                     self['file_entry'].append(operand)
                     add_entry_old_state(ex_opcode, [operand], is_extended=True)
+                elif ex_opcode == DW_LNE_set_discriminator:
+                    operand = struct_parse(self.structs.Dwarf_uleb128(''),
+                                           self.stream)
+                    state.discriminator = operand
                 else:
                     # Unknown, but need to roll forward the stream because the
                     # length is specified. Seek forward inst_len - 1 because

--- a/test/test_dwarf_lineprogram.py
+++ b/test/test_dwarf_lineprogram.py
@@ -18,7 +18,7 @@ class TestLineProgram(unittest.TestCase):
         """
         ds = DWARFStructs(little_endian=True, dwarf_format=32, address_size=4)
         header = ds.Dwarf_lineprog_header.parse(
-            b'\x04\x10\x00\x00' +    # initial lenght
+            b'\x04\x10\x00\x00' +    # initial length
             b'\x03\x00' +            # version
             b'\x20\x00\x00\x00' +    # header length
             b'\x01\x01\x01\x0F' +    # flags
@@ -99,6 +99,26 @@ class TestLineProgram(unittest.TestCase):
         self.assertLineState(linetable[5].state, address=0x244, line=6)
         self.assertLineState(linetable[7].state, address=0x24b, line=7, end_sequence=False)
         self.assertLineState(linetable[9].state, address=0x24d, line=7, end_sequence=True)
+
+    def test_lne_set_discriminator(self):
+        """
+        Tests the handling of DWARFv4's new DW_LNE_set_discriminator opcode.
+        """
+        s = BytesIO()
+        s.write(
+            b'\x00\x02\x04\x05' +  # DW_LNE_set_discriminator (discriminator=0x05)
+            b'\x01' +              # DW_LNS_copy
+            b'\x00\x01\x01'        # DW_LNE_end_sequence
+        )
+
+        lp = self._make_program_in_stream(s)
+        linetable = lp.get_entries()
+
+        self.assertEqual(len(linetable), 3)
+        self.assertEqual(linetable[0].command, DW_LNE_set_discriminator)
+        self.assertIs(linetable[0].state, None)
+        self.assertLineState(linetable[1].state, discriminator=0x05, end_sequence=False)
+        self.assertLineState(linetable[2].state, discriminator=0x00, end_sequence=True)
 
 
 if __name__ == '__main__':

--- a/test/test_dwarf_lineprogram.py
+++ b/test/test_dwarf_lineprogram.py
@@ -114,11 +114,12 @@ class TestLineProgram(unittest.TestCase):
         lp = self._make_program_in_stream(s)
         linetable = lp.get_entries()
 
-        self.assertEqual(len(linetable), 3)
-        self.assertEqual(linetable[0].command, DW_LNE_set_discriminator)
-        self.assertIs(linetable[0].state, None)
-        self.assertLineState(linetable[1].state, discriminator=0x05, end_sequence=False)
-        self.assertLineState(linetable[2].state, discriminator=0x00, end_sequence=True)
+        # We expect two entries, since DW_LNE_set_discriminator does not add
+        # an entry of its own.
+        self.assertEqual(len(linetable), 2)
+        self.assertEqual(linetable[0].command, DW_LNS_copy)
+        self.assertLineState(linetable[0].state, discriminator=0x05)
+        self.assertLineState(linetable[1].state, discriminator=0x00, end_sequence=True)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Adds `DW_LNE_set_discriminator` support to the LNP state machine. Also adds the relevant constant and two `lo`/`hi` constants in the LNE family.

Ref DWARFv4:
* 6.2.2 State Machine Registers
* 6.2.5.2 Standard Opcodes
* 6.2.5.3 Extended Opcodes