### PR TITLE
Support for DWARFv5 debug_rnglists section

### DIFF
--- a/elftools/dwarf/dwarfinfo.py
+++ b/elftools/dwarf/dwarfinfo.py
@@ -102,7 +102,7 @@ class DWARFInfo(object):
         self.debug_pubtypes_sec = debug_pubtypes_sec
         self.debug_pubnames_sec = debug_pubnames_sec
         self.debug_loclists_sec = debug_loclists_sec
-        self.debug_rnglists_sec = debug_rnglists_sec # Ignored for now
+        self.debug_rnglists_sec = debug_rnglists_sec
 
         # This is the DWARFStructs the context uses, so it doesn't depend on
         # DWARF format and address_size (these are determined per CU) - set them

--- a/elftools/dwarf/dwarfinfo.py
+++ b/elftools/dwarf/dwarfinfo.py
@@ -358,8 +358,11 @@ class DWARFInfo(object):
         """ Get a RangeLists object representing the .debug_ranges section of
             the DWARF data, or None if this section doesn't exist.
         """
-        if self.debug_ranges_sec:
-            return RangeLists(self.debug_ranges_sec.stream, self.structs, self)
+        if self.debug_rnglists_sec:
+            assert(self.debug_ranges_sec is None)
+            return RangeLists(self.debug_rnglists_sec.stream, self.structs, 5, self)
+        elif self.debug_ranges_sec:
+            return RangeLists(self.debug_ranges_sec.stream, self.structs, 4, self)
         else:
             return None
 

--- a/elftools/dwarf/dwarfinfo.py
+++ b/elftools/dwarf/dwarfinfo.py
@@ -359,7 +359,7 @@ class DWARFInfo(object):
             the DWARF data, or None if this section doesn't exist.
         """
         if self.debug_ranges_sec:
-            return RangeLists(self.debug_ranges_sec.stream, self.structs)
+            return RangeLists(self.debug_ranges_sec.stream, self.structs, self)
         else:
             return None
 

--- a/elftools/dwarf/enums.py
+++ b/elftools/dwarf/enums.py
@@ -429,3 +429,14 @@ ENUM_DW_LLE = dict(
     DW_LLE_start_end        = 0x07,
     DW_LLE_start_length     = 0x08    
 )
+
+ENUM_DW_RLE = dict(
+    DW_RLE_end_of_list   = 0x00,
+    DW_RLE_base_addressx = 0x01,
+    DW_RLE_startx_endx   = 0x02,
+    DW_RLE_startx_length = 0x03,
+    DW_RLE_offset_pair   = 0x04,
+    DW_RLE_base_address  = 0x05,
+    DW_RLE_start_end     = 0x06,
+    DW_RLE_start_length  = 0x07
+)

--- a/elftools/dwarf/ranges.py
+++ b/elftools/dwarf/ranges.py
@@ -12,18 +12,24 @@ from collections import namedtuple
 from ..common.utils import struct_parse
 
 
-RangeEntry = namedtuple('RangeEntry', 'begin_offset end_offset')
-BaseAddressEntry = namedtuple('BaseAddressEntry', 'base_address')
+RangeEntry = namedtuple('RangeEntry', 'entry_offset begin_offset end_offset')
+BaseAddressEntry = namedtuple('BaseAddressEntry', 'entry_offset base_address')
 
 
 class RangeLists(object):
     """ A single range list is a Python list consisting of RangeEntry or
         BaseAddressEntry objects.
+
+        The dwarfinfo is needed for enumeration, because it requires
+        scanning the DIEs, because ranges may overlap.
     """
-    def __init__(self, stream, structs):
+    # Since dwarfinfo is not a required parameter, there is fallback to the
+    # broken enumeration logic, in case there is an old consumer
+    def __init__(self, stream, structs, dwarfinfo = None):
         self.stream = stream
         self.structs = structs
         self._max_addr = 2 ** (self.structs.address_size * 8) - 1
+        self._dwarfinfo = dwarfinfo
 
     def get_range_list_at_offset(self, offset):
         """ Get a range list at the given offset in the section.
