### PR TITLE
DW_FORM_implicit_const is an integer const

### DIFF
--- a/elftools/dwarf/descriptions.py
+++ b/elftools/dwarf/descriptions.py
@@ -462,7 +462,7 @@ def _data_member_location_extra(attr, die, section_offset):
     #
     if attr.form in ('DW_FORM_data1', 'DW_FORM_data2',
                      'DW_FORM_data4', 'DW_FORM_data8',
-                     'DW_FORM_sdata'):
+                     'DW_FORM_sdata', 'DW_FORM_implicit_const'):
         return ''  # No extra description needed
     else:
         return describe_DWARF_expr(attr.value, die.cu.structs, die.cu.cu_offset)


### PR DESCRIPTION
This came up while investigating #545. `data_member_location` can be either an expression or a constant. readelf.py needs to distinguish the two in order to dump correctly.