### PR TITLE
CI: Enable Python 3.13 testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
         os: [ubuntu-latest]
 
     steps:


### PR DESCRIPTION
Python 3.13 has been released first 2024-10-07.
Python 3.14 is scheduled for 2025-10-01.

<https://devguide.python.org/versions/>

While working on #514 