@@ -34,19 +40,31 @@ class RangeLists(object):
     def iter_range_lists(self):
         """ Yield all range lists found in the section.
         """
-        # Just call _parse_range_list_from_stream until the stream ends
-        self.stream.seek(0, os.SEEK_END)
-        endpos = self.stream.tell()
+        # Calling parse until the stream ends is wrong, because ranges can overlap.
+        # Need to scan the DIEs to know all range locations
+        if self._dwarfinfo:
+            all_offsets = list(set(die.attributes['DW_AT_ranges'].value
+                for cu in self._dwarfinfo.iter_CUs()
+                for die in cu.iter_DIEs()
+                if 'DW_AT_ranges' in die.attributes))
+            all_offsets.sort()
 
-        self.stream.seek(0, os.SEEK_SET)
-        while self.stream.tell() < endpos:
-            yield self._parse_range_list_from_stream()
+            for offset in all_offsets:
+                yield self.get_range_list_at_offset(offset)
+        else: # Flawed logic for legacy consumers, if any
+            self.stream.seek(0, os.SEEK_END)
+            endpos = self.stream.tell()
+
+            self.stream.seek(0, os.SEEK_SET)
+            while self.stream.tell() < endpos:
+                yield self._parse_range_list_from_stream()
 
     #------ PRIVATE ------#
 
     def _parse_range_list_from_stream(self):
         lst = []
         while True:
