### PR TITLE
Debug raising error when running as packaged app by pyinstaller

### DIFF
--- a/elftools/elf/elffile.py
+++ b/elftools/elf/elffile.py
@@ -12,10 +12,16 @@ import os
 import struct
 import zlib
 
+PAGESIZE = None
 try:
     import resource
     PAGESIZE = resource.getpagesize()
 except ImportError:
+    pass
+except AttributeError:  # may raise AttributeError when running as packaged app (packed by pyinstaller)
+    pass
+
+if PAGESIZE is None:
     try:
         # Windows system
         import mmap


### PR DESCRIPTION
I run the packaged app by pyinstaller on windows platform, and get error raised as below:

```
Traceback (most recent call last):
  File "<frozen __main__>", line 3, in <module>
  File "<frozen src.main>", line 7, in <module>
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 688, in _load_unlocked
  File "PyInstaller\loader\pyimod02_importers.py", line 378, in exec_module
  File "main_window.py", line 11, in <module>
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 688, in _load_unlocked
  File "PyInstaller\loader\pyimod02_importers.py", line 378, in exec_module
  File "bincopy.py", line 18, in <module>
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 688, in _load_unlocked
  File "PyInstaller\loader\pyimod02_importers.py", line 378, in exec_module
  File "elftools\elf\elffile.py", line 17, in <module>
AttributeError: module 'resource' has no attribute 'getpagesize'
[PYI-26572:ERROR] Failed to execute script 'main' due to unhandled exception!
```

Still not sure where this resouce.py come from. I use dir() and get output as below:
```
['__doc__', '__file__', '__loader__', '__name__', '__package__', '__path__', '__spec__']
```
This resource.py seems to be empty.


After all, I changed the source code in elffile.py and the problem is gone.