### PR TITLE
Fix running tests

### DIFF
--- a/test/all_tests.py
+++ b/test/all_tests.py
@@ -18,8 +18,7 @@ def run_test_script(path, *args):
 
 def main():
     if not is_in_rootdir():
-        testlog.error('Error: Please run me from the root dir of pyelftools!')
-        return 1
+        sys.exit('Error: Please run me from the root dir of pyelftools!')
     run_test_script('test/run_all_unittests.py')
     run_test_script('test/run_examples_test.py')
     run_test_script('test/run_readelf_tests.py', '--parallel')

--- a/test/utils.py
+++ b/test/utils.py
@@ -20,7 +20,8 @@ def run_exe(exe_path, args=[], echo=False):
         popen_cmd.insert(0, sys.executable)
     if echo:
       print('[cmd]', ' '.join(popen_cmd))
-    proc = subprocess.Popen(popen_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    env = dict(os.environ, LC_ALL="C")
+    proc = subprocess.Popen(popen_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env)
     proc_stdout = proc.communicate()[0]
     return proc.returncode, proc_stdout.decode('latin-1')
 


### PR DESCRIPTION
While working on #514 I noticed two issues while running the test suite:
1. `testlog` is used but not defined
2. output is locale dependent and fails when running in non-English-locale