+            entry_offset = self.stream.tell()
             begin_offset = struct_parse(
                 self.structs.Dwarf_target_addr(''), self.stream)
             end_offset = struct_parse(
@@ -56,10 +74,11 @@ class RangeLists(object):
                 break
             elif begin_offset == self._max_addr:
                 # Base address selection entry
-                lst.append(BaseAddressEntry(base_address=end_offset))
+                lst.append(BaseAddressEntry(entry_offset=entry_offset, base_address=end_offset))
             else:
                 # Range entry
                 lst.append(RangeEntry(
+                    entry_offset=entry_offset,
                     begin_offset=begin_offset,
                     end_offset=end_offset))
         return lst

--- a/examples/reference_output/dwarf_range_lists.out
+++ b/examples/reference_output/dwarf_range_lists.out
@@ -4,4 +4,4 @@ Processing file: ./examples/sample_exe64.elf
   Found a compile unit at offset 258, length 156
   Found a compile unit at offset 418, length 300
    DIE DW_TAG_lexical_block. attr DW_AT_ranges.
-[RangeEntry(entry_offset=0, begin_offset=26, end_offset=40), RangeEntry(entry_offset=16, begin_offset=85, end_offset=118), RangeEntry(entry_offset=32, begin_offset=73, end_offset=77), RangeEntry(entry_offset=48, begin_offset=64, end_offset=67)]
+[RangeEntry(entry_offset=0, entry_length=16, begin_offset=26, end_offset=40, is_absolute=False), RangeEntry(entry_offset=16, entry_length=16, begin_offset=85, end_offset=118, is_absolute=False), RangeEntry(entry_offset=32, entry_length=16, begin_offset=73, end_offset=77, is_absolute=False), RangeEntry(entry_offset=48, entry_length=16, begin_offset=64, end_offset=67, is_absolute=False)]

--- a/examples/reference_output/dwarf_range_lists.out
+++ b/examples/reference_output/dwarf_range_lists.out
@@ -4,4 +4,4 @@ Processing file: ./examples/sample_exe64.elf
   Found a compile unit at offset 258, length 156
   Found a compile unit at offset 418, length 300
    DIE DW_TAG_lexical_block. attr DW_AT_ranges.
-[RangeEntry(begin_offset=26, end_offset=40), RangeEntry(begin_offset=85, end_offset=118), RangeEntry(begin_offset=73, end_offset=77), RangeEntry(begin_offset=64, end_offset=67)]
+[RangeEntry(entry_offset=0, begin_offset=26, end_offset=40), RangeEntry(entry_offset=16, begin_offset=85, end_offset=118), RangeEntry(entry_offset=32, begin_offset=73, end_offset=77), RangeEntry(entry_offset=48, begin_offset=64, end_offset=67)]

--- a/scripts/readelf.py
+++ b/scripts/readelf.py
@@ -63,10 +63,21 @@ from elftools.dwarf.descriptions import (
 from elftools.dwarf.constants import (
     DW_LNS_copy, DW_LNS_set_file, DW_LNE_define_file)
 from elftools.dwarf.locationlists import LocationParser, LocationEntry, LocationViewPair, BaseAddressEntry
+from elftools.dwarf.ranges import RangeEntry # ranges.BaseAddressEntry collides with the one above
+import elftools.dwarf.ranges
 from elftools.dwarf.callframe import CIE, FDE, ZERO
 from elftools.ehabi.ehabiinfo import CorruptEHABIEntry, CannotUnwindEHABIEntry, GenericEHABIEntry
 from elftools.dwarf.enums import ENUM_DW_UT
 
+def _get_cu_base(cu):
+    top_die = cu.get_top_DIE()
+    attr = top_die.attributes
+    if 'DW_AT_low_pc' in attr:
+        return attr['DW_AT_low_pc'].value
+    elif 'DW_AT_entry_pc' in attr:
+        return attr['DW_AT_entry_pc'].value
+    else:
+        raise ValueError("Can't find the base IP (low_pc) for a CU")
 
 class ReadElf(object):
     """ display_* methods are used to emit output into the output stream
@@ -859,6 +870,8 @@ class ReadElf(object):
             self._dump_debug_namelut(dump_what)
         elif dump_what == 'loc':
             self._dump_debug_locations()
+        elif dump_what == 'Ranges':
+            self._dump_debug_ranges()
         else:
             self._emitline('debug dump not yet supported for "%s"' % dump_what)
 
@@ -1429,16 +1442,6 @@ class ReadElf(object):
     def _dump_debug_locations(self):
         """ Dump the location lists from .debug_loc/.debug_loclists section
         """
-        def _get_cu_base(cu):
-            top_die = cu.get_top_DIE()
-            attr = top_die.attributes
-            if 'DW_AT_low_pc' in attr:
-                return attr['DW_AT_low_pc'].value
-            elif 'DW_AT_entry_pc' in attr:
-                return attr['DW_AT_entry_pc'].value
-            else:
-                raise ValueError("Can't find the base IP (low_pc) for a CU")
-
         di = self._dwarfinfo
         loc_lists = di.location_lists()
         if not loc_lists: # No locations section - readelf outputs nothing
@@ -1529,6 +1532,55 @@ class ReadElf(object):
             # but readelf emits its offset, so this should too.
             last = loc_list[-1]
             self._emitline("    %08x <End of list>" % (last.entry_offset + last.entry_length))
+
+    def _dump_debug_ranges(self):
+        # TODO: GNU readelf format doesn't need entry_length?
+        di = self._dwarfinfo
+        range_lists = di.range_lists()
+        if not range_lists: # No ranges section - readelf outputs nothing
+            return
+
+        range_lists = list(range_lists.iter_range_lists())
+        if len(range_lists) == 0:
+            # Present but empty locations section - readelf outputs a message
+            self._emitline("\nSection '%s' has no debugging data." % (di.debug_rnglists_sec or di.debug_ranges_sec).name)
+            return
+
+        # In order to determine the base address of the range
+        # We need to know the corresponding CU.
+        cu_map = {die.attributes['DW_AT_ranges'].value : cu  # Range list offset => CU
+            for cu in di.iter_CUs()
+            for die in cu.iter_DIEs()
+            if 'DW_AT_ranges' in die.attributes}
+
+        addr_size = di.config.default_address_size # In bytes, 4 or 8
+        addr_width = addr_size * 2 # In hex digits, 8 or 16
+        line_template = "    %%08x %%0%dx %%0%dx %%s" % (addr_width, addr_width)
+        base_template = "    %%08x %%0%dx (base address)" % (addr_width)
+
+        self._emitline('Contents of the %s section:\n' % (di.debug_rnglists_sec or di.debug_ranges_sec).name)
+        self._emitline('    Offset   Begin    End')
+        
+        for range_list in range_lists:
+            first = range_list[0]
+            base_ip = _get_cu_base(cu_map[first.entry_offset])
+            for entry in range_list:
+                if isinstance(entry, RangeEntry):
+                    postfix = ' (start == end)' if entry.begin_offset == entry.end_offset else ''
+                    self._emitline(line_template % (
+                        first.entry_offset,
+                        base_ip + entry.begin_offset,
+                        base_ip + entry.end_offset,
+                        postfix))
+                elif isinstance(entry, elftools.dwarf.ranges.BaseAddressEntry):
+                    base_ip = entry.base_address
+                    self._emitline(base_template % (
+                        first.entry_offset,
+                        entry.base_address))
+                else:
+                    raise NotImplementedError("Unknown object in a range list")
+            last = range_list[-1]
+            self._emitline('    %08x <End of list>' % (first.entry_offset))            
 
     def _display_arch_specific_arm(self):
         """ Display the ARM architecture-specific info contained in the file.

--- a/scripts/readelf.py
+++ b/scripts/readelf.py
@@ -1537,10 +1537,10 @@ class ReadElf(object):
         # TODO: GNU readelf format doesn't need entry_length?
         di = self._dwarfinfo
         range_lists = di.range_lists()
-        ver5 = range_lists.version >= 5
         if not range_lists: # No ranges section - readelf outputs nothing
             return
 
+        ver5 = range_lists.version >= 5
         range_lists = list(range_lists.iter_range_lists())
         if len(range_lists) == 0:
             # Present but empty locations section - readelf outputs a message
@@ -1675,7 +1675,7 @@ def main(stream=None):
             action='store', dest='debug_dump_what', metavar='<what>',
             help=(
                 'Display the contents of DWARF debug sections. <what> can ' +
-                'one of {info,decodedline,frames,frames-interp,aranges,pubtypes,pubnames,loc}'))
+                'one of {info,decodedline,frames,frames-interp,aranges,pubtypes,pubnames,loc,Ranges}'))
     argparser.add_argument('--traceback',
                            action='store_true', dest='show_traceback',
                            help='Dump the Python traceback on ELFError'

--- a/test/run_readelf_tests.py
+++ b/test/run_readelf_tests.py
@@ -67,7 +67,7 @@ def run_test_on_file(filename, verbose=False, opt=None):
             '--debug-dump=frames', '--debug-dump=frames-interp',
             '--debug-dump=aranges', '--debug-dump=pubtypes',
             '--debug-dump=pubnames', '--debug-dump=loc',
-            '--debug_dump=Ranges'
+            '--debug-dump=Ranges'
             ]
     else:
         options = [opt]

