### PR TITLE
Return the correct number of program headers when e_phnum is 0xffff

### DIFF
--- a/elftools/elf/elffile.py
+++ b/elftools/elf/elffile.py
@@ -120,7 +120,10 @@ class ELFFile(object):
     def num_segments(self):
         """ Number of segments in the file
         """
-        return self['e_phnum']
+        if self['e_phnum'] < 0xffff:
+            return self['e_phnum']
+        else:
+            return self.get_section(0)['sh_info']
 
     def get_segment(self, n):
         """ Get the segment at index #n from the file (Segment object)

--- a/elftools/elf/elffile.py
+++ b/elftools/elf/elffile.py
@@ -120,6 +120,13 @@ class ELFFile(object):
     def num_segments(self):
         """ Number of segments in the file
         """
+        # From: https://github.com/hjl-tools/x86-psABI/wiki/X86-psABI
+        # Section: 4.1.2 Number of Program Headers
+        # If the number of program headers is greater than or equal to
+        # PN_XNUM (0xffff), this member has the value PN_XNUM
+        # (0xffff). The actual number of program header table entries
+        # is contained in the sh_info field of the section header at
+        # index 0.
         if self['e_phnum'] < 0xffff:
             return self['e_phnum']
         else:

--- a/scripts/readelf.py
+++ b/scripts/readelf.py
@@ -218,7 +218,7 @@ class ReadElf(object):
             # readelf weirness - why isn't e_phoff printed as hex? (for section
             # headers, it is...)
             self._emitline('There are %s program headers, starting at offset %s' % (
-                elfheader['e_phnum'], elfheader['e_phoff']))
+                self.elffile.num_segments(), elfheader['e_phoff']))
             self._emitline()
 
         self._emitline('Program Headers:')


### PR DESCRIPTION
While using pyelftools to parse a QEMU memory dump (ELF corefile), I noticed that pyelftools returned only the first 65535 program headers, while readelf returned 65843. 
Per specification:
"If the number of program headers is greater than or equal to PN_XNUM (0xffff), this member has the value PN_XNUM (0xffff). The actual number of program header table entries is contained in the sh_info field of the section header at index 0."

This PR should implement this behaviour and fix the problem.

In case you want to test the code, [here](https://github.com/eliben/pyelftools/files/4915397/sample0.min.gz) you can find the corefile! 



