### PR TITLE
docs: Fix a few typos

### DIFF
--- a/elftools/common/py3compat.py
+++ b/elftools/common/py3compat.py
@@ -18,7 +18,7 @@ if PY3:
 
     # Functions for acting on bytestrings and strings. In Python 2 and 3,
     # strings and bytes are the same and chr/ord can be used to convert between
-    # numeric byte values and their string pepresentations. In Python 3, bytes
+    # numeric byte values and their string representations. In Python 3, bytes
     # and strings are different types and bytes hold numeric values when
     # iterated over.
 

--- a/elftools/dwarf/die.py
+++ b/elftools/dwarf/die.py
@@ -64,7 +64,7 @@ class DIE(object):
 
             abbrev_code:
                 The abbreviation code pointing to an abbreviation entry (note
-                that this is for informational pusposes only - this object
+                that this is for informational purposes only - this object
                 interacts with its abbreviation table transparently).
 
         See also the public methods.


### PR DESCRIPTION
There are small typos in:
- elftools/common/py3compat.py
- elftools/dwarf/die.py

Fixes:
- Should read `representations` rather than `pepresentations`.
- Should read `purposes` rather than `pusposes`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md