### PR TITLE
construct_utils.py: add missing import

### DIFF
--- a/elftools/common/construct_utils.py
+++ b/elftools/common/construct_utils.py
@@ -8,7 +8,7 @@
 #-------------------------------------------------------------------------------
 from ..construct import (
     Subconstruct, ConstructError, ArrayError, Adapter, Field, RepeatUntil,
-    Rename
+    Rename, SizeofError
     )
 
 


### PR DESCRIPTION
Add a forgotten import of SizeofError.

Fixes: #278