### PR TITLE
Add type hints

### DIFF
--- a/elftools/dwarf/descriptions.py
+++ b/elftools/dwarf/descriptions.py
@@ -27,6 +27,8 @@ if TYPE_CHECKING:
     from .die import AttributeValue
     from .structs import DWARFStructs
 
+    _INT = TypeVar("_INT", bound=int)
+
 
 def set_global_machine_arch(machine_arch: str) -> None:
     global _MACHINE_ARCH
@@ -447,7 +449,7 @@ _DESCR_CFI_REGISTER_RULE_TYPE = dict(
 )
 
 def _make_extra_mapper(
-    mapping,
+    mapping: Mapping[_INT, str],
     default: str,
     default_interpolate_value: bool = False,
 ) -> Callable[[AttributeValue, DIE, int], str]:

--- a/elftools/dwarf/descriptions.py
+++ b/elftools/dwarf/descriptions.py
@@ -9,7 +9,7 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal, overload
 
 from .constants import (
     DW_ACCESS, DW_ATE, DW_CC, DW_CFA, DW_ID, DW_INL, DW_LANG, DW_ORD, DW_VIRTUALITY, DW_VIS,
@@ -168,6 +168,10 @@ def describe_DWARF_expr(expr: Any, structs: DWARFStructs, cu_offset: int | None 
     return '(' + dwarf_expr_dumper.dump_expr(expr, cu_offset) + ')'
 
 
+@overload
+def describe_reg_name(regnum: int, machine_arch: str | None, default: Literal[False]) -> str | None: ...
+@overload
+def describe_reg_name(regnum: int, machine_arch: str | None = ..., default: Literal[True] = ...) -> str: ...
 def describe_reg_name(regnum: int, machine_arch: str | None = None, default: bool = True) -> str | None:
     """ Provide a textual description for a register name, given its serial
         number. The number is expected to be valid.

--- a/elftools/elf/descriptions.py
+++ b/elftools/elf/descriptions.py
@@ -19,6 +19,7 @@ from .enums import (
     ENUM_DT_FLAGS_1, ENUM_RELOC_TYPE_PPC)
 from .constants import (
     P_FLAGS, RH_FLAGS, SH_FLAGS, SUNW_SYMINFO_FLAGS, VER_FLAGS)
+from .dynamic import DynamicSection
 
 if TYPE_CHECKING:
     from collections.abc import Container as TContainer
@@ -55,6 +56,7 @@ def describe_e_type(x: str, elffile: ELFFile | None = None) -> str:
         # Detect whether this is a normal SO or a PIE executable
         dynamic = elffile.get_section_by_name('.dynamic')
         if dynamic:
+            assert isinstance(dynamic, DynamicSection)
             for t in dynamic.iter_tags('DT_FLAGS_1'):
                 if t.entry.d_val & ENUM_DT_FLAGS_1['DF_1_PIE']:
                     return 'DYN (Position-Independent Executable file)'

--- a/elftools/elf/descriptions.py
+++ b/elftools/elf/descriptions.py
@@ -8,7 +8,7 @@
 #-------------------------------------------------------------------------------
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Final
+from typing import TYPE_CHECKING, Any, Final, TypeVar
 
 from .enums import (
     ENUM_D_TAG, ENUM_E_VERSION, ENUM_P_TYPE_BASE, ENUM_SH_TYPE_BASE,
@@ -21,10 +21,14 @@ from .constants import (
     P_FLAGS, RH_FLAGS, SH_FLAGS, SUNW_SYMINFO_FLAGS, VER_FLAGS)
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable
+    from collections.abc import Container as TContainer
+    from collections.abc import Iterable, Mapping
 
     from ..construct.lib.container import Container
     from .elffile import ELFFile
+
+    _K = TypeVar("_K")
+    _V = TypeVar("_V")
 
 
 def describe_ei_class(x: str) -> str:
@@ -705,7 +709,7 @@ _DESCR_NOTE_GNU_PROPERTY_RISCV_FEATURE_1_AND = (
     (2, 'ZICFISS'),
 )
 
-def _reverse_dict(d, low_priority=()):
+def _reverse_dict(d: Mapping[_K, _V], low_priority: TContainer[_K] = ()) -> dict[_V, _K]:
     """
     This is a tiny helper function to "reverse" the keys/values of a dictionary
     provided in the first argument, i.e. {k: v} becomes {v: k}.
@@ -714,7 +718,7 @@ def _reverse_dict(d, low_priority=()):
     the case of conflicting values - if a value is present in this list, it will
     not override any other entries of the same value.
     """
-    out = {}
+    out: dict[_V, _K] = {}
     for k, v in d.items():
         if v in out and k in low_priority:
             continue

--- a/elftools/elf/dynamic.py
+++ b/elftools/elf/dynamic.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import itertools
 from collections import defaultdict
 from functools import cached_property
-from typing import IO, TYPE_CHECKING, Any, TypedDict
+from typing import IO, TYPE_CHECKING, Any, Protocol, TypedDict, cast, runtime_checkable
 
 from ..common.exceptions import ELFError
 from ..common.utils import elf_assert, struct_parse, parse_cstring_from_stream
@@ -33,6 +33,16 @@ class RelocationTables(TypedDict, total=False):
     RELA: RelocationTable
     RELR: RelrRelocationTable
     JMPREL: RelocationTable
+
+
+@runtime_checkable
+class _StringTable(Protocol):
+    """Common base-class of elftools.elf.dynamic._DynamicStringTable and
+    elftools.elf.section.StringTableSection to be consumed by
+    DynamicTag|Dynamic.
+    Requires @runtime_checkable as `assert isinstance(…, _StringTable)` is
+    used."""
+    def get_string(self, offset: int, /) -> str: ...
 
 
 class _DynamicStringTable:
@@ -66,7 +76,7 @@ class DynamicTag:
     def __init__(
         self,
         entry: Container,
-        stringtable,
+        stringtable: _StringTable | None,
     ) -> None:
         if stringtable is None:
             raise ELFError('Creating DynamicTag without string table')
@@ -98,7 +108,7 @@ class Dynamic:
         self,
         stream: IO[bytes],
         elffile: ELFFile,
-        stringtable,
+        stringtable: _StringTable | Section | None,
         position: int,
         empty: bool,
     ) -> None:
@@ -129,7 +139,7 @@ class Dynamic:
         self._empty = empty
 
         # Do not access this directly yourself; use _get_stringtable() instead.
-        self._stringtable = stringtable
+        self._stringtable: _StringTable | Section | None = stringtable
 
     def get_table_offset(self, tag_name: str) -> tuple[int | None, int | None]:
         """ Return the virtual address and file offset of a dynamic table.
@@ -148,13 +158,14 @@ class Dynamic:
 
         return ptr, offset
 
-    def _get_stringtable(self):
+    def _get_stringtable(self) -> _StringTable:
         """ Return a string table for looking up dynamic tag related strings.
 
             This won't be a "full" string table object, but will at least
             support the get_string() function.
         """
         if self._stringtable:
+            assert isinstance(self._stringtable, _StringTable)
             return self._stringtable
 
         # If the ELF has stripped its section table (which is unusual, but
@@ -163,11 +174,13 @@ class Dynamic:
         _, table_offset = self.get_table_offset('DT_STRTAB')
         if table_offset is not None:
             self._stringtable = _DynamicStringTable(self._stream, table_offset)
+            assert isinstance(self._stringtable, _StringTable)
             return self._stringtable
 
         # That didn't work for some reason.  Let's use the section header
         # even though this ELF is super weird.
         self._stringtable = self.elffile.get_section_by_name('.dynstr')
+        assert isinstance(self._stringtable, _StringTable)
         return self._stringtable
 
     def _iter_tags(self, type: str | None = None) -> Iterator[Container]:

--- a/elftools/elf/dynamic.py
+++ b/elftools/elf/dynamic.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import itertools
 from collections import defaultdict
 from functools import cached_property
-from typing import IO, TYPE_CHECKING, Any
+from typing import IO, TYPE_CHECKING, Any, TypedDict
 
 from ..common.exceptions import ELFError
 from ..common.utils import elf_assert, struct_parse, parse_cstring_from_stream
@@ -26,6 +26,13 @@ if TYPE_CHECKING:
 
     from ..construct.lib.container import Container
     from .elffile import ELFFile
+
+
+class RelocationTables(TypedDict, total=False):
+    REL: RelocationTable
+    RELA: RelocationTable
+    RELR: RelrRelocationTable
+    JMPREL: RelocationTable
 
 
 class _DynamicStringTable:
@@ -211,14 +218,14 @@ class Dynamic:
 
         return None
 
-    def get_relocation_tables(self):
+    def get_relocation_tables(self) -> RelocationTables:
         """ Load all available relocation tables from DYNAMIC tags.
 
             Returns a dictionary mapping found table types (REL, RELA,
             RELR, JMPREL) to RelocationTable objects.
         """
 
-        result = {}
+        result: RelocationTables = {}
 
         if list(self.iter_tags('DT_REL')):
             result['REL'] = RelocationTable(self.elffile,

--- a/elftools/elf/dynamic.py
+++ b/elftools/elf/dynamic.py
@@ -317,8 +317,8 @@ class DynamicSegment(Segment, Dynamic):
         # from the corresponding hash table
         _, gnu_hash_offset = self.get_table_offset('DT_GNU_HASH')
         if gnu_hash_offset is not None:
-            hash_section = GNUHashTable(self.elffile, gnu_hash_offset, self)
-            return hash_section.get_number_of_symbols()
+            gnu_hash_section = GNUHashTable(self.elffile, gnu_hash_offset, self)
+            return gnu_hash_section.get_number_of_symbols()
 
         # If DT_GNU_HASH did not exist, maybe we can use DT_HASH
         _, hash_offset = self.get_table_offset('DT_HASH')

--- a/elftools/elf/elffile.py
+++ b/elftools/elf/elffile.py
@@ -114,7 +114,7 @@ class ELFFile:
         return ELFFile(stream, ELFFile.make_relative_loader(os.fsdecode(path)))
 
     @staticmethod
-    def make_relative_loader(base_path) -> Callable[[str], IO[bytes]]:
+    def make_relative_loader(base_path: str) -> Callable[[str], IO[bytes]]:
         """ Return a function that takes a potentially relative path,
             resolves it against base_path (str), and opens a file at that.
 
@@ -126,7 +126,7 @@ class ELFFile:
             raise TypeError('base_path must be str')
         base_directory = os.path.realpath(os.path.dirname(base_path))
 
-        def loader(rel_path) -> IO[bytes]:
+        def loader(rel_path: str) -> IO[bytes]:
             if not isinstance(rel_path, str):
                 raise TypeError('rel_path must be str')
 

--- a/elftools/elf/hash.py
+++ b/elftools/elf/hash.py
@@ -9,7 +9,7 @@
 from __future__ import annotations
 
 import struct
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Protocol
 
 from ..common.utils import struct_parse
 from ..construct.lib.container import Container
@@ -18,6 +18,13 @@ from .sections import Section
 if TYPE_CHECKING:
     from .elffile import ELFFile
     from .sections import Symbol
+
+
+class _SymbolTable(Protocol):
+    """Common base-class of elftools.elf.sections.SymbolTableSection and
+    elftools.elf.dynamic.DynamicSegment to be consumed by
+    (ELF|GNU)Hash(Section|Table)."""
+    def get_symbol(self, index: int, /) -> Symbol | None: ...
 
 
 class ELFHashTable:
@@ -39,7 +46,7 @@ class ELFHashTable:
         elffile: ELFFile,
         start_offset: int,
         size: int | None,
-        symboltable,
+        symboltable: _SymbolTable,
     ) -> None:
         """
         Args:
@@ -108,7 +115,7 @@ class ELFHashSection(Section, ELFHashTable):
         header: Container,
         name: str,
         elffile: ELFFile,
-        symboltable,
+        symboltable: _SymbolTable,
     ) -> None:
         Section.__init__(self, header, name, elffile)
         ELFHashTable.__init__(self, elffile, self['sh_offset'], self['sh_size'], symboltable)
@@ -131,7 +138,7 @@ class GNUHashTable:
         self,
         elffile: ELFFile,
         start_offset: int,
-        symboltable,
+        symboltable: _SymbolTable,
     ) -> None:
         self.elffile = elffile
         self._symboltable = symboltable
@@ -225,7 +232,7 @@ class GNUHashSection(Section, GNUHashTable):
         header: Container,
         name: str,
         elffile: ELFFile,
-        symboltable,
+        symboltable: _SymbolTable,
     ) -> None:
         Section.__init__(self, header, name, elffile)
         GNUHashTable.__init__(self, elffile, self['sh_offset'], symboltable)

