### PR TITLE
Section type check on dynamic to strtab link

### DIFF
--- a/elftools/elf/dynamic.py
+++ b/elftools/elf/dynamic.py
@@ -234,7 +234,7 @@ class DynamicSection(Section, Dynamic):
     """
     def __init__(self, header, name, elffile):
         Section.__init__(self, header, name, elffile)
-        stringtable = elffile.get_section(header['sh_link'])
+        stringtable = elffile.get_section(header['sh_link'], 'SHT_STRTAB')
         Dynamic.__init__(self, self.stream, self.elffile, stringtable,
             self['sh_offset'], self['sh_type'] == 'SHT_NOBITS')
 

--- a/elftools/elf/dynamic.py
+++ b/elftools/elf/dynamic.py
@@ -234,7 +234,7 @@ class DynamicSection(Section, Dynamic):
     """
     def __init__(self, header, name, elffile):
         Section.__init__(self, header, name, elffile)
-        stringtable = elffile.get_section(header['sh_link'], 'SHT_STRTAB')
+        stringtable = elffile.get_section(header['sh_link'], ('SHT_STRTAB', 'SHT_NOBITS'))
         Dynamic.__init__(self, self.stream, self.elffile, stringtable,
             self['sh_offset'], self['sh_type'] == 'SHT_NOBITS')
 

--- a/elftools/elf/elffile.py
+++ b/elftools/elf/elffile.py
@@ -138,7 +138,7 @@ class ELFFile(object):
             subclass)
         """
         section_header = self._get_section_header(n)
-        if type and section_header.sh_type != type:
+        if type and section_header.sh_type not in type:
             raise ELFError("Unexpected section type %s, expected %s" % (section_header['sh_type'], type))
         return self._make_section(section_header)
     

--- a/elftools/elf/elffile.py
+++ b/elftools/elf/elffile.py
@@ -133,11 +133,13 @@ class ELFFile(object):
             return self._get_section_header(0)['sh_size']
         return self['e_shnum']
 
-    def get_section(self, n):
+    def get_section(self, n, type=None):
         """ Get the section at index #n from the file (Section object or a
             subclass)
         """
         section_header = self._get_section_header(n)
+        if type and section_header.sh_type != type:
+            raise ELFError("Unexpected section type %s, expected %s" % (section_header['sh_type'], type))
         return self._make_section(section_header)
     
     def _get_linked_symtab_section(self, n):


### PR DESCRIPTION
Addresses #60.
Throws `ELFError` instead of stack overflow.