### PR TITLE
Check for SHN_UNDEF during symbol dumping

### DIFF
--- a/scripts/readelf.py
+++ b/scripts/readelf.py
@@ -487,6 +487,7 @@ class ReadElf(object):
                 symbol_name = symbol.name
                 # Print section names for STT_SECTION symbols as readelf does
                 if (symbol['st_info']['type'] == 'STT_SECTION'
+                    and symbol['st_shndx'] != 'SHN_UNDEF'
                     and symbol['st_shndx'] < self.elffile.num_sections()
                     and symbol['st_name'] == 0):
                     symbol_name = self.elffile.get_section(symbol['st_shndx']).name


### PR DESCRIPTION
Supersedes #566

Now, I don't know what was the original motivation for that one, but this fix should be equivalent.