### PR TITLE
fix setup.py test

### DIFF
--- a/test/all_tests.py
+++ b/test/all_tests.py
@@ -9,7 +9,7 @@
 #-------------------------------------------------------------------------------
 from __future__ import print_function
 import subprocess, sys
-from utils import is_in_rootdir
+from .utils import is_in_rootdir
 
 def run_test_script(path):
     cmd = [sys.executable, path]

--- a/test/run_examples_test.py
+++ b/test/run_examples_test.py
@@ -9,7 +9,7 @@
 #-------------------------------------------------------------------------------
 import os, sys
 import logging
-from utils import run_exe, is_in_rootdir, dump_output_to_temp_files
+from .utils import run_exe, is_in_rootdir, dump_output_to_temp_files
 
 # Make it possible to run this file from the root dir of pyelftools without
 # installing pyelftools; useful for CI testing, etc.

--- a/test/run_readelf_tests.py
+++ b/test/run_readelf_tests.py
@@ -17,7 +17,7 @@ import re
 import sys
 import time
 
-from utils import run_exe, is_in_rootdir, dump_output_to_temp_files
+from .utils import run_exe, is_in_rootdir, dump_output_to_temp_files
 
 # Make it possible to run this file from the root dir of pyelftools without
 # installing pyelftools; useful for CI testing, etc.


### PR DESCRIPTION
Attempting to run tests using setup.py fails with:

$ python3 setup.py test
======================================================================
ERROR: all_tests (unittest.loader._FailedTest)
----------------------------------------------------------------------
ImportError: Failed to import test module: all_tests
Traceback (most recent call last):
  File "/usr/lib/python3.9/unittest/loader.py", line 154, in loadTestsFromName
    module = __import__(module_name)
  File "/home/jlevon/src/pyelftools/test/all_tests.py", line 12, in <module>
    from utils import is_in_rootdir
ModuleNotFoundError: No module named 'utils'

Fix by using a relative import where necessary.

Signed-off-by: John Levon <levon@movementarian.org>