### PR TITLE
Modernize python code for `construct`

### DIFF
--- a/elftools/construct/__init__.py
+++ b/elftools/construct/__init__.py
@@ -28,6 +28,7 @@ Hands-on example:
     b'\\x01\\x02\\x03'
 """
 
+from .lib.container import *
 from .core import *
 from .adapters import *
 from .macros import *

--- a/elftools/construct/__init__.py
+++ b/elftools/construct/__init__.py
@@ -12,22 +12,20 @@ Homepage:
     http://construct.wikispaces.com (including online tutorial)
 
 Typical usage:
-    >>> from construct import *
+    >>> from ..construct import *
 
 Hands-on example:
-    >>> from construct import *
+    >>> from ..construct import *
     >>> s = Struct("foo",
     ...     UBInt8("a"),
     ...     UBInt16("b"),
     ... )
-    >>> s.parse("\\x01\\x02\\x03")
-    Container(a = 1, b = 515)
-    >>> print(s.parse("\\x01\\x02\\x03"))
-    Container:
-        a = 1
-        b = 515
-    >>> s.build(Container(a = 1, b = 0x0203))
-    "\\x01\\x02\\x03"
+    >>> s.parse(b"\\x01\\x02\\x03")
+    Container({'a': 1, 'b': 515})
+    >>> print(s.parse(b"\\x01\\x02\\x03"))
+    Container({'a': 1, 'b': 515})
+    >>> s.build(Container(a=1, b=0x0203))
+    b'\\x01\\x02\\x03'
 """
 
 from .core import *

--- a/elftools/construct/__init__.py
+++ b/elftools/construct/__init__.py
@@ -27,6 +27,7 @@ Hands-on example:
     >>> s.build(Container(a=1, b=0x0203))
     b'\\x01\\x02\\x03'
 """
+from __future__ import annotations
 
 from .lib.container import *
 from .core import *
@@ -38,9 +39,9 @@ from .debug import Probe, Debugger
 #===============================================================================
 # Metadata
 #===============================================================================
-__author__ = "tomer filiba (tomerfiliba [at] gmail.com)"
-__maintainer__ = "Corbin Simpson <MostAwesomeDude@gmail.com>"
-__version__ = "2.06"
+__author__: str = "tomer filiba (tomerfiliba [at] gmail.com)"
+__maintainer__: str = "Corbin Simpson <MostAwesomeDude@gmail.com>"
+__version__: str = "2.06"
 
 #===============================================================================
 # Shorthand expressions
@@ -58,10 +59,20 @@ Embed = Embedded
 #===============================================================================
 import functools
 import warnings
+from typing import TYPE_CHECKING, TypeVar
 
-def deprecated(f):
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from typing_extensions import ParamSpec
+
+    _P = ParamSpec('_P')
+    _T = TypeVar('_T')
+
+
+def deprecated(f: Callable[_P, _T]) -> Callable[_P, _T]:
     @functools.wraps(f)
-    def wrapper(*args, **kwargs):
+    def wrapper(*args: _P.args, **kwargs: _P.kwargs) -> _T:
         warnings.warn(
             "This name is deprecated, use %s instead" % f.__name__,
             DeprecationWarning, stacklevel=2)

--- a/elftools/construct/adapters.py
+++ b/elftools/construct/adapters.py
@@ -311,11 +311,15 @@ class ExprAdapter(Adapter):
         decoder = lambda obj, ctx: obj * 4,
     )
     """
-    __slots__: list[str] = ["_encode", "_decode"]
+    __slots__: list[str] = ["__encode", "__decode"]
     def __init__(self, subcon: Construct, encoder: Callable[[Any, Container], bytes], decoder: Callable[[bytes, Container], Any]) -> None:
         Adapter.__init__(self, subcon)
-        self._encode = encoder
-        self._decode = decoder
+        self.__encode = encoder
+        self.__decode = decoder
+    def _encode(self, obj: Any, context: Container) -> Any:
+        return self.__encode(obj, context)
+    def _decode(self, obj: Any, context: Container) -> Any:
+        return self.__decode(obj, context)
 
 class HexDumpAdapter(Adapter):
     """

--- a/elftools/construct/adapters.py
+++ b/elftools/construct/adapters.py
@@ -5,6 +5,15 @@ from .lib import int_to_bin, bin_to_int, swap_bytes
 from .lib import FlagsContainer, HexString
 
 
+__all__ = [
+    "BitIntegerError", "MappingError", "ConstError", "ValidationError", "PaddingError",
+    "BitIntegerAdapter", "MappingAdapter", "FlagsAdapter", "StringAdapter", "PaddedStringAdapter",
+    "LengthValueAdapter", "CStringAdapter", "TunnelAdapter", "ExprAdapter", "HexDumpAdapter", "ConstAdapter",
+    "SlicingAdapter", "IndexingAdapter", "PaddingAdapter",
+    "Validator", "OneOf", "NoneOf",
+]
+
+
 #===============================================================================
 # exceptions
 #===============================================================================

--- a/elftools/construct/adapters.py
+++ b/elftools/construct/adapters.py
@@ -1,8 +1,17 @@
+from __future__ import annotations
+
 from io import BytesIO
+from typing import TYPE_CHECKING, Any, Callable, Literal
 
 from .core import Adapter, AdaptationError, Pass
 from .lib import int_to_bin, bin_to_int, swap_bytes
 from .lib import FlagsContainer, HexString
+
+if TYPE_CHECKING:
+    from collections.abc import Hashable, Mapping, Sized
+
+    from .core import Construct, _Pass
+    from .lib import Container, ListContainer
 
 
 __all__ = [
@@ -18,15 +27,15 @@ __all__ = [
 # exceptions
 #===============================================================================
 class BitIntegerError(AdaptationError):
-    __slots__ = []
+    __slots__: list[str] = []
 class MappingError(AdaptationError):
-    __slots__ = []
+    __slots__: list[str] = []
 class ConstError(AdaptationError):
-    __slots__ = []
+    __slots__: list[str] = []
 class ValidationError(AdaptationError):
-    __slots__ = []
+    __slots__: list[str] = []
 class PaddingError(AdaptationError):
-    __slots__ = []
+    __slots__: list[str] = []
 
 #===============================================================================
 # adapters
@@ -46,15 +55,15 @@ class BitIntegerAdapter(Adapter):
     * bytesize - number of bits per byte, used for byte-swapping (if swapped).
       default is 8.
     """
-    __slots__ = ["width", "swapped", "signed", "bytesize"]
-    def __init__(self, subcon, width, swapped = False, signed = False,
-                 bytesize = 8):
+    __slots__: list[str] = ["width", "swapped", "signed", "bytesize"]
+    def __init__(self, subcon: Construct, width: int, swapped: bool = False, signed: bool = False,
+            bytesize: int = 8) -> None:
         Adapter.__init__(self, subcon)
         self.width = width
         self.swapped = swapped
         self.signed = signed
         self.bytesize = bytesize
-    def _encode(self, obj, context):
+    def _encode(self, obj: int, context: Container) -> bytes:
         if obj < 0 and not self.signed:
             raise BitIntegerError("object is negative, but field is not signed",
                 obj)
@@ -62,7 +71,7 @@ class BitIntegerAdapter(Adapter):
         if self.swapped:
             obj2 = swap_bytes(obj2, bytesize = self.bytesize)
         return obj2
-    def _decode(self, obj, context):
+    def _decode(self, obj: bytes, context: Container) -> int:
         if self.swapped:
             obj = swap_bytes(obj, bytesize = self.bytesize)
         return bin_to_int(obj, signed = self.signed)
@@ -83,15 +92,17 @@ class MappingAdapter(Adapter):
       in the encoding mapping. if no object is given, an exception is raised.
       if `Pass` is used, the unmapped object will be passed as-is
     """
-    __slots__ = ["encoding", "decoding", "encdefault", "decdefault"]
-    def __init__(self, subcon, decoding, encoding,
-                 decdefault = NotImplemented, encdefault = NotImplemented):
+    __slots__: list[str] = ["encoding", "decoding", "encdefault", "decdefault"]
+    def __init__(self, subcon: Construct, decoding: Mapping[Any, Any], encoding: Mapping[Any, Any],
+            decdefault: Hashable | _Pass = NotImplemented,
+            encdefault: Hashable | _Pass = NotImplemented,
+    ) -> None:
         Adapter.__init__(self, subcon)
         self.decoding = decoding
         self.encoding = encoding
         self.decdefault = decdefault
         self.encdefault = encdefault
-    def _encode(self, obj, context):
+    def _encode(self, obj: Hashable, context: Container) -> Hashable:
         try:
             return self.encoding[obj]
         except (KeyError, TypeError):
@@ -101,7 +112,7 @@ class MappingAdapter(Adapter):
             if self.encdefault is Pass:
                 return obj
             return self.encdefault
-    def _decode(self, obj, context):
+    def _decode(self, obj: Hashable, context: Container) -> Hashable:
         try:
             return self.decoding[obj]
         except (KeyError, TypeError):
@@ -122,17 +133,17 @@ class FlagsAdapter(Adapter):
     * subcon - the subcon to extract
     * flags - a dictionary mapping flag-names to their value
     """
