### PR TITLE
Only byteswap the little endian version of mips64 r_raw_info

### DIFF
--- a/elftools/elf/structs.py
+++ b/elftools/elf/structs.py
@@ -237,6 +237,9 @@ class ELFStructs(object):
 
             def compute_r_info(ctx):
                 raw = ctx['r_raw_info']
+                if not self.little_endian:
+                    return raw
+                # little endian requires an additional byteswap
                 return (((raw & 0xffffffff) << 32)
                         | ((raw >> 56) & 0xff)
                         | ((raw >> 40) & 0xff00)


### PR DESCRIPTION
Followup to #295. It turns out i was not thorough enough with my testing.

The only test file I have for this change is a libc, which is way bigger than any of the binaries currently in the test files archive. But I can confirm it works, and mirrors the way we hacked around this weird ELF edge case in angr before it was supported here.