### PR TITLE
More register names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ dist
 MANIFEST
 *.sublime-workspace
 *.egg-info
+.vscode
 
 
 

--- a/elftools/dwarf/descriptions.py
+++ b/elftools/dwarf/descriptions.py
@@ -604,6 +604,29 @@ _REG_NAMES_MIPS = [
         '$fp%d' % n for n in range(35)] + ['<none>'] + [
         '$cp%d' % n for n in range(15)] + ['$prid']
 
+# Source: https://github.com/riscv-non-isa/riscv-elf-psabi-doc/blob/master/riscv-dwarf.adoc
+_REG_NAMES_RISCV = [
+    'zero', 'ra', 'sp', 'gp', 'tp', 't0', 't1', 't2',
+    'fp', 's1', 'a0', 'a1', 'a2', 'a3', 'a4', 'a5',
+    'a6', 'a7', 's2', 's3', 's4', 's5', 's6', 's7',
+    't8', 't9', 's10', 's11', 't3', 't4', 't5', 't6'] + [
+        'f%d' % n for n in range(32)] + ['afrc'] + ['<none>']*31 + [
+        'v%d' % n for n in range(32)]
+
+# Source for 64 bit: https://refspecs.linuxfoundation.org/ELF/ppc64/PPC-elf64abi.html
+# Source for 32 bit: http://refspecs.linux-foundation.org/elf/elfspec_ppc.pdf
+# They are sufficiently similar
+# There are some more kernel level registers defined in the ABI at #356 and further, not listed here
+_REG_NAMES_POWERPC = ['r%d' % n for n in range(32)] + [
+      'f%d' % n for n in range(32)] +[
+    'cr', 'fpscr', 'msr', '<none>', '<none>', '<none>',
+    'sr0', 'sr1', 'sr2', 'sr3', 'sr4', 'sr5', 'sr6', 'sr7',
+    'sr8', 'sr9', 'sr10', 'sr11', 'sr12', 'sr13', 'sr14', 'sr15'] + ['<none>']*14 + [
+    'mq', 'xer', '<none>', '<none>', 'rtcu', 'rtcl', '<none>', '<none>',
+    'lr', 'ctr', '<none>', '<none>', '<none>', '<none>', '<none>', '<none>',
+    '<none>', '<none>', 'dsisr', 'dar', '<none>', '<none>', 'dec', '<none>',
+    '<none>', 'sdr1', 'srr0', 'srr1']
+
 
 class ExprDumper(object):
     """ A dumper for DWARF expressions that dumps a textual

--- a/elftools/dwarf/descriptions.py
+++ b/elftools/dwarf/descriptions.py
@@ -160,8 +160,7 @@ def describe_reg_name(regnum, machine_arch=None, default=True):
         return _REG_NAMES_x64[regnum]
     elif machine_arch == 'AArch64':
         return _REG_NAMES_AArch64[regnum]
-    elif machine_arch == 'ARM' and not regnum in (13, 14, 15): # Readelf emits unfriendly names for r13..15
-        return _REG_NAMES_ARM[regnum]
+    # elif machine_arch == 'ARM': readelf treats them as if no friendly names exist
     elif default:
         return 'r%s' % regnum
     else:

--- a/elftools/dwarf/descriptions.py
+++ b/elftools/dwarf/descriptions.py
@@ -160,7 +160,7 @@ def describe_reg_name(regnum, machine_arch=None, default=True):
         return _REG_NAMES_x64[regnum]
     elif machine_arch == 'AArch64':
         return _REG_NAMES_AArch64[regnum]
-    elif machine_arch == 'ARM':
+    elif machine_arch == 'ARM' and not regnum in (13, 14, 15): # Readelf emits unfriendly names for r13..15
         return _REG_NAMES_ARM[regnum]
     elif default:
         return 'r%s' % regnum

--- a/elftools/dwarf/descriptions.py
+++ b/elftools/dwarf/descriptions.py
@@ -160,6 +160,8 @@ def describe_reg_name(regnum, machine_arch=None, default=True):
         return _REG_NAMES_x64[regnum]
     elif machine_arch == 'AArch64':
         return _REG_NAMES_AArch64[regnum]
+    elif machine_arch == 'ARM':
+        return _REG_NAMES_ARM[regnum]
     elif default:
         return 'r%s' % regnum
     else:
@@ -572,6 +574,25 @@ _REG_NAMES_AArch64 = [
     'z8', 'z9', 'z10', 'z11', 'z12', 'z13', 'z14', 'z15',
     'z16', 'z17', 'z18', 'z19', 'z20', 'z21', 'z22', 'z23',
     'z24', 'z25', 'z26', 'z27', 'z28', 'z29', 'z30', 'z31'
+]
+
+# Source: https://github.com/ARM-software/abi-aa/blob/main/aadwarf32/aadwarf32.rst#dwarf-register-names
+_REG_NAMES_ARM = [
+    'r0', 'r1', 'r2', 'r3', 'r4', 'r5', 'r6', 'r7',
+    'r8', 'r9', 'r10', 'r11', 'r12', 'sp', 'lr', 'pc'
+] + ['<none>']*48 + ["s%d" %(n,) for n in range(32)] + [
+    'f0', 'f1', 'f2', 'f3', 'f4', 'f5', 'f6', 'f7',
+    'acc0', 'acc1', 'acc2', 'acc3', 'acc4', 'acc5', 'acc6', 'acc7', #AKA wcgr0..7
+    'wr0', 'wr1', 'wr2', 'wr3', 'wr4', 'wr5', 'wr6', 'wr7',
+    'wr8', 'wr9', 'wr10', 'wr11', 'wr12', 'wr13', 'wr14', 'wr15',
+    'spsr', 'spsr_fiq', 'spsr_irq', 'spsr_abt', 'spsr_und', 'spsr_svc'] + ['<none>']*9 + [
+    'ra_auth_code', 'r8_usr', 'r9_usr', 'r10_usr', 'r11_usr', 'r12_usr', 'r13_usr', 'r14_usr',
+    'r8_fiq', 'r9_fiq', 'r10_fiq', 'r11_fiq', 'r12_fiq', 'r13_fiq', 'r14_fiq',
+    'r13_irq', 'r14_irq', 'r13_abt', 'r14_abt',
+    'r13_und', 'r14_und', 'r13_svc', 'r14_svc'] + ['<none>']*26 + [
+    'wc0', 'wc1', 'wc2', 'wc3', 'wc4', 'wc5', 'wc6', 'wc7'] + ['<none>']*56 + [
+        "d%d" %(n,) for n in range(32)] + ['<none>']*32 + [
+     'tpidruro', 'tpidrurw', 'tpidpr', 'htpidpr'
 ]
 
 

--- a/elftools/dwarf/descriptions.py
+++ b/elftools/dwarf/descriptions.py
@@ -594,6 +594,16 @@ _REG_NAMES_ARM = [
      'tpidruro', 'tpidrurw', 'tpidpr', 'htpidpr'
 ]
 
+# From mips-tdep.h in the GDB sources
+_REG_NAMES_MIPS = [
+    '$zero', '$at', '$v0', '$v1', '$a0', '$a1', '$a2', '$a3',
+    '$t0', '$t1', '$t2', '$t3', '$t4', '$t5', '$t6', '$t7',
+    '$s0', '$s1', '$s2', '$s3', '$s4', '$s5', '$s6', '$s7',
+    '$t8', '$t9', '$k0', '$k1', '$gp', '$sp', '$fp', '$ra',
+    '$ps', '$lo', '$hi', '$badvaddr', '$cause', '$pc'] + [
+        '$fp%d' % n for n in range(35)] + ['<none>'] + [
+        '$cp%d' % n for n in range(15)] + ['$prid']
+
 
 class ExprDumper(object):
     """ A dumper for DWARF expressions that dumps a textual


### PR DESCRIPTION
For now just the 32-bit ARM and MIPS (the latter might be incomplete). The ARM mapping is hairy, with several reserved gaps and numerous kernel-level registers, but the potentially relevant Neon (SIMD) registers D0..D31 are towards the end of the list - to include those, it made no sense to not include the middle of the list also.

Any other architectures we might want to get in there? PowerPC, RISC-V, LoongArch maybe? Android is, supposedly, coming to RISC-V.