-    __slots__ = ["flags"]
-    def __init__(self, subcon, flags):
+    __slots__: list[str] = ["flags"]
+    def __init__(self, subcon: Construct, flags: dict[str, int]) -> None:
         Adapter.__init__(self, subcon)
         self.flags = flags
-    def _encode(self, obj, context):
+    def _encode(self, obj: FlagsContainer, context: Container) -> int:
         flags = 0
         for name, value in self.flags.items():
             if getattr(obj, name, False):
                 flags |= value
         return flags
-    def _decode(self, obj, context):
+    def _decode(self, obj: int, context: Container) -> FlagsContainer:
         obj2 = FlagsContainer()
         for name, value in self.flags.items():
             setattr(obj2, name, bool(obj & value))
@@ -149,15 +160,15 @@ class StringAdapter(Adapter):
     * encoding - the character encoding name (e.g., "utf8"), or None to
       return raw bytes (usually 8-bit ASCII).
     """
-    __slots__ = ["encoding"]
-    def __init__(self, subcon, encoding = None):
+    __slots__: list[str] = ["encoding"]
+    def __init__(self, subcon: Construct, encoding: str | None = None) -> None:
         Adapter.__init__(self, subcon)
         self.encoding = encoding
-    def _encode(self, obj, context):
+    def _encode(self, obj: bytes | str, context: Container) -> bytes:
         if self.encoding:
             obj = obj.encode(self.encoding)
         return obj
-    def _decode(self, obj, context):
+    def _decode(self, obj: bytes, context: Container) -> bytes | str:
         if self.encoding:
             obj = obj.decode(self.encoding)
         return obj
@@ -176,9 +187,9 @@ class PaddedStringAdapter(Adapter):
       "left"). the default is "right". trimming is only meaningful for
       building, when the given string is too long.
     """
-    __slots__ = ["padchar", "paddir", "trimdir"]
-    def __init__(self, subcon, padchar = b"\x00", paddir = "right",
-                 trimdir = "right"):
+    __slots__: list[str] = ["padchar", "paddir", "trimdir"]
+    def __init__(self, subcon: Construct, padchar: bytes = b"\x00", paddir: Literal["right", "left", "center"] = "right",
+            trimdir: Literal["right", "left"] = "right"):
         if paddir not in ("right", "left", "center"):
             raise ValueError("paddir must be 'right', 'left' or 'center'",
                 paddir)
@@ -188,7 +199,7 @@ class PaddedStringAdapter(Adapter):
         self.padchar = padchar
         self.paddir = paddir
         self.trimdir = trimdir
-    def _decode(self, obj, context):
+    def _decode(self, obj: bytes, context: Container) -> bytes:
         if self.paddir == "right":
             obj = obj.rstrip(self.padchar)
         elif self.paddir == "left":
@@ -196,7 +207,7 @@ class PaddedStringAdapter(Adapter):
         else:
             obj = obj.strip(self.padchar)
         return obj
-    def _encode(self, obj, context):
+    def _encode(self, obj: bytes, context: Container) -> bytes:
         size = self._sizeof(context)
         if self.paddir == "right":
             obj = obj.ljust(size, self.padchar)
@@ -220,10 +231,10 @@ class LengthValueAdapter(Adapter):
     Parameters:
     * subcon - the subcon returning a length-value pair
     """
-    __slots__ = []
-    def _encode(self, obj, context):
+    __slots__: list[str] = []
+    def _encode(self, obj: Sized, context: Container) -> tuple[int, Sized]:
         return (len(obj), obj)
-    def _decode(self, obj, context):
+    def _decode(self, obj: tuple[int, Sized] | ListContainer, context: Container) -> Sized:
         return obj[1]
 
 class CStringAdapter(StringAdapter):
@@ -237,13 +248,13 @@ class CStringAdapter(StringAdapter):
       return raw-bytes. the terminator characters are not affected by the
       encoding.
     """
-    __slots__ = ["terminators"]
-    def __init__(self, subcon, terminators = b"\x00", encoding = None):
+    __slots__: list[str] = ["terminators"]
+    def __init__(self, subcon: Construct, terminators: bytes = b"\x00", encoding: str | None = None) -> None:
         StringAdapter.__init__(self, subcon, encoding = encoding)
         self.terminators = terminators
-    def _encode(self, obj, context):
+    def _encode(self, obj: bytes | str, context: Container) -> bytes:
         return StringAdapter._encode(self, obj, context) + self.terminators[0:1]
-    def _decode(self, obj, context):
+    def _decode(self, obj: list[bytes], context: Container) -> bytes | str:  # type: ignore[override]
         return StringAdapter._decode(self, b''.join(obj[:-1]), context)
 
 class TunnelAdapter(Adapter):
@@ -268,13 +279,13 @@ class TunnelAdapter(Adapter):
         GreedyRange(UBInt16("elements"))
     )
     """
-    __slots__ = ["inner_subcon"]
-    def __init__(self, subcon, inner_subcon):
+    __slots__: list[str] = ["inner_subcon"]
+    def __init__(self, subcon: Construct, inner_subcon: Construct) -> None:
         Adapter.__init__(self, subcon)
         self.inner_subcon = inner_subcon
-    def _decode(self, obj, context):
+    def _decode(self, obj: bytes, context: Container) -> Any:
         return self.inner_subcon._parse(BytesIO(obj), context)
-    def _encode(self, obj, context):
+    def _encode(self, obj: Any, context: Container) -> bytes:
         stream = BytesIO()
         self.inner_subcon._build(obj, stream, context)
         return stream.getvalue()
@@ -298,8 +309,8 @@ class ExprAdapter(Adapter):
         decoder = lambda obj, ctx: obj * 4,
     )
     """
-    __slots__ = ["_encode", "_decode"]
-    def __init__(self, subcon, encoder, decoder):
+    __slots__: list[str] = ["_encode", "_decode"]
+    def __init__(self, subcon: Construct, encoder: Callable[[Any, Container], bytes], decoder: Callable[[bytes, Container], Any]) -> None:
         Adapter.__init__(self, subcon)
         self._encode = encoder
         self._decode = decoder
@@ -308,13 +319,13 @@ class HexDumpAdapter(Adapter):
     """
     Adapter for hex-dumping strings. It returns a HexString, which is a string
     """
-    __slots__ = ["linesize"]
-    def __init__(self, subcon, linesize = 16):
+    __slots__: list[str] = ["linesize"]
+    def __init__(self, subcon: Construct, linesize: int = 16) -> None:
         Adapter.__init__(self, subcon)
         self.linesize = linesize
-    def _encode(self, obj, context):
+    def _encode(self, obj: Any, context: Container) -> Any:
         return obj
-    def _decode(self, obj, context):
+    def _decode(self, obj: bytes, context: Container) -> HexString:
         return HexString(obj, linesize = self.linesize)
 
 class ConstAdapter(Adapter):
@@ -330,15 +341,15 @@ class ConstAdapter(Adapter):
     Const(Field("signature", 2), "MZ")
     """
     __slots__ = ["value"]
-    def __init__(self, subcon, value):
+    def __init__(self, subcon: Construct, value: object) -> None:
         Adapter.__init__(self, subcon)
         self.value = value
-    def _encode(self, obj, context):
+    def _encode(self, obj: object, context: Container) -> object:
         if obj is None or obj == self.value:
             return self.value
         else:
             raise ConstError("expected %r, found %r" % (self.value, obj))
-    def _decode(self, obj, context):
+    def _decode(self, obj: object, context: Container) -> object:
         if obj != self.value:
             raise ConstError("expected %r, found %r" % (self.value, obj))
         return obj
@@ -353,16 +364,16 @@ class SlicingAdapter(Adapter):
     * stop - stop index (or None for up-to-end)
     * step - step (or None for every element)
     """
-    __slots__ = ["start", "stop", "step"]
-    def __init__(self, subcon, start, stop = None):
+    __slots__: list[str] = ["start", "stop", "step"]
+    def __init__(self, subcon: Construct, start: int, stop: int | None = None) -> None:
         Adapter.__init__(self, subcon)
         self.start = start
         self.stop = stop
-    def _encode(self, obj, context):
+    def _encode(self, obj: list[Any], context: Container) -> list[Any]:
         if self.start is None:
             return obj
         return [None] * self.start + obj
-    def _decode(self, obj, context):
+    def _decode(self, obj: list[Any], context: Container) -> list[Any]:
         return obj[self.start:self.stop]
 
 class IndexingAdapter(Adapter):
