### PR TITLE
Use assertEqual instead of assertEquals for Python 3.11 compatibility.

### DIFF
--- a/test/test_arm_call_reloc.py
+++ b/test/test_arm_call_reloc.py
@@ -38,7 +38,7 @@ class TestARMRElocation(unittest.TestCase):
             elf = ELFFile(f)
 
             # Comparison of '.text' section data
-            self.assertEquals(do_relocation(rel_elf),
+            self.assertEqual(do_relocation(rel_elf),
                               elf.get_section_by_name('.text').data())
 
 if __name__ == '__main__':

--- a/test/test_die_size.py
+++ b/test/test_die_size.py
@@ -26,7 +26,7 @@ class TestDieSize(unittest.TestCase):
             dwarfinfo = elffile.get_dwarf_info()
             for CU in dwarfinfo.iter_CUs():
                  for child in CU.get_top_DIE().iter_children():
-                     self.assertEquals(child.size, 3)
+                     self.assertEqual(child.size, 3)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The deprecated aliases were removed in Python 3.11 in python/cpython#28268 . `assertEqual` is present in both Python 2 and 3