### PR TITLE
fix examples/dwarf_location_info.py

### DIFF
--- a/examples/dwarf_location_info.py
+++ b/examples/dwarf_location_info.py
@@ -76,7 +76,7 @@ def process_file(filename):
                     if loc_parser.attribute_has_location(attr, CU['version']):
                         print('   DIE %s. attr %s.' % (DIE.tag, attr.name))
                         loc = loc_parser.parse_from_attribute(attr,
-                                                              CU['version'])
+                                                              CU['version'], DIE)
                         # We either get a list (in case the attribute is a
                         # reference to the .debug_loc section) or a LocationExpr
                         # object (in case the attribute itself contains location


### PR DESCRIPTION
Pass along the DIE otherwise the following error is observed:

    Traceback (most recent call last):
      File "/tmp/pyelftools/examples/dwarf_location_info.py", line 110, in <module>
        process_file(filename)
      File "/tmp/pyelftools/examples/dwarf_location_info.py", line 78, in process_file
        loc = loc_parser.parse_from_attribute(attr,
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/tmp/pyelftools/elftools/dwarf/locationlists.py", line 307, in parse_from_attribute
        return self.location_lists.get_location_list_at_offset(
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/tmp/pyelftools/elftools/dwarf/locationlists.py", line 96, in get_location_list_at_offset
        return self._parse_location_list_from_stream_v5(die.cu) if self.version >= 5 else self._parse_location_list_from_stream()
                                                        ^^^^^^
    AttributeError: 'NoneType' object has no attribute 'cu'