@@ -373,15 +384,15 @@ class IndexingAdapter(Adapter):
     * subcon - the subcon to index
     * index - the index of the list to get
     """
-    __slots__ = ["index"]
-    def __init__(self, subcon, index):
+    __slots__: list[str] = ["index"]
+    def __init__(self, subcon: Construct, index: int) -> None:
         Adapter.__init__(self, subcon)
         if type(index) is not int:
             raise TypeError("index must be an integer", type(index))
         self.index = index
-    def _encode(self, obj, context):
+    def _encode(self, obj: Any, context: Container) -> list[Any]:
         return [None] * self.index + [obj]
-    def _decode(self, obj, context):
+    def _decode(self, obj: list[Any], context: Container) -> Any:
         return obj[self.index]
 
 class PaddingAdapter(Adapter):
@@ -394,14 +405,14 @@ class PaddingAdapter(Adapter):
     * strict - whether or not to verify, during parsing, that the given
       padding matches the padding pattern. default is False (unstrict)
     """
-    __slots__ = ["pattern", "strict"]
-    def __init__(self, subcon, pattern = b"\x00", strict = False):
+    __slots__: list[str] = ["pattern", "strict"]
+    def __init__(self, subcon: Construct, pattern: bytes = b"\x00", strict: bool = False) -> None:
         Adapter.__init__(self, subcon)
         self.pattern = pattern
         self.strict = strict
-    def _encode(self, obj, context):
+    def _encode(self, obj: None, context: Container) -> bytes:
         return self._sizeof(context) * self.pattern
-    def _decode(self, obj, context):
+    def _decode(self, obj: bytes, context: Container) -> bytes:
         if self.strict:
             expected = self._sizeof(context) * self.pattern
             if obj != expected:
@@ -420,14 +431,14 @@ class Validator(Adapter):
     Parameters:
     * subcon - the subcon to validate
     """
-    __slots__ = []
-    def _decode(self, obj, context):
+    __slots__: list[str] = []
+    def _decode(self, obj: object, context: Container) -> object:
         if not self._validate(obj, context):
             raise ValidationError("invalid object", obj)
         return obj
-    def _encode(self, obj, context):
+    def _encode(self, obj: object, context: Container) -> object:
         return self._decode(obj, context)
-    def _validate(self, obj, context):
+    def _validate(self, obj: object, context: Container) -> bool:
         raise NotImplementedError()
 
 class OneOf(Validator):
@@ -452,11 +463,11 @@ class OneOf(Validator):
         ...
     ValidationError: ('invalid object', 9)
     """
-    __slots__ = ["valids"]
-    def __init__(self, subcon, valids):
+    __slots__: list[str] = ["valids"]
+    def __init__(self, subcon: Construct, valids: list[object]) -> None:
         Validator.__init__(self, subcon)
         self.valids = valids
-    def _validate(self, obj, context):
+    def _validate(self, obj: object, context: Container) -> bool:
         return obj in self.valids
 
 class NoneOf(Validator):
@@ -474,9 +485,9 @@ class NoneOf(Validator):
         ...
     ValidationError: ('invalid object', 6)
     """
-    __slots__ = ["invalids"]
-    def __init__(self, subcon, invalids):
+    __slots__: list[str] = ["invalids"]
+    def __init__(self, subcon: Construct, invalids: list[object]) -> None:
         Validator.__init__(self, subcon)
         self.invalids = invalids
-    def _validate(self, obj, context):
+    def _validate(self, obj: object, context: Container) -> bool:
         return obj not in self.invalids

--- a/elftools/construct/adapters.py
+++ b/elftools/construct/adapters.py
@@ -172,7 +172,7 @@ class StringAdapter(Adapter):
         return obj
     def _decode(self, obj: bytes, context: Container) -> bytes | str:
         if self.encoding:
-            obj = obj.decode(self.encoding)
+            return obj.decode(self.encoding)
         return obj
 
 class PaddedStringAdapter(Adapter):

--- a/elftools/construct/adapters.py
+++ b/elftools/construct/adapters.py
@@ -166,7 +166,9 @@ class StringAdapter(Adapter):
         self.encoding = encoding
     def _encode(self, obj: bytes | str, context: Container) -> bytes:
         if self.encoding:
+            assert isinstance(obj, str)
             obj = obj.encode(self.encoding)
+        assert isinstance(obj, bytes)
         return obj
     def _decode(self, obj: bytes, context: Container) -> bytes | str:
         if self.encoding:

--- a/elftools/construct/adapters.py
+++ b/elftools/construct/adapters.py
@@ -428,19 +428,20 @@ class OneOf(Validator):
     :param ``Construct`` subcon: object to validate
     :param iterable valids: a set of valid values
 
-    >>> OneOf(UBInt8("foo"), [4,5,6,7]).parse("\\x05")
+    >>> from ..construct import UBInt8
+    >>> OneOf(UBInt8("foo"), [4,5,6,7]).parse(b"\\x05")
     5
-    >>> OneOf(UBInt8("foo"), [4,5,6,7]).parse("\\x08")
+    >>> OneOf(UBInt8("foo"), [4,5,6,7]).parse(b"\\x08")  # doctest: +IGNORE_EXCEPTION_DETAIL
     Traceback (most recent call last):
         ...
-    construct.core.ValidationError: ('invalid object', 8)
+    ValidationError: ('invalid object', 8)
     >>>
     >>> OneOf(UBInt8("foo"), [4,5,6,7]).build(5)
-    '\\x05'
-    >>> OneOf(UBInt8("foo"), [4,5,6,7]).build(9)
+    b'\\x05'
+    >>> OneOf(UBInt8("foo"), [4,5,6,7]).build(9)  # doctest: +IGNORE_EXCEPTION_DETAIL
     Traceback (most recent call last):
         ...
-    construct.core.ValidationError: ('invalid object', 9)
+    ValidationError: ('invalid object', 9)
     """
     __slots__ = ["valids"]
     def __init__(self, subcon, valids):
@@ -456,12 +457,13 @@ class NoneOf(Validator):
     :param ``Construct`` subcon: object to validate
     :param iterable invalids: a set of invalid values
 
-    >>> NoneOf(UBInt8("foo"), [4,5,6,7]).parse("\\x08")
+    >>> from ..construct import UBInt8
+    >>> NoneOf(UBInt8("foo"), [4,5,6,7]).parse(b"\\x08")
     8
-    >>> NoneOf(UBInt8("foo"), [4,5,6,7]).parse("\\x06")
+    >>> NoneOf(UBInt8("foo"), [4,5,6,7]).parse(b"\\x06")  # doctest: +IGNORE_EXCEPTION_DETAIL
     Traceback (most recent call last):
         ...
-    construct.core.ValidationError: ('invalid object', 6)
+    ValidationError: ('invalid object', 6)
     """
     __slots__ = ["invalids"]
     def __init__(self, subcon, invalids):

--- a/elftools/construct/core.py
+++ b/elftools/construct/core.py
@@ -4,6 +4,18 @@ from struct import Struct as Packer
 from .lib import Container, ListContainer, LazyContainer
 
 
+__all__ = [
+    "ConstructError", "FieldError", "SizeofError", "AdaptationError", "ArrayError", "RangeError", "SwitchError", "SelectError", "TerminatorError",
+    "Construct", "Subconstruct", "Adapter",
+    "StaticField", "FormatField", "MetaField", "MetaArray", "Range", "RepeatUntil",
+    "Struct", "Sequence", "Union",
+    "Switch", "Select",
+    "Pointer", "Peek", "OnDemand", "Buffered", "Restream",
+    "Reconfig", "Anchor", "Value", "LazyBound",
+    "_Pass", "Pass", "_Terminator", "Terminator",
+]
+
+
 #===============================================================================
 # exceptions
 #===============================================================================

--- a/elftools/construct/core.py
+++ b/elftools/construct/core.py
@@ -366,14 +366,15 @@ class MetaField(Construct):
     :param callable lengthfunc: callable that takes a context and returns
                                 length as an int
 
+    >>> from ..construct import Byte
     >>> foo = Struct("foo",
     ...     Byte("length"),
     ...     MetaField("data", lambda ctx: ctx["length"])
     ... )
-    >>> foo.parse("\\x03ABC")
-    Container(data = 'ABC', length = 3)
-    >>> foo.parse("\\x04ABCD")
-    Container(data = 'ABCD', length = 4)
+    >>> foo.parse(b"\\x03ABC")
+    Container({'length': 3, 'data': b'ABC'})
+    >>> foo.parse(b"\\x04ABCD")
+    Container({'length': 4, 'data': b'ABCD'})
     """
 
     __slots__ = ["lengthfunc"]
@@ -459,29 +460,30 @@ class Range(Subconstruct):
     :param int maxcount: the maximal count
     :param Construct subcon: the subcon to repeat
 
+    >>> from ..construct import UBInt8
     >>> c = Range(3, 7, UBInt8("foo"))
-    >>> c.parse("\\x01\\x02")
+    >>> c.parse(b"\\x01\\x02")  # doctest: +IGNORE_EXCEPTION_DETAIL
     Traceback (most recent call last):
       ...
-    construct.core.RangeError: expected 3..7, found 2
-    >>> c.parse("\\x01\\x02\\x03")
+    RangeError: expected 3..7, found 2
+    >>> c.parse(b"\\x01\\x02\\x03")
     [1, 2, 3]
