### PR TITLE
Add pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools >= 46.4.0", "wheel"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
This adds a pyproject.toml for compatibility with PEP 517/518-based build systems. With this, modern pip and other tools can build a wheel without relying on fallback setuptools compatibility.