### PR TITLE
Fix for CU version check in LocationListsPair

### DIFF
--- a/elftools/dwarf/locationlists.py
+++ b/elftools/dwarf/locationlists.py
@@ -46,7 +46,7 @@ class LocationListsPair(object):
         """
         if die is None:
             raise DWARFError("For this binary, \"die\" needs to be provided")
-        section = self._loclists if die.cu.version >= 5 else self._loc
+        section = self._loclists if die.cu.header.version >= 5 else self._loc
         return section.get_location_list_at_offset(offset, die)
 
     def iter_location_lists(self):


### PR DESCRIPTION
Minor fix, no test. For an identical check that *is* on the tests, see ranges.py:51.