-    >>> c.parse("\\x01\\x02\\x03\\x04\\x05\\x06")
+    >>> c.parse(b"\\x01\\x02\\x03\\x04\\x05\\x06")
     [1, 2, 3, 4, 5, 6]
-    >>> c.parse("\\x01\\x02\\x03\\x04\\x05\\x06\\x07")
+    >>> c.parse(b"\\x01\\x02\\x03\\x04\\x05\\x06\\x07")
     [1, 2, 3, 4, 5, 6, 7]
-    >>> c.parse("\\x01\\x02\\x03\\x04\\x05\\x06\\x07\\x08\\x09")
+    >>> c.parse(b"\\x01\\x02\\x03\\x04\\x05\\x06\\x07\\x08\\x09")
     [1, 2, 3, 4, 5, 6, 7]
-    >>> c.build([1,2])
+    >>> c.build([1,2])  # doctest: +IGNORE_EXCEPTION_DETAIL
     Traceback (most recent call last):
       ...
-    construct.core.RangeError: expected 3..7, found 2
+    RangeError: expected 3..7, found 2
     >>> c.build([1,2,3,4])
-    '\\x01\\x02\\x03\\x04'
-    >>> c.build([1,2,3,4,5,6,7,8])
+    b'\\x01\\x02\\x03\\x04'
+    >>> c.build([1,2,3,4,5,6,7,8])  # doctest: +IGNORE_EXCEPTION_DETAIL
     Traceback (most recent call last):
       ...
-    construct.core.RangeError: expected 3..7, found 8
+    RangeError: expected 3..7, found 8
     """
 
     __slots__ = ["mincount", "maxcout"]

--- a/elftools/construct/core.py
+++ b/elftools/construct/core.py
@@ -1003,7 +1003,7 @@ class Peek(Subconstruct):
         try:
             return self.subcon._parse(stream, context)
         except FieldError:
-            pass
+            return None
         finally:
             stream.seek(pos)
     def _build(self, obj: Construct, stream: IO[bytes], context: Container) -> None:

--- a/elftools/construct/core.py
+++ b/elftools/construct/core.py
@@ -852,6 +852,7 @@ class Switch(Construct, Generic[_T]):
             return obj
     def _build(self, obj: tuple[_T | None, Construct] | Construct, stream: IO[bytes], context: Container) -> None:
         if self.include_key:
+            assert isinstance(obj, tuple)
             key, obj = obj
         else:
             key = self.keyfunc(context)
@@ -908,6 +909,7 @@ class Select(Construct):
         raise SelectError("no subconstruct matched")
     def _build(self, obj: tuple[str, Any] | Any, stream: IO[bytes], context: Container) -> None:
         if self.include_name:
+            assert isinstance(obj, tuple)
             name, obj = obj
             for sc in self.subcons:
                 if sc.name == name:

--- a/elftools/construct/core.py
+++ b/elftools/construct/core.py
@@ -779,7 +779,7 @@ class Switch(Construct):
     Parameters:
     * name - the name of the construct
     * keyfunc - a function that takes the context and returns a key, which
-      will ne used to choose the relevant case.
+      will be used to choose the relevant case.
     * cases - a dictionary mapping keys to constructs. the keys can be any
       values that may be returned by keyfunc.
     * default - a default value to use when the key is not found in the cases.

--- a/elftools/construct/core.py
+++ b/elftools/construct/core.py
@@ -625,10 +625,8 @@ class Struct(Construct):
     )
     """
     __slots__ = ["subcons", "nested"]
-    def __init__(self, name, *subcons, **kw):
-        self.nested = kw.pop("nested", True)
-        if kw:
-            raise TypeError("the only keyword argument accepted is 'nested'", kw)
+    def __init__(self, name, *subcons, nested=True):
+        self.nested = nested
         Construct.__init__(self, name)
         self.subcons = subcons
         self._inherit_flags(*subcons)
@@ -753,7 +751,7 @@ class Union(Construct):
     )
     """
     __slots__ = ["parser", "builder"]
-    def __init__(self, name, master, *subcons, **kw):
+    def __init__(self, name, master, *subcons):
         Construct.__init__(self, name)
         args = [Peek(sc) for sc in subcons]
         args.append(MetaField(None, lambda ctx: master._sizeof(ctx)))
@@ -864,11 +862,7 @@ class Select(Construct):
     )
     """
     __slots__ = ["subcons", "include_name"]
-    def __init__(self, name, *subcons, **kw):
-        include_name = kw.pop("include_name", False)
-        if kw:
-            raise TypeError("the only keyword argument accepted "
-                "is 'include_name'", kw)
+    def __init__(self, name, *subcons, include_name=False):
         Construct.__init__(self, name)
         self.subcons = subcons
         self.include_name = include_name

--- a/elftools/construct/core.py
+++ b/elftools/construct/core.py
@@ -495,7 +495,7 @@ class Range(Subconstruct):
         self._set_flag(self.FLAG_DYNAMIC)
     def _parse(self, stream, context):
         obj = ListContainer()
-        c = 0
+        c = pos = 0
         try:
             if self.subcon.conflags & self.FLAG_COPY_CONTEXT:
                 while c < self.maxcout:

--- a/elftools/construct/core.py
+++ b/elftools/construct/core.py
@@ -354,6 +354,8 @@ class FormatField(StaticField, Generic[_T]):
     """
 
     __slots__: list[str] = ["packer"]
+    if TYPE_CHECKING:
+        name: str
     def __init__(self, name: str, endianity: Literal["<", ">", "="], format: str) -> None:
         if endianity not in (">", "<", "="):
             raise ValueError("endianity must be be '=', '<', or '>'",
@@ -1197,6 +1199,8 @@ class Anchor(Construct):
     )
     """
     __slots__: list[str] = []
+    if TYPE_CHECKING:
+        name: str
     def _parse(self, stream: IO[bytes], context: Container) -> int:
         return stream.tell()
     def _build(self, obj: None, stream: IO[bytes], context: Container) -> None:
@@ -1220,6 +1224,8 @@ class Value(Construct, Generic[_T]):
     )
     """
     __slots__: list[str] = ["func"]
+    if TYPE_CHECKING:
+        name: str
     def __init__(self, name: str, func: Callable[[Container], _T]) -> None:
         Construct.__init__(self, name)
         self.func = func

--- a/elftools/construct/core.py
+++ b/elftools/construct/core.py
@@ -831,7 +831,7 @@ class Switch(Construct, Generic[_T]):
             raise SwitchError("no default case defined")
         def _sizeof(self, context: Container) -> int:
             raise SwitchError("no default case defined")
-    NoDefault = NoDefault("No default value specified")
+    NoDefault: Final = _NoDefault("No default value specified")
 
     __slots__: list[str] = ["subcons", "keyfunc", "cases", "default", "include_key"]
 
@@ -1304,7 +1304,7 @@ class LazyBound(Construct):
             self.bound = self.bindfunc()
         return self.bound._sizeof(context)
 
-class Pass(Construct):
+class _Pass(Construct):
     """
     A do-nothing construct, useful as the default case for Switch, or
     to indicate Enums.
@@ -1326,9 +1326,9 @@ class Pass(Construct):
         return 0
     def __reduce__(self) -> str:
         return self.__class__.__name__
-Pass = Pass(None)
+Pass: Final[Any] = _Pass(None)
 
-class Terminator(Construct):
+class _Terminator(Construct):
     """
     Asserts the end of the stream has been reached at the point it's placed.
     You can use this to ensure no more unparsed data follows.
@@ -1350,4 +1350,4 @@ class Terminator(Construct):
         assert obj is None
     def _sizeof(self, context: Container) -> int:
         return 0
-Terminator = Terminator(None)
+Terminator: Final[Any] = _Terminator(None)

--- a/elftools/construct/debug.py
+++ b/elftools/construct/debug.py
@@ -1,10 +1,14 @@
 """
 Debugging utilities for constructs
 """
+from __future__ import annotations
+
 import sys
 import traceback
 import pdb
 import inspect
+from typing import IO, Any
+
 from .core import Construct, Subconstruct
 from .lib import HexString, Container, ListContainer
 
@@ -38,9 +42,9 @@ class Probe(Construct):
     ]
     counter = 0
 
-    def __init__(self, name = None, show_stream = True,
-                 show_context = True, show_stack = True,
-                 stream_lookahead = 100):
+    def __init__(self, name: str | None = None, show_stream: bool = True,
+            show_context: bool = True, show_stack: bool = True,
+            stream_lookahead: int = 100) -> None:
         Construct.__init__(self, None)
         if name is None:
             Probe.counter += 1
@@ -50,16 +54,16 @@ class Probe(Construct):
         self.show_context = show_context
         self.show_stack = show_stack
         self.stream_lookahead = stream_lookahead
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "%s(%r)" % (self.__class__.__name__, self.printname)
-    def _parse(self, stream, context):
+    def _parse(self, stream: IO[bytes], context: Container) -> None:
         self.printout(stream, context)
-    def _build(self, obj, stream, context):
+    def _build(self, obj: Any, stream: IO[bytes], context: Container) -> None:
         self.printout(stream, context)
-    def _sizeof(self, context):
+    def _sizeof(self, context: Container) -> int:
         return 0
 
-    def printout(self, stream, context):
+    def printout(self, stream: IO[bytes], context: Container) -> None:
         obj = Container()
         if self.show_stream:
             obj.stream_position = stream.tell()
@@ -105,7 +109,7 @@ class Debugger(Subconstruct):
     )
     """
     __slots__ = ["retval"]
