### PR TITLE
Storing the offset of DWARF operations within the expression block

### DIFF
--- a/elftools/dwarf/dwarf_expr.py
+++ b/elftools/dwarf/dwarf_expr.py
@@ -114,7 +114,7 @@ DW_OP_opcode2name = dict((v, k) for k, v in iteritems(DW_OP_name2opcode))
 
 # Each parsed DWARF expression is returned as this type with its numeric opcode,
 # op name (as a string) and a list of arguments.
-DWARFExprOp = namedtuple('DWARFExprOp', 'op op_name args')
+DWARFExprOp = namedtuple('DWARFExprOp', 'op op_name args offset')
 
 
 class DWARFExprParser(object):
@@ -138,6 +138,7 @@ class DWARFExprParser(object):
         while True:
             # Get the next opcode from the stream. If nothing is left in the
             # stream, we're done.
+            offset = stream.tell()
             byte = stream.read(1)
             if len(byte) == 0:
                 break
@@ -150,7 +151,7 @@ class DWARFExprParser(object):
             arg_parser = self._dispatch_table[op]
             args = arg_parser(stream)
 
-            parsed.append(DWARFExprOp(op=op, op_name=op_name, args=args))
+            parsed.append(DWARFExprOp(op=op, op_name=op_name, args=args, offset = offset))
 
         return parsed
 

--- a/elftools/dwarf/dwarf_expr.py
+++ b/elftools/dwarf/dwarf_expr.py
@@ -151,7 +151,7 @@ class DWARFExprParser(object):
             arg_parser = self._dispatch_table[op]
             args = arg_parser(stream)
 
-            parsed.append(DWARFExprOp(op=op, op_name=op_name, args=args, offset = offset))
+            parsed.append(DWARFExprOp(op=op, op_name=op_name, args=args, offset=offset))
 
         return parsed
 


### PR DESCRIPTION
The DWARF operation `DW_OP_bra` (branch) has an argument which is a byte count within the expression block to skip. Pyelftools' parsed expressions lose the byte positions, so interpreting this command is impossible. Same for `DW_OP_skip`.

This commit adds `offset` to the expression operation object (`DWARFExprOp`).

I've seen `DW_OP_bra` in the wild, in a binary generated by Free Pascal for Windows. It was in the expression that described the dynamic upper bound of the Pascal `AnsiStr` datatype.

It's a two line change. I've provided a trivial test script, with a hard-coded expression blob.

Ref: DWARFv5, 2.5.1.5, section 3:

> DW_OP_bra is a conditional branch. Its single operand is a 2-byte signed
> integer constant. This operation pops the top of stack. If the value popped is
> not the constant 0, the 2-byte constant operand is the number of bytes of the
> DWARF expression to skip forward or backward from the current operation,
> beginning after the 2-byte constant.