--- a/test/run_readelf_tests.py
+++ b/test/run_readelf_tests.py
@@ -66,7 +66,8 @@ def run_test_on_file(filename, verbose=False, opt=None):
             '--debug-dump=info', '--debug-dump=decodedline',
             '--debug-dump=frames', '--debug-dump=frames-interp',
             '--debug-dump=aranges', '--debug-dump=pubtypes',
-            '--debug-dump=pubnames', '--debug-dump=loc'
+            '--debug-dump=pubnames', '--debug-dump=loc',
+            '--debug_dump=Ranges'
             ]
     else:
         options = [opt]


### PR DESCRIPTION
The changes to the ranges section format are close in spirit to those that they did to loclists (see #418) , but not as drastic. There are no CU headers.

Instead of fixed format records with magic values, range list entries are now stored as prefixed with type (`DW_RLE`), with several possible encodings for each kind, so storing both entry address and entry length became necessary for readelf dumping.

I saw range lists overlapping - one `DW_AT_ranges` pointing in the middle of a range list that was referenced in some other `DW_AT_ranges`. GNU readelf handles that gracefully, so we had to. The preexisting logic of RangeLists.iter_range_lists() didn't accommodate for that, so I changed it to scan all DIEs for `DW_AT_ranges` values and scrolling through those.

The indirect encodings are not supported, just like with loclists. **I could try and debug that on my clang-11 binary, but no autotest until we upgrade readelf. Should I?**

FYI, the tag 2.38 is present in the binutils' sources...