-    def _parse(self, stream, context):
+    def _parse(self, stream: IO[bytes], context: Container) -> Any:
         try:
             return self.subcon._parse(stream, context)
         except Exception:
@@ -116,12 +120,12 @@ class Debugger(Subconstruct):
                 raise
             else:
                 return self.retval
-    def _build(self, obj, stream, context):
+    def _build(self, obj: Any, stream: IO[bytes], context: Container) -> None:
         try:
             self.subcon._build(obj, stream, context)
         except Exception:
             self.handle_exc()
-    def handle_exc(self, msg = None):
+    def handle_exc(self, msg: str | None = None) -> None:
         print("=" * 80)
         print("Debugging exception of %s:" % (self.subcon,))
         print("".join(traceback.format_exception(*sys.exc_info())[1:]))

--- a/elftools/construct/lib/binary.py
+++ b/elftools/construct/lib/binary.py
@@ -1,4 +1,7 @@
-def int_to_bin(number, width=32):
+from __future__ import annotations
+
+
+def int_to_bin(number: int, width: int = 32) -> bytes:
     r"""
     Convert an integer into its binary representation in a bytes object.
     Width is the amount of bits to generate. If width is larger than the actual
@@ -24,14 +27,14 @@ def int_to_bin(number, width=32):
     return bytes(bits)
 
 
-_bit_values = {
+_bit_values: dict[int, int] = {
     0: 0,
     1: 1,
     48: 0, # '0'
     49: 1, # '1'
     }
 
-def bin_to_int(bits, signed=False):
+def bin_to_int(bits: bytes, signed: bool = False) -> int:
     r"""
     Logical opposite of int_to_bin. Both '0' and '\x00' are considered zero,
     and both '1' and '\x01' are considered one. Set sign to True to interpret
@@ -48,7 +51,7 @@ def bin_to_int(bits, signed=False):
     return number - bias
 
 
-def swap_bytes(bits, bytesize=8):
+def swap_bytes(bits: bytes, bytesize: int = 8) -> bytes:
     r"""
     Bits is a b'' object containing a binary representation. Assuming each
     bytesize bits constitute a bytes, perform a endianness byte swap. Example:
@@ -76,7 +79,7 @@ for i in range(256):
     _bin_to_char[bin] = ch
 
 
-def encode_bin(data):
+def encode_bin(data: bytes) -> bytes:
     r"""
     Create a binary representation of the given b'' object. Assume 8-bit
     ASCII. Example:
@@ -87,7 +90,7 @@ def encode_bin(data):
     return b"".join(_char_to_bin[ch] for ch in data)
 
 
-def decode_bin(data):
+def decode_bin(data: bytes) -> bytes:
     """
     Logical opposite of decode_bin.
     """

--- a/elftools/construct/lib/binary.py
+++ b/elftools/construct/lib/binary.py
@@ -77,12 +77,12 @@ for i in range(256):
 
 
 def encode_bin(data):
-    """
+    r"""
     Create a binary representation of the given b'' object. Assume 8-bit
     ASCII. Example:
 
         >>> encode_bin(b'ab')
-        b"\x00\x01\x01\x00\x00\x00\x00\x01\x00\x01\x01\x00\x00\x00\x01\x00"
+        b'\x00\x01\x01\x00\x00\x00\x00\x01\x00\x01\x01\x00\x00\x00\x01\x00'
     """
     return b"".join(_char_to_bin[ch] for ch in data)
 

--- a/elftools/construct/lib/bitstream.py
+++ b/elftools/construct/lib/bitstream.py
@@ -7,7 +7,7 @@ class BitStreamReader:
     def __init__(self, substream):
         self.substream = substream
         self.total_size = 0
-        self.buffer = ""
+        self.buffer = b""
 
     def close(self):
         if self.total_size % 8 != 0:
@@ -18,7 +18,7 @@ class BitStreamReader:
         return self.substream.tell()
 
     def seek(self, pos, whence = 0):
-        self.buffer = ""
+        self.buffer = b""
         self.total_size = 0
         self.substream.seek(pos, whence)
 
@@ -28,7 +28,7 @@ class BitStreamReader:
 
         l = len(self.buffer)
         if count == 0:
-            data = ""
+            data = b""
         elif count <= l:
             data = self.buffer[:count]
             self.buffer = self.buffer[count:]
@@ -57,7 +57,7 @@ class BitStreamWriter:
         self.flush()
 
     def flush(self):
-        bytes = decode_bin("".join(self.buffer))
+        bytes = decode_bin(b"".join(self.buffer))
         self.substream.write(bytes)
         self.buffer = []
         self.pos = 0
@@ -72,6 +72,6 @@ class BitStreamWriter:
     def write(self, data):
         if not data:
             return
-        if type(data) is not str:
-            raise TypeError("data must be a string, not %r" % (type(data),))
+        if type(data) is not bytes:
+            raise TypeError("data must be a bytes, not %r" % (type(data),))
         self.buffer.append(data)

--- a/elftools/construct/lib/bitstream.py
+++ b/elftools/construct/lib/bitstream.py
@@ -1,42 +1,52 @@
+from __future__ import annotations
+
 import io
+from typing import IO, TYPE_CHECKING
 
 from .binary import encode_bin, decode_bin
 
-class BitStream(io.RawIOBase):
+if TYPE_CHECKING:
+    # Py3.12+ # from collections.abc import Buffer
+    from typing import Self  # 3.11+
 
-    __slots__ = ["substream"]
+    from typing_extensions import Buffer
 
-    def __init__(self, substream):
+
+class BitStream(io.RawIOBase, IO[bytes]):
+
+    __slots__: list[str] = ["substream"]
+
+    def __init__(self, substream: IO[bytes]) -> None:
         self.substream = substream
 
-    def __enter__(self):
+    def __enter__(self) -> Self:
         return self
 
 
 class BitStreamReader(BitStream):
 
-    __slots__ = ["buffer", "total_size"]
+    __slots__: list[str] = ["buffer", "total_size"]
 
-    def __init__(self, substream):
+    def __init__(self, substream: IO[bytes]) -> None:
         super().__init__(substream)
         self.total_size = 0
         self.buffer = b""
 
-    def close(self):
+    def close(self) -> None:
         if self.total_size % 8 != 0:
             raise ValueError("total size of read data must be a multiple of 8",
                 self.total_size)
 
-    def tell(self):
+    def tell(self) -> int:
         return self.substream.tell()
 
-    def seek(self, pos, whence = 0):
+    def seek(self, pos: int, whence: int = 0) -> int:
         self.buffer = b""
         self.total_size = 0
         self.substream.seek(pos, whence)
         return 0
 
-    def read(self, count):
+    def read(self, count: int = -1) -> bytes:
         if count < 0:
             raise ValueError("count cannot be negative")
 
@@ -61,30 +71,30 @@ class BitStreamReader(BitStream):
 
 class BitStreamWriter(BitStream):
 
-    __slots__ = ["buffer", "pos"]
+    __slots__: list[str] = ["buffer", "pos"]
 
-    def __init__(self, substream):
+    def __init__(self, substream: IO[bytes]) -> None:
         super().__init__(substream)
-        self.buffer = []
+        self.buffer: list[bytes] = []
         self.pos = 0
 
-    def close(self):
+    def close(self) -> None:
         self.flush()
 
-    def flush(self):
+    def flush(self) -> None:
         bytes = decode_bin(b"".join(self.buffer))
         self.substream.write(bytes)
         self.buffer = []
         self.pos = 0
 
-    def tell(self):
+    def tell(self) -> int:
         return self.substream.tell() + self.pos // 8
 
-    def seek(self, pos, whence = 0):
+    def seek(self, pos: int, whence: int = 0) -> int:
         self.flush()
         return self.substream.seek(pos, whence)
 
-    def write(self, data):
+    def write(self, data: Buffer) -> int:
         if not data:
             return 0
         if type(data) is not bytes:

--- a/elftools/construct/lib/container.py
+++ b/elftools/construct/lib/container.py
@@ -148,10 +148,10 @@ class LazyContainer:
         return self.subcon._parse(self.stream, self.context)
 
     def dispose(self) -> None:
-        self.subcon = None
-        self.stream = None
-        self.context = None
-        self.pos = None
+        del self.subcon
+        del self.stream
+        del self.context
+        del self.pos
 
     def _get_value(self) -> Any:
         if self._value is NotImplemented:

--- a/elftools/construct/lib/container.py
+++ b/elftools/construct/lib/container.py
@@ -124,7 +124,7 @@ class LazyContainer:
 
     def __eq__(self, other: object) -> bool:
         try:
-            return self._value == other._value
+            return self._value == other._value  # type: ignore[attr-defined]
         except AttributeError:
             return False
 

--- a/elftools/construct/lib/container.py
+++ b/elftools/construct/lib/container.py
@@ -6,6 +6,12 @@ from collections.abc import MutableMapping
 from pprint import pformat
 
 
+__all__ = [
+    "recursion_lock",
+    "Container", "FlagsContainer", "ListContainer", "LazyContainer",
+]
+
+
 def recursion_lock(retval, lock_name = "__recursion_lock__"):
     def decorator(func):
         def wrapper(self, *args, **kw):

--- a/elftools/construct/lib/container.py
+++ b/elftools/construct/lib/container.py
@@ -59,6 +59,23 @@ class Container(MutableMapping[str, Any]):
 
     # The core dictionary interface.
 
+    @overload
+    def __getitem__(self, name: Literal[
+        "ch_addralign", "ch_size",
+        "length",
+        "n_descsz", "n_offset", "n_namesz",
+        "sh_addralign", "sh_flags", "sh_size",
+        "bloom_size", "nbuckets",
+    ]) -> int: ...
+    @overload
+    def __getitem__(self, name: Literal[
+        "ch_type",
+        "sh_type",
+        "n_name", "n_type",
+        "tag", "vendor_name",
+    ]) -> str: ...
+    @overload
+    def __getitem__(self, name: str) -> Any: ...
     def __getitem__(self, name: str) -> Any:
         return self.__dict__[name]
 
@@ -86,6 +103,16 @@ class Container(MutableMapping[str, Any]):
 
     def __str__(self) -> str:
         return "%s(%s)" % (self.__class__.__name__, str(self.__dict__))
+
+    if TYPE_CHECKING:
+        # elftools.construct.debug Probe.printout()
+        stream_position: int
+        following_stream_data: str | HexString
+        context: Container
+        stack: ListContainer
+        # allow arbitray attributes
+        def __setattr__(self, name: str, value: object) -> None: ...
+        def __getattr__(self, name: str) -> Any: ...
 
 class FlagsContainer(Container):
     """

