### PR TITLE
[example] bug fixes in dwarf_decode_address example

### DIFF
--- a/examples/dwarf_decode_address.py
+++ b/examples/dwarf_decode_address.py
@@ -67,7 +67,7 @@ def decode_funcname(dwarfinfo, address):
                               highpc_attr_class)
                         continue
 
-                    if lowpc <= address <= highpc:
+                    if lowpc <= address < highpc:
                         return DIE.attributes['DW_AT_name'].value
             except KeyError:
                 continue

--- a/examples/dwarf_decode_address.py
+++ b/examples/dwarf_decode_address.py
@@ -85,17 +85,22 @@ def decode_file_line(dwarfinfo, address):
             # We're interested in those entries where a new state is assigned
             if entry.state is None:
                 continue
-            if entry.state.end_sequence:
-                # if the line number sequence ends, clear prevstate.
-                prevstate = None
-                continue
             # Looking for a range of addresses in two consecutive states that
             # contain the required address.
             if prevstate and prevstate.address <= address < entry.state.address:
                 filename = lineprog['file_entry'][prevstate.file - 1].name
                 line = prevstate.line
                 return filename, line
-            prevstate = entry.state
+            if entry.state.end_sequence:
+                # For the state with `end_sequence`, `address` means the address
+                # of the first byte after the target machine instruction
+                # sequence and other information is meaningless. We clear
+                # prevstate so that it's not used in the next iteration. Address
+                # info is used in the above comparison to see if we need to use
+                # the line information for the prevstate.
+                prevstate = None
+            else:
+                prevstate = entry.state
     return None, None
 
 


### PR DESCRIPTION
I was building call trace analyzer based on the examples in pyelftools, and found out that line program entry with end_sequence=True is not handled, so it made my analyzer fail to get source code information for some cases.

I think it should be handled as in this PR.

Also, highpc should not be included in `decode_funcname`.
Because of it, multiple DIEs were matched for specific addresses.
I think it is right also according to DWARF v4 spec:
> DW_AT_high_pc  ...  is the relocated address of the first location past the last instruction associated with the entity

But I'm not 100% sure since I'm not the expert. I just spent a few days with pyelftools..