### PR TITLE
elftools: StringTableSection: Check table size before returning string

### DIFF
--- a/elftools/elf/sections.py
+++ b/elftools/elf/sections.py
@@ -140,7 +140,19 @@ class StringTableSection(Section):
         """ Get the string stored at the given offset in this string table.
         """
         table_offset = self['sh_offset']
+        table_size = self['sh_size']
+        if table_size == 0:
+            return ''
+
+        elf_assert(offset < table_size,
+                   'Expected string offset %x < table size %x' %
+                   (offset, table_size))
+
         s = parse_cstring_from_stream(self.stream, table_offset + offset)
+
+        elf_assert((offset + len(s)) < table_size,
+                   'Expected string offset + length %x < table size %x' %
+                   (offset + len(s), table_size))
         return s.decode('utf-8', errors='replace') if s else ''
 
 


### PR DESCRIPTION
Some ELF files have strings pointing to an offset outside the string table dimension, let's throw an exception in that case.

Bug-Url: https://crbug.com/788925
Reviewed-on: https://chromium-review.googlesource.com/792553