### PR TITLE
DW_OP_GNU_uninit

### DIFF
--- a/elftools/dwarf/dwarf_expr.py
+++ b/elftools/dwarf/dwarf_expr.py
@@ -86,6 +86,7 @@ DW_OP_name2opcode = dict(
     DW_OP_lo_user=0xe0,
     DW_OP_GNU_push_tls_address=0xe0,
     DW_OP_WASM_location=0xed,
+    DW_OP_GNU_uninit=0xf0,
     DW_OP_GNU_implicit_pointer=0xf2,
     DW_OP_GNU_entry_value=0xf3,
     DW_OP_GNU_const_type=0xf4,
@@ -238,7 +239,7 @@ def _init_dispatch_table(structs):
                     'DW_OP_gt', 'DW_OP_le', 'DW_OP_lt', 'DW_OP_ne', 'DW_OP_nop',
                     'DW_OP_push_object_address', 'DW_OP_form_tls_address',
                     'DW_OP_call_frame_cfa', 'DW_OP_stack_value',
-                    'DW_OP_GNU_push_tls_address']:
+                    'DW_OP_GNU_push_tls_address', 'DW_OP_GNU_uninit']:
         add(opname, parse_noargs())
 
     for n in range(0, 32):

--- a/test/test_dwarf_expr.py
+++ b/test/test_dwarf_expr.py
@@ -107,7 +107,14 @@ class TestParseExpr(unittest.TestCase):
             DWARFExprOp(op=0x34, op_name='DW_OP_lit4', args=[], offset=10),
             DWARFExprOp(op=0x1c, op_name='DW_OP_minus', args=[], offset=11),
             DWARFExprOp(op=0x6,  op_name='DW_OP_deref', args=[], offset=12)])
-
+        
+        # This expression blob came from the test binary in issue 508,
+        # DT_TAG_variable at 0x2a48C, DW_AT_location
+        lst = p.parse_expr([0x5f, 0xf0])
+        self.assertEqual(len(lst), 2)
+        self.assertEqual(lst, [
+            DWARFExprOp(op=0x5f, op_name='DW_OP_reg15', args=[], offset=0),
+            DWARFExprOp(op=0xf0,  op_name='DW_OP_GNU_uninit', args=[], offset=1)])
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Addresses #508. No args on that opcode. Independent confirmation here: https://sourceware.org/elfutils/DwarfExtensions

Do we want to put the attached binary into autotests? It's big.

EDIT: did a unit test with the expression blob as it appears in the binary. Could have done a unittest with that binary per se, but don't see the point.