### PR TITLE
Fix crash in readelf.py if a symbol doesn't define st_shndx

### DIFF
--- a/scripts/readelf.py
+++ b/scripts/readelf.py
@@ -487,7 +487,7 @@ class ReadElf(object):
                 symbol_name = symbol.name
                 # Print section names for STT_SECTION symbols as readelf does
                 if (symbol['st_info']['type'] == 'STT_SECTION'
-                    and symbol['st_shndx'] < self.elffile.num_sections()
+                    and (type(symbol['st_shndx']) == int and symbol['st_shndx'] < self.elffile.num_sections())
                     and symbol['st_name'] == 0):
                     symbol_name = self.elffile.get_section(symbol['st_shndx']).name
 


### PR DESCRIPTION
symbol['st_shndx'] can take a value of 'SHN_UNDEF' -- causing a crash in readelf.py when dumping the symbol table since that non-numeric value can't be compared to self.elffile.num_sections().

Add a check before assuming st_shndx is numeric.