### PR TITLE
False positive on LocationParser.attribute_has_location()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ MANIFEST
 *.sublime-workspace
 *.egg-info
 .vscode
+temp
 
 
 

--- a/elftools/dwarf/locationlists.py
+++ b/elftools/dwarf/locationlists.py
@@ -331,6 +331,8 @@ class LocationParser(object):
                 attr.form in ('DW_FORM_sec_offset', 'DW_FORM_loclistx')) and
                 not LocationParser._attribute_is_member_offset(attr, dwarf_version))
     
+    # Starting with DWARF3, DW_AT_data_member_location may contain an integer offset
+    # instead of a location expression. Need to prevent false positives on attribute_has_location().
     @staticmethod
     def _attribute_is_member_offset(attr, dwarf_version):
         return (dwarf_version >= 3 and

--- a/elftools/dwarf/locationlists.py
+++ b/elftools/dwarf/locationlists.py
@@ -350,4 +350,8 @@ class LocationParser(object):
                                'DW_AT_call_value',
                                'DW_AT_GNU_call_site_value',
                                'DW_AT_GNU_call_site_target',
-                               'DW_AT_GNU_call_site_data_value'))
+                               'DW_AT_GNU_call_site_data_value',
+                               'DW_AT_call_target',
+                               'DW_AT_call_target_clobbered',
+                               'DW_AT_call_data_location',
+                               'DW_AT_call_data_value'))

--- a/elftools/dwarf/locationlists.py
+++ b/elftools/dwarf/locationlists.py
@@ -325,10 +325,17 @@ class LocationParser(object):
 
     @staticmethod
     def _attribute_has_loc_list(attr, dwarf_version):
-        return ((dwarf_version < 4 and
+        return (((dwarf_version < 4 and
                  attr.form in ('DW_FORM_data1', 'DW_FORM_data2', 'DW_FORM_data4', 'DW_FORM_data8') and
                  not attr.name == 'DW_AT_const_value') or
-                attr.form in ('DW_FORM_sec_offset', 'DW_FORM_loclistx'))
+                attr.form in ('DW_FORM_sec_offset', 'DW_FORM_loclistx')) and
+                not LocationParser._attribute_is_member_offset(attr, dwarf_version))
+    
+    @staticmethod
+    def _attribute_is_member_offset(attr, dwarf_version):
+        return (dwarf_version >= 3 and
+            attr.name == 'DW_AT_data_member_location' and
+            attr.form in ('DW_FORM_data1', 'DW_FORM_data2', 'DW_FORM_data4', 'DW_FORM_data8', 'DW_FORM_sdata', 'DW_FORM_udata'))
 
     @staticmethod
     def _attribute_is_loclistptr_class(attr):

--- a/test/test_dwarf_locationattr.py
+++ b/test/test_dwarf_locationattr.py
@@ -11,8 +11,27 @@ from elftools.dwarf.die import AttributeValue
 
 class TestLocationAttrubute(unittest.TestCase):
     def test_has_location(self):
+        # This attribute comes from a DWARFv3 binary that doesn't have a location lists
+        # section. Before the patch, pyelftools would interpret it as an attribute with a
+        # location, more specifically with a location list offset (as opposed to an expression).
+        # Meanwhile, by the spec, DW_AT_data_member_location is not even capable
+        # of storing a location list offset (since structure layout
+        # can't vary by code location). DWARFv3 spec also provides that DW_AT_data_member_location
+        # may be a small integer with an offset from the structure's base address, and that
+        # seems to be the case here. Ergo, pyelftools should not claim this attribute a location.
+        # Since the location/loclist parse function uses the same check, ths fix will 
+        # prevent such attribute values from being misparsed, also.
+        #
+        # The notion that member location in a structure had to be a DWARF expression
+        # was a misnomer all along - how often does one see a compound datatype
+        # with a static member set but a dynamic layout?
         attr = AttributeValue(name='DW_AT_data_member_location', form='DW_FORM_data1', value=0, raw_value=0, offset=402, indirection_length=0)
         self.assertFalse(LocationParser.attribute_has_location(attr, 3))
+
+        # This attribute comes from a DWARFv5 binary. Its form unambiguously tells us it's a
+        # location expression. Before the patch, pyelftools would not recognize it as one,
+        # because it has a hard-coded list of attributes that may contain a location, and
+        # DW_AT_call_target was not in that list.
         attr = AttributeValue(name='DW_AT_call_target', form='DW_FORM_exprloc', value=[80], raw_value=[80], offset=8509, indirection_length=0)
         self.assertTrue(LocationParser.attribute_has_location(attr, 5))
 

--- a/test/test_dwarf_locationattr.py
+++ b/test/test_dwarf_locationattr.py
@@ -1,0 +1,19 @@
+#-------------------------------------------------------------------------------
+# elftools tests
+#
+# Eli Bendersky (eliben@gmail.com)
+# This code is in the public domain
+#-------------------------------------------------------------------------------
+import unittest
+
+from elftools.dwarf.locationlists import LocationParser
+from elftools.dwarf.die import AttributeValue
+
+class TestLocationAttrubute(unittest.TestCase):
+    def test_has_location(self):
+        attr = AttributeValue(name='DW_AT_data_member_location', form='DW_FORM_data1', value=0, raw_value=0, offset=402, indirection_length=0)
+        self.assertFalse(LocationParser.attribute_has_location(attr, 3))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_dwarf_locationattr.py
+++ b/test/test_dwarf_locationattr.py
@@ -13,6 +13,8 @@ class TestLocationAttrubute(unittest.TestCase):
     def test_has_location(self):
         attr = AttributeValue(name='DW_AT_data_member_location', form='DW_FORM_data1', value=0, raw_value=0, offset=402, indirection_length=0)
         self.assertFalse(LocationParser.attribute_has_location(attr, 3))
+        attr = AttributeValue(name='DW_AT_call_target', form='DW_FORM_exprloc', value=[80], raw_value=[80], offset=8509, indirection_length=0)
+        self.assertTrue(LocationParser.attribute_has_location(attr, 5))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The description of `DW_AT_member_location` changed between DWARFv2 and DWARFv3:

v2, section 5.5.4:

> If the member entry is defined in the structure or class body, it has a
DW_AT_data_member_location attribute whose value is a location description

v3, section 5.5.6:

 >If a data member is defined in a structure, union or class, the corresponding member entry has a DW_AT_data_member_location attribute whose value describes the location of that member relative to the base address of the structure, union, or class that most closely encloses the member declaration. **If that value is a constant, it is the offset in bytes from the beginning of the innermost enclosing structure, union or class to the beginning of the data member.** Otherwise, the value must be a location description.

The case of DW_AT_data_member_location containing an integer constant is not handled by pyelftools - the method `LocationParser.attribute_has_location()` returns True, and it shouldn't.

---
I have a crash report where an attribute with the following data:

`AttributeValue(name='DW_AT_data_member_location', form='DW_FORM_data1', value=0, raw_value=0, offset=402, indirection_length=0)`

is being interpreted as a location list pointer (`LocationParser.parse_from_attribute()` tries to parse it), which in turn exceptions, because the binary doesn't contain a loclist section (`self.location_lists` is None).