--- a/elftools/construct/lib/hex.py
+++ b/elftools/construct/lib/hex.py
@@ -1,9 +1,17 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing import Self  # 3.11+
+
+
 # Map an integer in the inclusive range 0-255 to its string byte representation
 _printable = dict((i, ".") for i in range(256))
 _printable.update((i, chr(i)) for i in range(32, 128))
 
 
-def hexdump(data, linesize):
+def hexdump(data: bytes, linesize: int) -> list[str]:
     """
     data is a bytes object. The returned result is a string.
     """
@@ -26,13 +34,13 @@ class HexString(bytes):
     Represents bytes that will be hex-dumped to a string when its string
     representation is requested.
     """
-    def __init__(self, data, linesize = 16):
+    def __init__(self, data: bytes, linesize: int = 16) -> None:
         self.linesize = linesize
 
-    def __new__(cls, data, *args, **kwargs):
+    def __new__(cls, data: bytes, *args: object, **kwargs: object) -> Self:
         return bytes.__new__(cls, data)
 
-    def __str__(self):
+    def __str__(self) -> str:
         if not self:
             return "''"
         sep = "\n"

--- a/elftools/construct/macros.py
+++ b/elftools/construct/macros.py
@@ -291,10 +291,12 @@ def PrefixedArray(subcon: Construct, length_field: Construct = UBInt8("length"))
     * subcon - the subcon to be repeated
     * length_field - a construct returning an integer
     """
+    assert length_field.name is not None
+    name = length_field.name
     return LengthValueAdapter(
         Sequence(subcon.name,
             length_field,
-            Array(lambda ctx: ctx[length_field.name], subcon),
+            Array(lambda ctx: ctx[name], subcon),
             nested = False
         )
     )

--- a/elftools/construct/macros.py
+++ b/elftools/construct/macros.py
@@ -10,6 +10,27 @@ from .adapters import (BitIntegerAdapter, PaddingAdapter,
     PaddedStringAdapter, FlagsAdapter, StringAdapter, MappingAdapter)
 
 
+__all__ = [
+    "Field", "BitField", "Padding", "Flag",
+    "Bit", "Nibble", "Octet",
+    "UBInt8", "UBInt16", "UBInt32", "UBInt64",
+    "SBInt8", "SBInt16", "SBInt32", "SBInt64",
+    "ULInt8", "ULInt16", "ULInt32", "ULInt64",
+    "SLInt8", "SLInt16", "SLInt32", "SLInt64",
+    "UNInt8", "UNInt16", "UNInt32", "UNInt64",
+    "SNInt8", "SNInt16", "SNInt32", "SNInt64",
+    "BFloat32", "LFloat32", "NFloat32",
+    "BFloat64", "LFloat64", "NFloat64",
+    "Array", "PrefixedArray", "OpenRange", "GreedyRange", "OptionalGreedyRange",
+    "Optional", "Bitwise", "Aligned", "SeqOfOne", "Embedded", "Rename", "Alias",
+    "SymmetricMapping", "Enum", "FlagsEnum",
+    "AlignedStruct", "BitStruct", "EmbeddedBitStruct",
+    "String", "PascalString", "CString",
+    "IfThenElse", "If",
+    "OnDemandPointer", "Magic",
+]
+
+
 #===============================================================================
 # fields
 #===============================================================================

--- a/elftools/construct/macros.py
+++ b/elftools/construct/macros.py
@@ -98,6 +98,7 @@ def BitField(name: str, length: Length, swapped: bool = False, signed: bool = Fa
     Container({'a': 7, 'b': False, 'c': 8, 'bar': Container({'d': 15, 'e': 1})})
     """
 
+    assert isinstance(length, int)  # FIXME: Field(len=f()) is supported, but not BitIntegerAdapter(width=f())
     return BitIntegerAdapter(Field(name, length),
         length,
         swapped=swapped,

--- a/elftools/construct/macros.py
+++ b/elftools/construct/macros.py
@@ -1,6 +1,11 @@
-from sys import maxsize
+from __future__ import annotations
 
-from .lib import (BitStreamReader, BitStreamWriter, encode_bin,
+from collections.abc import Callable
+from sys import maxsize
+from typing import TYPE_CHECKING, Any, Literal, TypedDict
+from typing import Union as TUnion
+
+from .lib import (BitStreamReader, BitStreamWriter, Container, encode_bin,
     decode_bin)
 from .core import (Struct, MetaField, StaticField, FormatField,
     OnDemand, Pointer, Switch, Value, RepeatUntil, MetaArray, Sequence, Range,
@@ -8,6 +13,15 @@ from .core import (Struct, MetaField, StaticField, FormatField,
 from .adapters import (BitIntegerAdapter, PaddingAdapter,
     ConstAdapter, CStringAdapter, LengthValueAdapter, IndexingAdapter,
     PaddedStringAdapter, FlagsAdapter, StringAdapter, MappingAdapter)
+
+if TYPE_CHECKING:
+    from collections.abc import Hashable, Mapping
+    from typing import Unpack  # Py3.11+
+
+    from .adapters import Adapter
+    from .core import Construct, Subconstruct, _Pass
+
+Length = TUnion[int, Callable[[Container], int]]
 
 
 __all__ = [
@@ -34,7 +48,7 @@ __all__ = [
 #===============================================================================
 # fields
 #===============================================================================
-def Field(name, length):
+def Field(name: str | None, length: Length) -> MetaField | StaticField:
     """
     A field consisting of a specified number of bytes.
 
@@ -48,7 +62,7 @@ def Field(name, length):
     else:
         return StaticField(name, length)
 
-def BitField(name, length, swapped = False, signed = False, bytesize = 8):
+def BitField(name: str, length: Length, swapped: bool = False, signed: bool = False, bytesize: int = 8) -> BitIntegerAdapter:
     r"""
     BitFields, as the name suggests, are fields that operate on raw, unaligned
     bits, and therefore must be enclosed in a BitStruct. Using them is very
@@ -91,7 +105,7 @@ def BitField(name, length, swapped = False, signed = False, bytesize = 8):
         bytesize=bytesize
     )
 
-def Padding(length, pattern = b"\x00", strict = False):
+def Padding(length: Length, pattern: bytes = b"\x00", strict: bool = False) -> PaddingAdapter:
     r"""a padding field (value is discarded)
     * length - the length of the field. the length can be either an integer,
       or a function that takes the context as an argument and returns the
@@ -105,7 +119,7 @@ def Padding(length, pattern = b"\x00", strict = False):
         strict = strict,
     )
 