--- a/elftools/elf/relocation.py
+++ b/elftools/elf/relocation.py
@@ -9,7 +9,7 @@
 from __future__ import annotations
 
 from functools import cached_property
-from typing import IO, TYPE_CHECKING, Any, Callable, NamedTuple
+from typing import IO, TYPE_CHECKING, Any, NamedTuple, Protocol
 
 from ..common.exceptions import ELFRelocationError
 from ..common.utils import elf_assert, struct_parse
@@ -21,7 +21,7 @@ from .enums import (
 from ..construct import Container
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator
+    from collections.abc import Iterator, Mapping
 
     from .elffile import ELFFile
 
@@ -216,6 +216,10 @@ class RelrRelocationSection(Section, RelrRelocationTable):
             self['sh_offset'], self['sh_size'], self['sh_entsize'])
 
 
+class _RelocationFunction(Protocol):
+    def __call__(self, value: int, sym_value: int, offset: int, addend: int = 0) -> int: ...
+
+
 def _reloc_calc_identity(value: int, sym_value: int, offset: int, addend: int = 0) -> int:
     return value
 
@@ -394,9 +398,9 @@ class RelocationHandler:
     class _RELOCATION_RECIPE_TYPE(NamedTuple):
         bytesize: int
         has_addend: bool
