### PR TITLE
dwarf/constants: add DW_LNCT_* constants

### DIFF
--- a/elftools/dwarf/constants.py
+++ b/elftools/dwarf/constants.py
@@ -160,6 +160,15 @@ DW_LNE_set_discriminator = 0x04
 DW_LNE_lo_user = 0x80
 DW_LNE_hi_user = 0xff
 
+# Line program header content types
+#
+DW_LNCT_path = 0x01
+DW_LNCT_directory_index = 0x02
+DW_LNCT_timestamp = 0x03
+DW_LNCT_size = 0x04
+DW_LNCT_MD5 = 0x05
+DW_LNCT_lo_user = 0x2000
+DW_LNCT_hi_user = 0x3fff
 
 # Call frame instructions
 #


### PR DESCRIPTION
These were introduced with DWARFv5 and are documented in S. 6.2.4.1.

The constants themselves are documented in Table 7.27:

![Screen Shot 2021-05-20 at 4 16 03 PM](https://user-images.githubusercontent.com/3059210/119043107-afbbaa80-b986-11eb-84fa-e92d56e0015d.png)