### PR TITLE
Tuple indices must be integers or slices, not str

### DIFF
--- a/examples/dwarf_lineprogram_filenames.py
+++ b/examples/dwarf_lineprogram_filenames.py
@@ -78,7 +78,7 @@ def lpe_filename(line_program, file_index):
 
     # File and directory indices are 1-indexed.
     file_entry = file_entries[file_index - 1]
-    dir_index = file_entry["dir_index"]
+    dir_index = file_entry.dir_index
 
     # A dir_index of 0 indicates that no absolute directory was recorded during
     # compilation; return just the basename.


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/yzm/pyelftools/examples/dwarf_lineprogram_filenames.py", line 95, in <module>
    process_file(filename)
  File "/home/yzm/pyelftools/examples/dwarf_lineprogram_filenames.py", line 45, in process_file
    line_entry_mapping(line_program)
  File "/home/yzm/pyelftools/examples/dwarf_lineprogram_filenames.py", line 61, in line_entry_mapping
    filename = lpe_filename(line_program, lpe.state.file)
  File "/home/yzm/pyelftools/examples/dwarf_lineprogram_filenames.py", line 81, in lpe_filename
    dir_index = file_entry["dir_index"]
TypeError: tuple indices must be integers or slices, not str
```