### PR TITLE
Handle hash sections with length 0

### DIFF
--- a/elftools/elf/dynamic.py
+++ b/elftools/elf/dynamic.py
@@ -280,7 +280,7 @@ class DynamicSegment(Segment, Dynamic):
             _, hash_offset = self.get_table_offset('DT_HASH')
             if hash_offset is not None:
                 # Get the hash table from the DT_HASH offset
-                hash_section = ELFHashTable(self.elffile, hash_offset, self)
+                hash_section = ELFHashTable(self.elffile, hash_offset, None, self)
                 self._num_symbols = hash_section.get_number_of_symbols()
 
         if self._num_symbols is None:

--- a/test/test_hash.py
+++ b/test/test_hash.py
@@ -41,7 +41,7 @@ class TestELFHash(unittest.TestCase):
 
             _, hash_offset = dynamic_segment.get_table_offset('DT_HASH')
 
-            hash_section = ELFHashTable(elf, hash_offset, dynamic_segment)
+            hash_section = ELFHashTable(elf, hash_offset, None, dynamic_segment)
             self.assertIsNotNone(hash_section)
             self.assertEqual(hash_section.get_number_of_symbols(), 4)
 
@@ -57,6 +57,15 @@ class TestELFHash(unittest.TestCase):
             symbol_main = hash_section.get_symbol('main')
             self.assertIsNotNone(symbol_main)
             self.assertEqual(symbol_main['st_value'], 0x400790)
+
+    def test_empty_table_without_header(self):
+        """ Verify we can handle an empty (0 byte) ELF hash section.
+        """
+        elffile = None
+        symboltable = None
+        empty_hash_section = ELFHashTable(elffile, 0, 0, symboltable)
+        self.assertEqual(empty_hash_section.get_number_of_symbols(), 0)
+        self.assertEqual(empty_hash_section.params['nbuckets'], 0)
 
 
 class TestGNUHash(unittest.TestCase):


### PR DESCRIPTION
When parsing an ELF file with an empty hash section (length 0), an exception is raised in the ELFHashTable constructor while trying to parse the struct.
This is fixed by checking if the section is empty before creating the ELFHashSection object. Note that this still leaves room for failure if the section is e.g. 1 byte long, but such malformed files should just raise an exception.