### PR TITLE
add support for aarch64 to dwarfdump

### DIFF
--- a/scripts/dwarfdump.py
+++ b/scripts/dwarfdump.py
@@ -342,7 +342,7 @@ class ReadElf(object):
         self.elffile = ELFFile(file)
         self.output = output
         self._dwarfinfo = self.elffile.get_dwarf_info()
-        arches = {"EM_386": "i386", "EM_X86_64": "x86-64"}
+        arches = {"EM_386": "i386", "EM_X86_64": "x86-64", "EM_AARCH64": "littleaarch64"}
         arch = arches[self.elffile['e_machine']]
         bits = self.elffile.elfclass
         self._emitline("%s:	file format elf%d-%s" % (filename, bits, arch))


### PR DESCRIPTION
llvm-dwarfdump prints
elf64-littleaarch64

We probably need more logic to differentiate between big endian (less common) vs little endian (more common), but at least this allows us to use ./scripts/dwarfdump on aarch64 targets now.

I probably should have added this to #318 / #317.