### PR TITLE
Remove unused imports

### DIFF
--- a/elftools/elf/structs.py
+++ b/elftools/elf/structs.py
@@ -7,7 +7,6 @@
 # Eli Bendersky (eliben@gmail.com)
 # This code is in the public domain
 #-------------------------------------------------------------------------------
-from elftools.construct.macros import AlignedStruct, IfThenElse, UNInt8
 from ..construct import (
     UBInt8, UBInt16, UBInt32, UBInt64,
     ULInt8, ULInt16, ULInt32, ULInt64,


### PR DESCRIPTION
Since these import from elftools.constuct rather than ..construct this import statement interferes with using pyelftools as a local (not pip installed) package