### PR TITLE
Update code to work with pickling

### DIFF
--- a/elftools/construct/core.py
+++ b/elftools/construct/core.py
@@ -345,7 +345,7 @@ class FormatField(StaticField):
         return attrs
     def __setstate__(self, attrs):
         attrs["packer"] = Packer(attrs["packer"])
-        return StaticField.__setstate__(attrs)
+        return StaticField.__setstate__(self, attrs)
     def _parse(self, stream, context):
         try:
             return self.packer.unpack(_read_stream(stream, self.length))[0]
@@ -1297,6 +1297,8 @@ class Pass(Construct):
         assert obj is None
     def _sizeof(self, context):
         return 0
+    def __reduce__(self):
+        return self.__class__.__name__
 Pass = Pass(None)
 
 class Terminator(Construct):


### PR DESCRIPTION
When pickling objects using the "dill" package, the pickler does not know how to handle singletons and will throw an error. The __reduce__ method I added on 1300 tells the pickler how to handle the object's serialization. After I was able to pickle the object, I noticed that I was having a few issues with unpickling. It seemed as if there might have been a small issue with how the parameters were being passed in on line 348. The error message said it required two arguments, not one. By adding the self argument, it managed to fix the problems. 