### PR TITLE
cfi: fix not parsing DW_CFA_def_cfa_offset_sf

### DIFF
--- a/elftools/dwarf/callframe.py
+++ b/elftools/dwarf/callframe.py
@@ -568,6 +568,10 @@ class CFIEntry(object):
                 cur_line['cfa'] = CFARule(
                     reg=cur_line['cfa'].reg,
                     offset=instr.args[0])
+            elif name == 'DW_CFA_def_cfa_offset_sf':
+                cur_line['cfa'] = CFARule(
+                    reg=cur_line['cfa'].reg,
+                    offset=instr.args[0] * cie['data_alignment_factor'])
             elif name == 'DW_CFA_def_cfa_expression':
                 cur_line['cfa'] = CFARule(expr=instr.args[0])
             elif name == 'DW_CFA_undefined':


### PR DESCRIPTION
CFI read is not working on golang, missing DW_CFA_def_cfa_offset_sf resolution.

https://github.com/eliben/pyelftools/issues/554