-        calc_func: Callable[..., int]
+        calc_func: _RelocationFunction
 
-    _RELOCATION_RECIPES_ARM = {
+    _RELOCATION_RECIPES_ARM: Mapping[int, _RELOCATION_RECIPE_TYPE] = {
         ENUM_RELOC_TYPE_ARM['R_ARM_ABS32']: _RELOCATION_RECIPE_TYPE(
             bytesize=4, has_addend=False,
             calc_func=_reloc_calc_sym_plus_value),
@@ -405,7 +409,7 @@ class RelocationHandler:
             calc_func=_arm_reloc_calc_sym_plus_value_pcrel),
     }
 
-    _RELOCATION_RECIPES_AARCH64 = {
+    _RELOCATION_RECIPES_AARCH64: Mapping[int, _RELOCATION_RECIPE_TYPE] = {
         ENUM_RELOC_TYPE_AARCH64['R_AARCH64_ABS64']: _RELOCATION_RECIPE_TYPE(
             bytesize=8, has_addend=True, calc_func=_reloc_calc_sym_plus_addend),
         ENUM_RELOC_TYPE_AARCH64['R_AARCH64_ABS32']: _RELOCATION_RECIPE_TYPE(
@@ -416,14 +420,14 @@ class RelocationHandler:
     }
 
     # https://dmz-portal.mips.com/wiki/MIPS_relocation_types
-    _RELOCATION_RECIPES_MIPS_REL = {
+    _RELOCATION_RECIPES_MIPS_REL: Mapping[int, _RELOCATION_RECIPE_TYPE] = {
         ENUM_RELOC_TYPE_MIPS['R_MIPS_NONE']: _RELOCATION_RECIPE_TYPE(
             bytesize=4, has_addend=False, calc_func=_reloc_calc_identity),
         ENUM_RELOC_TYPE_MIPS['R_MIPS_32']: _RELOCATION_RECIPE_TYPE(
             bytesize=4, has_addend=False,
             calc_func=_reloc_calc_sym_plus_value),
     }
-    _RELOCATION_RECIPES_MIPS_RELA = {
+    _RELOCATION_RECIPES_MIPS_RELA: Mapping[int, _RELOCATION_RECIPE_TYPE] = {
         ENUM_RELOC_TYPE_MIPS['R_MIPS_NONE']: _RELOCATION_RECIPE_TYPE(
             bytesize=4, has_addend=True, calc_func=_reloc_calc_identity),
         ENUM_RELOC_TYPE_MIPS['R_MIPS_32']: _RELOCATION_RECIPE_TYPE(
@@ -434,7 +438,7 @@ class RelocationHandler:
             calc_func=_reloc_calc_sym_plus_value),
     }
 
-    _RELOCATION_RECIPES_PPC64 = {
+    _RELOCATION_RECIPES_PPC64: Mapping[int, _RELOCATION_RECIPE_TYPE] = {
         ENUM_RELOC_TYPE_PPC64['R_PPC64_ADDR32']: _RELOCATION_RECIPE_TYPE(
             bytesize=4, has_addend=True, calc_func=_reloc_calc_sym_plus_addend),
         ENUM_RELOC_TYPE_PPC64['R_PPC64_REL32']: _RELOCATION_RECIPE_TYPE(
@@ -443,7 +447,7 @@ class RelocationHandler:
             bytesize=8, has_addend=True, calc_func=_reloc_calc_sym_plus_addend),
     }
 
-    _RELOCATION_RECIPES_X86 = {
+    _RELOCATION_RECIPES_X86: Mapping[int, _RELOCATION_RECIPE_TYPE] = {
         ENUM_RELOC_TYPE_i386['R_386_NONE']: _RELOCATION_RECIPE_TYPE(
             bytesize=4, has_addend=False, calc_func=_reloc_calc_identity),
         ENUM_RELOC_TYPE_i386['R_386_32']: _RELOCATION_RECIPE_TYPE(
@@ -454,7 +458,7 @@ class RelocationHandler:
             calc_func=_reloc_calc_sym_plus_value_pcrel),
     }
 
-    _RELOCATION_RECIPES_X64 = {
+    _RELOCATION_RECIPES_X64: Mapping[int, _RELOCATION_RECIPE_TYPE] = {
         ENUM_RELOC_TYPE_x64['R_X86_64_NONE']: _RELOCATION_RECIPE_TYPE(
             bytesize=8, has_addend=True, calc_func=_reloc_calc_identity),
         ENUM_RELOC_TYPE_x64['R_X86_64_64']: _RELOCATION_RECIPE_TYPE(
@@ -469,7 +473,7 @@ class RelocationHandler:
     }
 
     # https://www.kernel.org/doc/html/latest/bpf/llvm_reloc.html#different-relocation-types
-    _RELOCATION_RECIPES_EBPF = {
+    _RELOCATION_RECIPES_EBPF: Mapping[int, _RELOCATION_RECIPE_TYPE] = {
         ENUM_RELOC_TYPE_BPF['R_BPF_NONE']: _RELOCATION_RECIPE_TYPE(
             bytesize=8, has_addend=False, calc_func=_reloc_calc_identity),
         ENUM_RELOC_TYPE_BPF['R_BPF_64_64']: _RELOCATION_RECIPE_TYPE(
@@ -485,7 +489,7 @@ class RelocationHandler:
     }
 
     # https://github.com/loongson/la-abi-specs/blob/release/laelf.adoc
-    _RELOCATION_RECIPES_LOONGARCH = {
+    _RELOCATION_RECIPES_LOONGARCH: Mapping[int, _RELOCATION_RECIPE_TYPE] = {
         ENUM_RELOC_TYPE_LOONGARCH['R_LARCH_NONE']: _RELOCATION_RECIPE_TYPE(
             bytesize=4, has_addend=False, calc_func=_reloc_calc_identity),
         ENUM_RELOC_TYPE_LOONGARCH['R_LARCH_32']: _RELOCATION_RECIPE_TYPE(
@@ -526,7 +530,7 @@ class RelocationHandler:
             calc_func=_reloc_calc_sym_plus_addend_pcrel),
     }
 
-    _RELOCATION_RECIPES_S390X = {
+    _RELOCATION_RECIPES_S390X: Mapping[int, _RELOCATION_RECIPE_TYPE] = {
         ENUM_RELOC_TYPE_S390X['R_390_32']: _RELOCATION_RECIPE_TYPE(
             bytesize=4, has_addend=True, calc_func=_reloc_calc_sym_plus_addend),
         ENUM_RELOC_TYPE_S390X['R_390_PC32']: _RELOCATION_RECIPE_TYPE(

--- a/elftools/elf/relocation.py
+++ b/elftools/elf/relocation.py
@@ -171,6 +171,7 @@ class RelrRelocationTable:
             else:
                 # We're processing a bitmap.
                 elf_assert(base is not None, 'RELR bitmap without base address')
+                assert base is not None
                 i = 0
                 while True:
                     # Iterate over all bits except the least significant one.

--- a/elftools/elf/sections.py
+++ b/elftools/elf/sections.py
@@ -17,11 +17,11 @@ from ..common.utils import struct_parse, elf_assert, parse_cstring_from_stream
 from collections import defaultdict
 from .constants import SH_FLAGS
 from .notes import iter_notes
+from elftools.construct.lib.container import Container
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
 
-    from ..construct.lib.container import Container
     from .elffile import ELFFile
     from .structs import ELFStructs
 
@@ -333,6 +333,8 @@ class StabSection(Section):
 class Attribute:
     """ Attribute object - representing a build attribute of ELF files.
     """
+    if TYPE_CHECKING:
+        value: Any
 
     def __init__(self, structs: ELFStructs, stream: IO[bytes]) -> None:
         self._tag = self._parse(structs, stream)
@@ -356,12 +358,14 @@ class Attribute:
 class AttributesSubsubsection(Section):
     """ Subsubsection of an ELF attribute section's subsection.
     """
+    attribute: type[Attribute]
+
     def __init__(self, stream: IO[bytes], structs: ELFStructs, offset: int) -> None:
         self.stream = stream
         self.offset = offset
         self.structs = structs
 
-        self.header = self.attribute(self.structs, self.stream)
+        self.header: Attribute = self.attribute(self.structs, self.stream)  # type: ignore[assignment]
 
         self.attr_start = self.stream.tell()
 
@@ -411,7 +415,7 @@ class AttributesSubsection(Section):
         self.offset = offset
         self.structs = structs
 
-        self.header = struct_parse(structs.Elf_Attr_Subsection_Header, self.stream, self.offset)
+        self.header: Container = struct_parse(structs.Elf_Attr_Subsection_Header, self.stream, self.offset)
 
         self.subsubsec_start = self.stream.tell()
 

--- a/elftools/elf/sections.py
+++ b/elftools/elf/sections.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import zlib
 from functools import cached_property
-from typing import IO, TYPE_CHECKING, Any
+from typing import IO, TYPE_CHECKING, Any, Literal, overload
 
 from ..common.exceptions import ELFCompressionError
 from ..common.utils import struct_parse, elf_assert, parse_cstring_from_stream
@@ -126,6 +126,12 @@ class Section:
         """
         return False
 
+    @overload
+    def __getitem__(self, name: Literal["sh_addr", "sh_entsize", "sh_flags", "sh_offset", "sh_size"]) -> int: ...
+    @overload
+    def __getitem__(self, name: Literal["st_name", "sh_type"]) -> str: ...
+    @overload
+    def __getitem__(self, name: str) -> Any: ...
     def __getitem__(self, name: str) -> Any:
         """ Implement dict-like access to header entries
         """

--- a/elftools/elf/segments.py
+++ b/elftools/elf/segments.py
@@ -8,7 +8,7 @@
 #-------------------------------------------------------------------------------
 from __future__ import annotations
 
-from typing import IO, TYPE_CHECKING, Any
+from typing import IO, TYPE_CHECKING, Any, Literal, overload
 
 from ..construct import CString
 from ..common.utils import struct_parse
@@ -34,6 +34,12 @@ class Segment:
         self.stream.seek(self['p_offset'])
         return self.stream.read(self['p_filesz'])
 
+    @overload
+    def __getitem__(self, name: Literal["p_filesz", "p_memsz", "p_offset", "p_vaddr"]) -> int: ...
+    @overload
+    def __getitem__(self, name: Literal["p_type"]) -> str: ...
+    @overload
+    def __getitem__(self, name: str) -> Any: ...
     def __getitem__(self, name: str) -> Any:
         """ Implement dict-like access to header entries
         """

--- a/test/test_debuglink.py
+++ b/test/test_debuglink.py
@@ -14,6 +14,12 @@ from typing import IO
 from elftools.common.exceptions import ELFError
 from elftools.elf.elffile import ELFFile
 
+try:
+    from typeguard import suppress_type_checks
+except ImportError:
+    def suppress_type_checks(f):  # type: ignore[no-redef]
+        return f
+
 
 class TestDebuglink(unittest.TestCase):
     """ This test verifies that the .gnu_debuglink section is followed and parsed correctly.
@@ -113,6 +119,7 @@ class TestDebuglink(unittest.TestCase):
             with self.assertRaisesRegex(ELFError, 'must be relative'):
                 loader(os.path.abspath(os.path.join(tmpdir, 'outside.debug')))
 
+    @suppress_type_checks
     def test_relative_loader_rejects_bytes_paths(self):
         with self.assertRaisesRegex(TypeError, 'base_path must be str'):
             ELFFile.make_relative_loader(b'sample.elf')

--- a/test/test_hash.py
+++ b/test/test_hash.py
@@ -5,10 +5,11 @@
 # This code is in the public domain
 #-------------------------------------------------------------------------------
 import unittest
+import unittest.mock
 import os
 
 from elftools.elf.elffile import ELFFile
-from elftools.elf.hash import ELFHashTable, GNUHashTable
+from elftools.elf.hash import ELFHashTable, GNUHashTable, _SymbolTable
 
 class TestELFHash(unittest.TestCase):
     """ Tests for the ELF hash table.
@@ -61,8 +62,8 @@ class TestELFHash(unittest.TestCase):
     def test_empty_table_without_header(self):
         """ Verify we can handle an empty (0 byte) ELF hash section.
         """
-        elffile = None
-        symboltable = None
+        elffile = unittest.mock.MagicMock(ELFFile)
+        symboltable = unittest.mock.MagicMock(_SymbolTable)
         empty_hash_section = ELFHashTable(elffile, 0, 0, symboltable)
         self.assertEqual(empty_hash_section.get_number_of_symbols(), 0)
         self.assertEqual(empty_hash_section.params['nbuckets'], 0)


### PR DESCRIPTION
This is the mayor PR to add Python type hints #514 – without #609 this will not be complete as `elftools.construct.Container` is used in many places, which is a container for `Any`thing: retrieving values from it will be typed `Any`, which basically means _untyped_: without manually type-hinting every such use case those values do propagate further and even spill into the public API.

Because of missing 6f99ce09ddf25ce80422f388b7690e6323ccb89f  running `mypy` will find the following errors:
```
elftools/dwarf/structs.py:581: error: "Container" has no attribute "first"  [attr-defined]
elftools/dwarf/structs.py:583: error: "Container" has no attribute "first"  [attr-defined]
elftools/dwarf/structs.py:585: error: "Container" has no attribute "first"  [attr-defined]
elftools/dwarf/structs.py:587: error: "Container" has no attribute "second"  [attr-defined]
elftools/dwarf/structs.py:590: error: "Container" has no attribute "first"  [attr-defined]
elftools/dwarf/callframe.py:99: error: "Container" has no attribute "length"  [attr-defined]
elftools/dwarf/ranges.py:41: error: "Container" has no attribute "start_index"  [attr-defined]
elftools/dwarf/ranges.py:42: error: "Container" has no attribute "entry_offset"  [attr-defined]
elftools/dwarf/ranges.py:42: error: "Container" has no attribute "entry_length"  [attr-defined]
elftools/dwarf/ranges.py:42: error: "Container" has no attribute "length"  [attr-defined]
elftools/dwarf/ranges.py:46: error: "Container" has no attribute "entry_offset"  [attr-defined]
elftools/dwarf/ranges.py:46: error: "Container" has no attribute "address"  [attr-defined]
elftools/dwarf/ranges.py:47: error: "Container" has no attribute "entry_offset"  [attr-defined]
elftools/dwarf/ranges.py:47: error: "Container" has no attribute "entry_length"  [attr-defined]
elftools/dwarf/ranges.py:47: error: "Container" has no attribute "start_offset"  [attr-defined]
elftools/dwarf/ranges.py:47: error: "Container" has no attribute "end_offset"  [attr-defined]
elftools/dwarf/ranges.py:48: error: "Container" has no attribute "entry_offset"  [attr-defined]
elftools/dwarf/ranges.py:48: error: "Container" has no attribute "entry_length"  [attr-defined]
elftools/dwarf/ranges.py:48: error: "Container" has no attribute "start_address"  [attr-defined]
elftools/dwarf/ranges.py:48: error: "Container" has no attribute "end_address"  [attr-defined]
elftools/dwarf/ranges.py:49: error: "Container" has no attribute "entry_offset"  [attr-defined]
elftools/dwarf/ranges.py:49: error: "Container" has no attribute "entry_length"  [attr-defined]
elftools/dwarf/ranges.py:49: error: "Container" has no attribute "start_address"  [attr-defined]
elftools/dwarf/ranges.py:49: error: "Container" has no attribute "length"  [attr-defined]
elftools/dwarf/ranges.py:50: error: "Container" has no attribute "entry_offset"  [attr-defined]
elftools/dwarf/ranges.py:50: error: "Container" has no attribute "index"  [attr-defined]
elftools/dwarf/ranges.py:51: error: "Container" has no attribute "entry_offset"  [attr-defined]
elftools/dwarf/ranges.py:51: error: "Container" has no attribute "entry_length"  [attr-defined]
elftools/dwarf/ranges.py:51: error: "Container" has no attribute "start_index"  [attr-defined]
elftools/dwarf/ranges.py:51: error: "Container" has no attribute "end_index"  [attr-defined]
elftools/dwarf/ranges.py:70: error: "Container" has no attribute "version"  [attr-defined]
elftools/dwarf/ranges.py:180: error: "Container" has no attribute "offset_table_offset"  [attr-defined]
elftools/dwarf/ranges.py:180: error: "Container" has no attribute "is64"  [attr-defined]
elftools/dwarf/ranges.py:180: error: "Container" has no attribute "offset_count"  [attr-defined]
elftools/dwarf/ranges.py:181: error: "Container" has no attribute "offset_after_length"  [attr-defined]
elftools/dwarf/ranges.py:181: error: "Container" has no attribute "unit_length"  [attr-defined]
elftools/dwarf/ranges.py:188: error: "Container" has no attribute "entry_type"  [attr-defined]
elftools/dwarf/locationlists.py:53: error: "Container" has no attribute "start_index"  [attr-defined]
elftools/dwarf/locationlists.py:54: error: "Container" has no attribute "entry_offset"  [attr-defined]
elftools/dwarf/locationlists.py:54: error: "Container" has no attribute "entry_length"  [attr-defined]
elftools/dwarf/locationlists.py:54: error: "Container" has no attribute "length"  [attr-defined]
elftools/dwarf/locationlists.py:54: error: "Container" has no attribute "loc_expr"  [attr-defined]
elftools/dwarf/locationlists.py:58: error: "Container" has no attribute "entry_offset"  [attr-defined]
elftools/dwarf/locationlists.py:58: error: "Container" has no attribute "entry_length"  [attr-defined]
elftools/dwarf/locationlists.py:58: error: "Container" has no attribute "address"  [attr-defined]
elftools/dwarf/locationlists.py:59: error: "Container" has no attribute "entry_offset"  [attr-defined]
elftools/dwarf/locationlists.py:59: error: "Container" has no attribute "entry_length"  [attr-defined]
elftools/dwarf/locationlists.py:59: error: "Container" has no attribute "start_offset"  [attr-defined]
elftools/dwarf/locationlists.py:59: error: "Container" has no attribute "end_offset"  [attr-defined]
elftools/dwarf/locationlists.py:59: error: "Container" has no attribute "loc_expr"  [attr-defined]
elftools/dwarf/locationlists.py:60: error: "Container" has no attribute "entry_offset"  [attr-defined]
elftools/dwarf/locationlists.py:60: error: "Container" has no attribute "entry_length"  [attr-defined]
elftools/dwarf/locationlists.py:60: error: "Container" has no attribute "start_address"  [attr-defined]
elftools/dwarf/locationlists.py:60: error: "Container" has no attribute "length"  [attr-defined]
elftools/dwarf/locationlists.py:60: error: "Container" has no attribute "loc_expr"  [attr-defined]
elftools/dwarf/locationlists.py:61: error: "Container" has no attribute "entry_offset"  [attr-defined]
elftools/dwarf/locationlists.py:61: error: "Container" has no attribute "entry_length"  [attr-defined]
elftools/dwarf/locationlists.py:61: error: "Container" has no attribute "start_address"  [attr-defined]
elftools/dwarf/locationlists.py:61: error: "Container" has no attribute "end_address"  [attr-defined]
elftools/dwarf/locationlists.py:61: error: "Container" has no attribute "loc_expr"  [attr-defined]
elftools/dwarf/locationlists.py:62: error: "Container" has no attribute "entry_offset"  [attr-defined]
elftools/dwarf/locationlists.py:62: error: "Container" has no attribute "entry_length"  [attr-defined]
elftools/dwarf/locationlists.py:62: error: "Container" has no attribute "loc_expr"  [attr-defined]
elftools/dwarf/locationlists.py:63: error: "Container" has no attribute "entry_offset"  [attr-defined]
elftools/dwarf/locationlists.py:63: error: "Container" has no attribute "entry_length"  [attr-defined]
elftools/dwarf/locationlists.py:63: error: "Container" has no attribute "index"  [attr-defined]
elftools/dwarf/locationlists.py:64: error: "Container" has no attribute "entry_offset"  [attr-defined]
elftools/dwarf/locationlists.py:64: error: "Container" has no attribute "entry_length"  [attr-defined]
elftools/dwarf/locationlists.py:64: error: "Container" has no attribute "start_index"  [attr-defined]
elftools/dwarf/locationlists.py:64: error: "Container" has no attribute "end_index"  [attr-defined]
elftools/dwarf/locationlists.py:64: error: "Container" has no attribute "loc_expr"  [attr-defined]
elftools/dwarf/locationlists.py:81: error: "Container" has no attribute "version"  [attr-defined]
elftools/dwarf/locationlists.py:222: error: "Container" has no attribute "version"  [attr-defined]
elftools/dwarf/locationlists.py:286: error: "Container" has no attribute "entry_offset"  [attr-defined]
elftools/dwarf/locationlists.py:287: error: "Container" has no attribute "entry_end_offset"  [attr-defined]
elftools/dwarf/locationlists.py:288: error: "Container" has no attribute "entry_type"  [attr-defined]
elftools/dwarf/locationlists.py:290: error: "Container" has no attribute "address"  [attr-defined]
elftools/dwarf/locationlists.py:292: error: "Container" has no attribute "start_offset"  [attr-defined]
elftools/dwarf/locationlists.py:292: error: "Container" has no attribute "end_offset"  [attr-defined]
elftools/dwarf/locationlists.py:292: error: "Container" has no attribute "loc_expr"  [attr-defined]
elftools/dwarf/locationlists.py:294: error: "Container" has no attribute "start_address"  [attr-defined]
elftools/dwarf/locationlists.py:294: error: "Container" has no attribute "length"  [attr-defined]
elftools/dwarf/locationlists.py:294: error: "Container" has no attribute "loc_expr"  [attr-defined]
elftools/dwarf/locationlists.py:296: error: "Container" has no attribute "start_address"  [attr-defined]
elftools/dwarf/locationlists.py:296: error: "Container" has no attribute "end_address"  [attr-defined]
elftools/dwarf/locationlists.py:296: error: "Container" has no attribute "loc_expr"  [attr-defined]
elftools/dwarf/locationlists.py:298: error: "Container" has no attribute "loc_expr"  [attr-defined]
elftools/dwarf/dwarfinfo.py:478: error: "Container" has no attribute "address_size"  [attr-defined]
elftools/elf/structs.py:429: error: "Container" has no attribute "pr_datasz"  [attr-defined]
elftools/elf/structs.py:430: error: "Container" has no attribute "pr_datasz"  [attr-defined]
elftools/elf/structs.py:433: error: "Container" has no attribute "pr_type"  [attr-defined]
elftools/elf/structs.py:435: error: "Container" has no attribute "pr_type"  [attr-defined]
elftools/elf/structs.py:437: error: "Container" has no attribute "pr_type"  [attr-defined]
elftools/elf/structs.py:439: error: "Container" has no attribute "pr_type"  [attr-defined]
elftools/elf/structs.py:441: error: "Container" has no attribute "pr_type"  [attr-defined]
elftools/elf/structs.py:441: error: "Container" has no attribute "pr_datasz"  [attr-defined]
elftools/elf/notes.py:71: error: "Container" has no attribute "pr_datasz"  [attr-defined]
elftools/elf/dynamic.py:67: error: "Container" has no attribute "d_tag"  [attr-defined]
elftools/elf/dynamic.py:68: error: "Container" has no attribute "d_tag"  [attr-defined]
elftools/elf/dynamic.py:69: error: "Container" has no attribute "d_val"  [attr-defined]
elftools/elf/dynamic.py:77: error: "Container" has no attribute "d_tag"  [attr-defined]
elftools/elf/dynamic.py:80: error: "Container" has no attribute "d_tag"  [attr-defined]
elftools/elf/dynamic.py:81: error: "Container" has no attribute "d_tag"  [attr-defined]
elftools/elf/dynamic.py:83: error: "Container" has no attribute "d_ptr"  [attr-defined]
elftools/elf/dynamic.py:84: error: "Container" has no attribute "d_tag"  [attr-defined]
elftools/elf/dynamic.py:203: error: "Container" has no attribute "d_tag"  [attr-defined]
elftools/elf/elffile.py:152: error: "Container" has no attribute "sh_type"  [attr-defined]
elftools/elf/elffile.py:306: error: "Container" has no attribute "sh_offset"  [attr-defined]
elftools/elf/elffile.py:397: error: "Container" has no attribute "sh_offset"  [attr-defined]
elftools/elf/descriptions.py:59: error: "Container" has no attribute "d_val"  [attr-defined]
elftools/elf/descriptions.py:300: error: "Container" has no attribute "pr_type"  [attr-defined]
elftools/elf/descriptions.py:301: error: "Container" has no attribute "pr_data"  [attr-defined]
elftools/elf/descriptions.py:302: error: "Container" has no attribute "pr_datasz"  [attr-defined]
```
Similar missing db4fb21cd6040f1cca70ddc4a3fd5e42996f3f0b is responsible for
```
elftools/elf/enums.py:37: error: Dict entry 2 has incompatible type "str": "type[Pass]"; expected "str": "int"  [dict-item]
elftools/elf/enums.py:64: error: Dict entry 22 has incompatible type "str": "type[Pass]"; expected "str": "int"  [dict-item]
elftools/elf/enums.py:76: error: Dict entry 7 has incompatible type "str": "type[Pass]"; expected "str": "int"  [dict-item]
elftools/elf/enums.py:278: error: Dict entry 187 has incompatible type "str": "type[Pass]"; expected "str": "int"  [dict-item]
elftools/elf/enums.py:324: error: Dict entry 30 has incompatible type "str": "type[Pass]"; expected "str": "int"  [dict-item]
elftools/elf/enums.py:393: error: Dict entry 5 has incompatible type "str": "type[Pass]"; expected "str": "int"  [dict-item]
elftools/elf/enums.py:421: error: Dict entry 14 has incompatible type "str": "type[Pass]"; expected "str": "int"  [dict-item]
elftools/elf/enums.py:454: error: Dict entry 8 has incompatible type "str": "type[Pass]"; expected "str": "int"  [dict-item]
elftools/elf/enums.py:473: error: Dict entry 14 has incompatible type "str": "type[Pass]"; expected "str": "int"  [dict-item]
elftools/elf/enums.py:485: error: Dict entry 7 has incompatible type "str": "type[Pass]"; expected "str": "int"  [dict-item]
elftools/elf/enums.py:489: error: Dict entry 0 has incompatible type "str": "type[Pass]"; expected "str": "int"  [dict-item]
elftools/elf/enums.py:497: error: Dict entry 3 has incompatible type "str": "type[Pass]"; expected "str": "int"  [dict-item]
elftools/elf/enums.py:585: error: Dict entry 83 has incompatible type "str": "type[Pass]"; expected "str": "int"  [dict-item]
elftools/elf/enums.py:748: error: Dict entry 51 has incompatible type "str": "type[Pass]"; expected "str": "int"  [dict-item]
elftools/elf/enums.py:795: error: Dict entry 43 has incompatible type "str": "type[Pass]"; expected "str": "int"  [dict-item]
elftools/elf/enums.py:838: error: Dict entry 39 has incompatible type "str": "type[Pass]"; expected "str": "int"  [dict-item]
elftools/elf/enums.py:848: error: Dict entry 6 has incompatible type "str": "type[Pass]"; expected "str": "int"  [dict-item]
elftools/elf/enums.py:951: error: Dict entry 98 has incompatible type "str": "type[Pass]"; expected "str": "int"  [dict-item]
elftools/elf/enums.py:1023: error: Dict entry 4 has incompatible type "str": "type[Pass]"; expected "str": "int"  [dict-item]
elftools/elf/enums.py:1042: error: Dict entry 5 has incompatible type "str": "type[Pass]"; expected "str": "int"  [dict-item]
elftools/elf/enums.py:1054: error: Dict entry 7 has incompatible type "str": "type[Pass]"; expected "str": "int"  [dict-item]
elftools/elf/enums.py:1065: error: Dict entry 6 has incompatible type "str": "type[Pass]"; expected "str": "int"  [dict-item]
elftools/elf/enums.py:1077: error: Dict entry 7 has incompatible type "str": "type[Pass]"; expected "str": "int"  [dict-item]
elftools/elf/enums.py:1085: error: Dict entry 4 has incompatible type "str": "type[Pass]"; expected "str": "int"  [dict-item]
```
These I do not know how to fix - their type is not static and depends dynamically on the opened ELF file:
```
elftools/dwarf/ranges.py:50: error: Cannot determine type of "dwarfinfo"  [has-type]
elftools/dwarf/ranges.py:51: error: Cannot determine type of "dwarfinfo"  [has-type]
elftools/dwarf/locationlists.py:63: error: Cannot determine type of "dwarfinfo"  [has-type]
elftools/dwarf/locationlists.py:64: error: Cannot determine type of "dwarfinfo"  [has-type]
elftools/elf/notes.py:25: error: Cannot determine type of "structs"  [has-type]
elftools/elf/notes.py:30: error: Cannot determine type of "structs"  [has-type]
elftools/elf/notes.py:48: error: Cannot determine type of "structs"  [has-type]
elftools/elf/notes.py:56: error: Cannot determine type of "structs"  [has-type]
elftools/elf/notes.py:60: error: Cannot determine type of "structs"  [has-type]
elftools/elf/notes.py:70: error: Cannot determine type of "structs"  [has-type]
elftools/elf/sections.py:42: error: Cannot determine type of "structs"  [has-type]
elftools/elf/sections.py:180: error: Cannot determine type of "structs"  [has-type]
elftools/elf/relocation.py:63: error: Cannot determine type of "structs"  [has-type]
elftools/elf/relocation.py:131: error: Cannot determine type of "structs"  [has-type]
elftools/elf/relocation.py:185: error: Cannot determine type of "structs"  [has-type]
elftools/elf/relocation.py:345: error: Cannot determine type of "structs"  [has-type]
elftools/elf/relocation.py:347: error: Cannot determine type of "structs"  [has-type]
elftools/elf/relocation.py:349: error: Cannot determine type of "structs"  [has-type]
elftools/elf/relocation.py:351: error: Cannot determine type of "structs"  [has-type]
elftools/elf/hash.py:49: error: Cannot determine type of "structs"  [has-type]
elftools/elf/hash.py:115: error: Cannot determine type of "structs"  [has-type]
elftools/elf/hash.py:120: error: Cannot determine type of "structs"  [has-type]
elftools/elf/hash.py:121: error: Cannot determine type of "structs"  [has-type]
elftools/elf/gnuversions.py:153: error: Cannot determine type of "structs"  [has-type]
elftools/elf/gnuversions.py:196: error: Cannot determine type of "structs"  [has-type]
elftools/elf/dynamic.py:110: error: Cannot determine type of "structs"  [has-type]
```
And finally the last group of issues, which are also caused by missing cc7b1eaa277fd:
```
elftools/dwarf/structs.py:413: error: Unused "type: ignore" comment  [unused-ignore]
elftools/common/utils.py:41: error: "FormatField" expects no type arguments, but 1 given  [type-arg]
elftools/common/utils.py:41: error: A function returning TypeVar should receive at least one argument containing the same TypeVar  [type-var]
elftools/elf/structs.py:54: error: "FormatField" expects no type arguments, but 1 given  [type-arg]
elftools/elf/structs.py:55: error: "FormatField" expects no type arguments, but 1 given  [type-arg]
elftools/elf/structs.py:56: error: "FormatField" expects no type arguments, but 1 given  [type-arg]
elftools/elf/structs.py:57: error: "FormatField" expects no type arguments, but 1 given  [type-arg]
elftools/elf/structs.py:58: error: "FormatField" expects no type arguments, but 1 given  [type-arg]
elftools/elf/structs.py:59: error: "FormatField" expects no type arguments, but 1 given  [type-arg]
elftools/elf/structs.py:60: error: "FormatField" expects no type arguments, but 1 given  [type-arg]
elftools/elf/structs.py:61: error: "FormatField" expects no type arguments, but 1 given  [type-arg]
elftools/elf/structs.py:62: error: "FormatField" expects no type arguments, but 1 given  [type-arg]
elftools/dwarf/descriptions.py:93: error: Incompatible types in string interpolation (expression has type "int | None", placeholder has type "int")  [str-format]
elftools/dwarf/descriptions.py:135: error: Incompatible types in string interpolation (expression has type "ListContainer", placeholder has type "int | float | SupportsInt")  [str-format]
elftools/dwarf/descriptions.py:135: error: Incompatible types in string interpolation (expression has type "None", placeholder has type "int | float | SupportsInt")  [str-format]
elftools/dwarf/descriptions.py:149: error: Incompatible types in string interpolation (expression has type "int | None", placeholder has type "int | float | SupportsInt")  [str-format]
elftools/ehabi/ehabiinfo.py:58: error: Incompatible types in string interpolation (expression has type "int | None", placeholder has type "int | float | SupportsInt")  [str-format]
elftools/ehabi/ehabiinfo.py:164: error: Incompatible types in string interpolation (expression has type "int | None", placeholder has type "int")  [str-format]
elftools/ehabi/ehabiinfo.py:164: error: Incompatible types in string interpolation (expression has type "int | None", placeholder has type "int | float | SupportsInt")  [str-format]
elftools/ehabi/ehabiinfo.py:193: error: Incompatible types in string interpolation (expression has type "None", placeholder has type "int")  [str-format]
elftools/ehabi/ehabiinfo.py:204: error: Incompatible types in string interpolation (expression has type "int | None", placeholder has type "int")  [str-format]
elftools/elf/sections.py:106: error: Incompatible types in string interpolation (expression has type "str", placeholder has type "int")  [str-format]
elftools/elf/descriptions.py:349: error: Incompatible types in string interpolation (expression has type "str | int", placeholder has type "int")  [str-format]
```

Please have a 1st look.

Then we can decide on how to proceed, e.g. just merge it or try to extract a subset for only some public API files.