### PR TITLE
NameLUT: Raise IndexError instead of returning None

### DIFF
--- a/elftools/dwarf/namelut.py
+++ b/elftools/dwarf/namelut.py
@@ -112,7 +112,7 @@ class NameLUT(Mapping):
         """
         if self._entries is None:
             self._entries, self._cu_headers = self._get_entries()
-        return self._entries.get(name)
+        return self._entries[name]
 
     def __iter__(self):
         """


### PR DESCRIPTION
`Mapping.__get__()` should raise an `IndexError` instead of returning `None` like `Mapping.get()` does.

Otherwise type-checkers like `mypy` and `pyright` will complain #514 as the signature of the overwritten method is different from the signature of the super class `Mapping`.