### PR TITLE
_make_gnu_versym_section: {str -> sym}tab

### DIFF
--- a/elftools/elf/elffile.py
+++ b/elftools/elf/elffile.py
@@ -797,12 +797,12 @@ class ELFFile(object):
     def _make_gnu_versym_section(self, section_header, name):
         """ Create a GNUVerSymSection
         """
-        linked_strtab_index = section_header['sh_link']
-        strtab_section = self.get_section(linked_strtab_index)
+        linked_symtab_index = section_header['sh_link']
+        symtab_section = self._get_linked_symtab_section(linked_symtab_index)
         return GNUVerSymSection(
             section_header, name,
             elffile=self,
-            symboltable=strtab_section)
+            symboltable=symtab_section)
 
     def _make_elf_hash_section(self, section_header, name):
         linked_symtab_index = section_header['sh_link']


### PR DESCRIPTION
Class `GNUVerSymSection` has an associated `SymbolTableSection` that's passed in the constructor, but in `_make_gnu_versym_section()` the variables are named `linked_strtab_index` and `strtab_section`. Rename them to `…_symtab_…` as with all the other cases.

Also use the helper method `_get_linked_symtab_section()` which also checks the type for correctness compared to plain `get_section()` introduced later by 9257a0fc79af ("Exceptions on malformed ELF header contents (#552)").

Fixes: 7b24670deb53 ("added support for version definition, version dependency and version symbol sections in pyelftools and readelf.py")

Found while working on #514 