### PR TITLE
Add DW_FORM_line_strp to structs.py

### DIFF
--- a/elftools/common/py3compat.py
+++ b/elftools/common/py3compat.py
@@ -26,7 +26,10 @@ if PY3:
             return b.hex()
         return sep.join(map('{:02x}'.format, b))
 
-    def bytes2str(b): return b.decode('latin-1')
+    def bytes2str(b):
+        if isinstance(b, int):
+            return str(b)
+        return b.decode('latin-1')
     def str2bytes(s): return s.encode('latin-1')
     def int2byte(i): return bytes((i,))
     def byte2int(b): return b

--- a/elftools/dwarf/structs.py
+++ b/elftools/dwarf/structs.py
@@ -223,6 +223,7 @@ class DWARFStructs(object):
             DW_FORM_ref_addr=self.Dwarf_target_addr('') if self.dwarf_version == 2 else self.Dwarf_offset(''),
 
             DW_FORM_indirect=self.Dwarf_uleb128(''),
+            DW_FORM_line_strp=self.Dwarf_uint32('') if self.dwarf_format == 32 else self.Dwarf_uint64(''),
 
             # New forms in DWARFv4
             DW_FORM_flag_present = StaticField('', 0),


### PR DESCRIPTION
From https://dwarfstd.org/doc/DWARF5.pdf
`Chapter 7. Data Representation`: Page 218
```
In the 32-bit DWARF format, the
representation of a DW_FORM_strp,  or
DW_FORM_strp_sup value is a 4-byte unsigned offset; in the 64-bit
DWARF format, it is an 8-byte unsigned offset (see Section 7.4 on
page 196).
```

Testing Steps:
`test.c`
```
#include <stdint.h>

uint32_t fn1(void) {
    return 95;
}
```
`gcc -g3 -c test.c -o test.o`
`python examples/examine_dwarf_info.py --test test.o`
```
Processing file: elftools/common/test.o
  Found a compile unit at offset 0, length 164
    Top DIE with tag=DW_TAG_compile_unit
    name=7/0
```