### PR TITLE
pyproject: Fix py.typed marker

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ platforms = [
 version = {attr = "elftools.__version__"}
 
 [tool.setuptools.package-data]
-elftools = ["py.types"]
+elftools = ["py.typed"]
 
 [tool.mypy]
 error_summary = false


### PR DESCRIPTION
Fix wrongly named marker `py.type{s -> d}`.

Fixes: 88fa75cce3c2 ("Convert to pyproject.toml (#606)")