-def Flag(name, truth = 1, falsehood = 0, default = False):
+def Flag(name: str, truth: int = 1, falsehood: int = 0, default: bool = False) -> MappingAdapter:
     """
     A flag.
 
@@ -132,111 +146,111 @@ def Flag(name, truth = 1, falsehood = 0, default = False):
 #===============================================================================
 # field shortcuts
 #===============================================================================
-def Bit(name):
+def Bit(name: str) -> BitIntegerAdapter:
     """a 1-bit BitField; must be enclosed in a BitStruct"""
     return BitField(name, 1)
-def Nibble(name):
+def Nibble(name: str) -> BitIntegerAdapter:
     """a 4-bit BitField; must be enclosed in a BitStruct"""
     return BitField(name, 4)
-def Octet(name):
+def Octet(name: str) -> BitIntegerAdapter:
     """an 8-bit BitField; must be enclosed in a BitStruct"""
     return BitField(name, 8)
 
-def UBInt8(name):
+def UBInt8(name: str) -> FormatField[int]:
     """unsigned, big endian 8-bit integer"""
     return FormatField(name, ">", "B")
-def UBInt16(name):
+def UBInt16(name: str) -> FormatField[int]:
     """unsigned, big endian 16-bit integer"""
     return FormatField(name, ">", "H")
-def UBInt32(name):
+def UBInt32(name: str) -> FormatField[int]:
     """unsigned, big endian 32-bit integer"""
     return FormatField(name, ">", "L")
-def UBInt64(name):
+def UBInt64(name: str) -> FormatField[int]:
     """unsigned, big endian 64-bit integer"""
     return FormatField(name, ">", "Q")
 
-def SBInt8(name):
+def SBInt8(name: str) -> FormatField[int]:
     """signed, big endian 8-bit integer"""
     return FormatField(name, ">", "b")
-def SBInt16(name):
+def SBInt16(name: str) -> FormatField[int]:
     """signed, big endian 16-bit integer"""
     return FormatField(name, ">", "h")
-def SBInt32(name):
+def SBInt32(name: str) -> FormatField[int]:
     """signed, big endian 32-bit integer"""
     return FormatField(name, ">", "l")
-def SBInt64(name):
+def SBInt64(name: str) -> FormatField[int]:
     """signed, big endian 64-bit integer"""
     return FormatField(name, ">", "q")
 
-def ULInt8(name):
+def ULInt8(name: str) -> FormatField[int]:
     """unsigned, little endian 8-bit integer"""
     return FormatField(name, "<", "B")
-def ULInt16(name):
+def ULInt16(name: str) -> FormatField[int]:
     """unsigned, little endian 16-bit integer"""
     return FormatField(name, "<", "H")
-def ULInt32(name):
+def ULInt32(name: str) -> FormatField[int]:
     """unsigned, little endian 32-bit integer"""
     return FormatField(name, "<", "L")
-def ULInt64(name):
+def ULInt64(name: str) -> FormatField[int]:
     """unsigned, little endian 64-bit integer"""
     return FormatField(name, "<", "Q")
 
-def SLInt8(name):
+def SLInt8(name: str) -> FormatField[int]:
     """signed, little endian 8-bit integer"""
     return FormatField(name, "<", "b")
-def SLInt16(name):
+def SLInt16(name: str) -> FormatField[int]:
     """signed, little endian 16-bit integer"""
     return FormatField(name, "<", "h")
-def SLInt32(name):
+def SLInt32(name: str) -> FormatField[int]:
     """signed, little endian 32-bit integer"""
     return FormatField(name, "<", "l")
-def SLInt64(name):
+def SLInt64(name: str) -> FormatField[int]:
     """signed, little endian 64-bit integer"""
     return FormatField(name, "<", "q")
 
-def UNInt8(name):
+def UNInt8(name: str) -> FormatField[int]:
     """unsigned, native endianity 8-bit integer"""
     return FormatField(name, "=", "B")
-def UNInt16(name):
+def UNInt16(name: str) -> FormatField[int]:
     """unsigned, native endianity 16-bit integer"""
     return FormatField(name, "=", "H")
-def UNInt32(name):
+def UNInt32(name: str) -> FormatField[int]:
     """unsigned, native endianity 32-bit integer"""
     return FormatField(name, "=", "L")
-def UNInt64(name):
+def UNInt64(name: str) -> FormatField[int]:
     """unsigned, native endianity 64-bit integer"""
     return FormatField(name, "=", "Q")
 
-def SNInt8(name):
+def SNInt8(name: str) -> FormatField[int]:
     """signed, native endianity 8-bit integer"""
     return FormatField(name, "=", "b")
-def SNInt16(name):
+def SNInt16(name: str) -> FormatField[int]:
     """signed, native endianity 16-bit integer"""
     return FormatField(name, "=", "h")
-def SNInt32(name):
+def SNInt32(name: str) -> FormatField[int]:
     """signed, native endianity 32-bit integer"""
     return FormatField(name, "=", "l")
-def SNInt64(name):
+def SNInt64(name: str) -> FormatField[int]:
     """signed, native endianity 64-bit integer"""
     return FormatField(name, "=", "q")
 
-def BFloat32(name):
+def BFloat32(name: str) -> FormatField[float]:
     """big endian, 32-bit IEEE floating point number"""
     return FormatField(name, ">", "f")
-def LFloat32(name):
+def LFloat32(name: str) -> FormatField[float]:
     """little endian, 32-bit IEEE floating point number"""
     return FormatField(name, "<", "f")
-def NFloat32(name):
+def NFloat32(name: str) -> FormatField[float]:
     """native endianity, 32-bit IEEE floating point number"""
     return FormatField(name, "=", "f")
 
-def BFloat64(name):
+def BFloat64(name: str) -> FormatField[float]:
     """big endian, 64-bit IEEE floating point number"""
     return FormatField(name, ">", "d")
-def LFloat64(name):
+def LFloat64(name: str) -> FormatField[float]:
     """little endian, 64-bit IEEE floating point number"""
     return FormatField(name, "<", "d")
-def NFloat64(name):
+def NFloat64(name: str) -> FormatField[float]:
     """native endianity, 64-bit IEEE floating point number"""
     return FormatField(name, "=", "d")
 
@@ -244,7 +258,7 @@ def NFloat64(name):
 #===============================================================================
 # arrays
 #===============================================================================
-def Array(count, subcon):
+def Array(count: Length, subcon: Construct) -> MetaArray:
     r"""
     Repeats the given unit a fixed number of times.
 
@@ -271,7 +285,7 @@ def Array(count, subcon):
         con._clear_flag(con.FLAG_DYNAMIC)
     return con
 
-def PrefixedArray(subcon, length_field = UBInt8("length")):
+def PrefixedArray(subcon: Construct, length_field: Construct = UBInt8("length")) -> LengthValueAdapter:
     """an array prefixed by a length field.
     * subcon - the subcon to be repeated
     * length_field - a construct returning an integer
@@ -284,10 +298,10 @@ def PrefixedArray(subcon, length_field = UBInt8("length")):
         )
     )
 
-def OpenRange(mincount, subcon):
+def OpenRange(mincount: int, subcon: Construct) -> Range:
     return Range(mincount, maxsize, subcon)
 
-def GreedyRange(subcon):
+def GreedyRange(subcon: Construct) -> Range:
     r"""
     Repeats the given unit one or more times.
 
@@ -315,7 +329,7 @@ def GreedyRange(subcon):
 
     return OpenRange(1, subcon)
 
-def OptionalGreedyRange(subcon):
+def OptionalGreedyRange(subcon: Construct) -> Range:
     r"""
     Repeats the given unit zero or more times. This repeater can't
     fail, as it accepts lists of any length.
@@ -340,25 +354,25 @@ def OptionalGreedyRange(subcon):
 #===============================================================================
 # subconstructs
 #===============================================================================
-def Optional(subcon):
+def Optional(subcon: Construct) -> Select:
     """an optional construct. if parsing fails, returns None.
     * subcon - the subcon to optionally parse or build
     """
     return Select(subcon.name, subcon, Pass)
 
-def Bitwise(subcon):
+def Bitwise(subcon: Construct) -> Subconstruct:
     """converts the stream to bits, and passes the bitstream to subcon
     * subcon - a bitwise construct (usually BitField)
     """
     # subcons larger than MAX_BUFFER will be wrapped by Restream instead
     # of Buffered. implementation details, don't stick your nose in :)
     MAX_BUFFER = 1024 * 8
-    def resizer(length):
+    def resizer(length: int) -> int:
         if length & 7:
             raise SizeofError("size must be a multiple of 8", length)
         return length >> 3
     if not subcon._is_flag(subcon.FLAG_DYNAMIC) and subcon.sizeof() < MAX_BUFFER:
-        con = Buffered(subcon,
+        con: Subconstruct = Buffered(subcon,
             encoder = decode_bin,
             decoder = encode_bin,
             resizer = resizer
@@ -370,7 +384,7 @@ def Bitwise(subcon):
             resizer = resizer)
     return con
 
-def Aligned(subcon, modulus = 4, pattern = b"\x00"):
+def Aligned(subcon: Construct, modulus: int = 4, pattern: bytes = b"\x00") -> IndexingAdapter:
     r"""aligns subcon to modulus boundary using padding pattern
     * subcon - the subcon to align
     * modulus - the modulus boundary (default is 4)
