### PR TITLE
add latest 'e_machine' mappings: EM_BPF, EM_CSKY, EM_FRV

### DIFF
--- a/elftools/elf/elffile.py
+++ b/elftools/elf/elffile.py
@@ -467,7 +467,10 @@ class ELFFile(object):
             'EM_FT32'          : 'FTDI Chip FT32 32-bit RISC',
             'EM_MOXIE'         : 'Moxie',
             'EM_AMDGPU'        : 'AMD GPU',
-            'EM_RISCV'         : 'RISC-V'
+            'EM_RISCV'         : 'RISC-V',
+            'EM_BPF'           : 'Linux BPF - in-kernel virtual machine',
+            'EM_CSKY'          : 'C-SKY',
+            'EM_FRV'           : 'Fujitsu FR-V'
         }
 
         return architectures.get(self['e_machine'], '<unknown>')

--- a/elftools/elf/enums.py
+++ b/elftools/elf/enums.py
@@ -254,6 +254,9 @@ ENUM_E_MACHINE = dict(
     EM_MOXIE         = 223, # Moxie processor family
     EM_AMDGPU        = 224, # AMD GPU architecture
     EM_RISCV         = 243, # RISC-V
+    EM_BPF           = 247,	# Linux BPF - in-kernel virtual machine
+    EM_CSKY          = 252,	# C-SKY
+    EM_FRV           = 0x5441, # Fujitsu FR-V
     # Reservations
     # reserved  11-14   Reserved for future use
     # reserved  16      Reserved for future use


### PR DESCRIPTION
Adds latest `e_machine` ELF header value mappings: `EM_BPF, EM_CSKY, EM_FRV`
I see there is a variable called `_DESCR_E_MACHINE`; the descriptions it contains are quite partial -- I assumed that it's not used often, so it's just outdated. I didn't touch it. 