@@ -378,7 +392,7 @@ def Aligned(subcon, modulus = 4, pattern = b"\x00"):
     """
     if modulus < 2:
         raise ValueError("modulus must be >= 2", modulus)
-    def padlength(ctx):
+    def padlength(ctx: Container) -> int:
         return (modulus - (subcon._sizeof(ctx) % modulus)) % modulus
     return SeqOfOne(subcon.name,
         subcon,
@@ -390,7 +404,7 @@ def Aligned(subcon, modulus = 4, pattern = b"\x00"):
         nested = False,
     )
 
-def SeqOfOne(name, *args, **kw):
+def SeqOfOne(name: str | None, *args: Construct, **kw: bool) -> IndexingAdapter:
     """a sequence of one element. only the first element is meaningful, the
     rest are discarded
     * name - the name of the sequence
@@ -399,20 +413,20 @@ def SeqOfOne(name, *args, **kw):
     """
     return IndexingAdapter(Sequence(name, *args, **kw), index = 0)
 
-def Embedded(subcon):
+def Embedded(subcon: Construct) -> Reconfig:
     """embeds a struct into the enclosing struct.
     * subcon - the struct to embed
     """
     return Reconfig(subcon.name, subcon, subcon.FLAG_EMBED)
 
-def Rename(newname, subcon):
+def Rename(newname: str, subcon: Construct) -> Reconfig:
     """renames an existing construct
     * newname - the new name
     * subcon - the subcon to rename
     """
     return Reconfig(newname, subcon)
 
-def Alias(newname, oldname):
+def Alias(newname: str, oldname: str) -> Value[Any]:
     """creates an alias for an existing element in a struct
     * newname - the new name
     * oldname - the name of an existing element
@@ -423,7 +437,7 @@ def Alias(newname, oldname):
 #===============================================================================
 # mapping
 #===============================================================================
-def SymmetricMapping(subcon, mapping, default = NotImplemented):
+def SymmetricMapping(subcon: Construct, mapping: Mapping[Any, Any], default: Hashable | _Pass = NotImplemented) -> MappingAdapter:
     """defines a symmetrical mapping: a->b, b->a.
     * subcon - the subcon to map
     * mapping - the encoding mapping (a dict); the decoding mapping is
@@ -440,7 +454,7 @@ def SymmetricMapping(subcon, mapping, default = NotImplemented):
         decdefault = default,
     )
 
-def Enum(subcon, **kw):
+def Enum(subcon: Construct, **kw: Any) -> MappingAdapter:
     """a set of named values mapping.
     * subcon - the subcon to map
     * kw - keyword arguments which serve as the encoding mapping
@@ -451,7 +465,7 @@ def Enum(subcon, **kw):
     """
     return SymmetricMapping(subcon, kw, kw.pop("_default_", NotImplemented))
 
-def FlagsEnum(subcon, **kw):
+def FlagsEnum(subcon: Construct, **kw: Any) -> FlagsAdapter:
     """a set of flag values mapping.
     * subcon - the subcon to map
     * kw - keyword arguments which serve as the encoding mapping
@@ -462,7 +476,12 @@ def FlagsEnum(subcon, **kw):
 #===============================================================================
 # structs
 #===============================================================================
-def AlignedStruct(name, *subcons, **kw):
+class _AlignedStruct(TypedDict, total=False):
+    modulus: int
+    pattern: bytes
+
+
+def AlignedStruct(name: str, *subcons: Construct, **kw: Unpack[_AlignedStruct]) -> Struct:
     """a struct of aligned fields
     * name - the name of the struct
     * subcons - the subcons that make up this structure
@@ -470,14 +489,14 @@ def AlignedStruct(name, *subcons, **kw):
     """
     return Struct(name, *(Aligned(sc, **kw) for sc in subcons))
 
-def BitStruct(name, *subcons):
+def BitStruct(name: str, *subcons: Construct) -> Subconstruct:
     """a struct of bitwise fields
     * name - the name of the struct
     * subcons - the subcons that make up this structure
     """
     return Bitwise(Struct(name, *subcons))
 
-def EmbeddedBitStruct(*subcons):
+def EmbeddedBitStruct(*subcons: Construct) -> Subconstruct:
     """an embedded BitStruct. no name is necessary.
     * subcons - the subcons that make up this structure
     """
@@ -486,8 +505,8 @@ def EmbeddedBitStruct(*subcons):
 #===============================================================================
 # strings
 #===============================================================================
-def String(name, length, encoding=None, padchar=None, paddir="right",
-    trimdir="right"):
+def String(name: str, length: int, encoding: str | None = None, padchar: bytes | None = None, paddir: Literal["right", "left", "center"] = "right",
+        trimdir: Literal["right", "left"] = "right") -> Adapter:
     r"""
     A configurable, fixed-length string field.
 
@@ -515,13 +534,13 @@ def String(name, length, encoding=None, padchar=None, paddir="right",
     b'helloXXXXX'
     """
 
-    con = StringAdapter(Field(name, length), encoding=encoding)
+    con: Adapter = StringAdapter(Field(name, length), encoding=encoding)
     if padchar is not None:
         con = PaddedStringAdapter(con, padchar=padchar, paddir=paddir,
             trimdir=trimdir)
     return con
 
-def PascalString(name, length_field=UBInt8("length"), encoding=None):
+def PascalString(name: str, length_field: FormatField[int] = UBInt8("length"), encoding: str | None = None) -> StringAdapter:
     r"""
     A length-prefixed string.
 
@@ -559,8 +578,8 @@ def PascalString(name, length_field=UBInt8("length"), encoding=None):
         encoding=encoding,
     )
 
-def CString(name, terminators=b"\x00", encoding=None,
-            char_field=Field(None, 1)):
+def CString(name: str, terminators: bytes = b"\x00", encoding: str | None = None,
+        char_field: Construct = Field(None, 1)) -> Reconfig:
     r"""
     A string ending in a terminator.
 
@@ -603,7 +622,7 @@ def CString(name, terminators=b"\x00", encoding=None,
 #===============================================================================
 # conditional
 #===============================================================================
-def IfThenElse(name, predicate, then_subcon, else_subcon):
+def IfThenElse(name: str | None, predicate: Callable[[Container], bool], then_subcon: Construct, else_subcon: Construct) -> Switch[bool]:
     """an if-then-else conditional construct: if the predicate indicates True,
     `then_subcon` will be used; otherwise `else_subcon`
     * name - the name of the construct
@@ -619,7 +638,7 @@ def IfThenElse(name, predicate, then_subcon, else_subcon):
         }
     )
 
-def If(predicate, subcon, elsevalue = None):
+def If(predicate: Callable[[Container], bool], subcon: Construct, elsevalue: object | None = None) -> Switch[bool]:
     """an if-then conditional construct: if the predicate indicates True,
     subcon will be used; otherwise, `elsevalue` will be returned instead.
     * predicate - a function taking the context as an argument and returning
@@ -638,7 +657,7 @@ def If(predicate, subcon, elsevalue = None):
 #===============================================================================
 # misc
 #===============================================================================
-def OnDemandPointer(offsetfunc, subcon, force_build = True):
+def OnDemandPointer(offsetfunc: Callable[[Container], int], subcon: Construct, force_build: bool = True) -> OnDemand:
     """an on-demand pointer.
     * offsetfunc - a function taking the context as an argument and returning
       the absolute stream position
@@ -651,5 +670,5 @@ def OnDemandPointer(offsetfunc, subcon, force_build = True):
         force_build = force_build
     )
 
-def Magic(data):
+def Magic(data: bytes) -> ConstAdapter:
     return ConstAdapter(Field(None, len(data)), data)

--- a/elftools/construct/macros.py
+++ b/elftools/construct/macros.py
@@ -477,7 +477,7 @@ def String(name, length, encoding=None, padchar=None, paddir="right",
     :param str encoding: encoding (e.g. "utf8") or None for no encoding
     :param bytes padchar: optional character to pad out strings
     :param str paddir: direction to pad out strings; one of "right", "left",
-                       or "both"
+                       or "center"
     :param str trim: direction to trim strings; one of "right", "left"
 
     >>> from ..construct import String


### PR DESCRIPTION
While working on #514 I took the opportunity to modernize also some old code in #607. But there are several changed related to the internal copy of `construct`. That copy shall be updated by #548, but until then the following changes might be okay:

- Fix the doctest
- Use named arguments instead of kwargs to allow typing them
- Simplify `pyelftools.construct.core.Range`: `mypy` complained about `pos` not being declared in all cases; rewrite the logic.
- Some variables are `const`, except while declaring them.
    - Build `_printable` with a dict-comprehension
    - Same for `char2bin` and `bin2char`
- Rewrite some functions to use generater expressions
