### PR TITLE
Limit compilation units cache size

### DIFF
--- a/elftools/dwarf/dwarfinfo.py
+++ b/elftools/dwarf/dwarfinfo.py
@@ -82,7 +82,8 @@ class DWARFInfo:
             debug_rnglists_sec,
             debug_sup_sec,
             gnu_debugaltlink_sec,
-            debug_types_sec
+            debug_types_sec,
+            max_cu_cache_size = -1
             ):
         """ config:
                 A DwarfConfig object
@@ -91,6 +92,9 @@ class DWARFInfo:
                 DebugSectionDescriptor for a section. Pass None for sections
                 that don't exist. These arguments are best given with
                 keyword syntax.
+            
+            max_cu_cache_size:
+                Enforces a limit on CU cache size, For unlimitted  cache size set to -1
         """
         self.config = config
         self.debug_info_sec = debug_info_sec
@@ -113,6 +117,8 @@ class DWARFInfo:
         self.gnu_debugaltlink_sec = gnu_debugaltlink_sec
         self.debug_types_sec = debug_types_sec
 
+        self.max_cu_cache_size = max_cu_cache_size
+        
         # Sets the supplementary_dwarfinfo to None. Client code can set this
         # to something else, typically a DWARFInfo file read from an ELFFile
         # which path is stored in the debug_sup_sec or gnu_debugaltlink_sec.
@@ -547,6 +553,12 @@ class DWARFInfo:
         # bisect_right search while the parallel indexed ._cu_cache[] holds
         # the object references.
         cu = self._parse_CU_at_offset(offset)
+
+        # max_cu_cache_size of -1 makes cache size unlimited
+        if self.max_cu_cache_size != -1 and len(self._cu_cache) > self.max_cu_cache_size:
+            self._cu_offsets_map.pop(0)
+            self._cu_cache.pop(0) 
+        
         self._cu_offsets_map.insert(i, offset)
         self._cu_cache.insert(i, cu)
         return cu

--- a/elftools/elf/elffile.py
+++ b/elftools/elf/elffile.py
@@ -261,7 +261,7 @@ class ELFFile:
             self.has_section('.zdebug_info') or
             (not strict and self.has_section('.eh_frame')))
 
-    def get_dwarf_info(self, relocate_dwarf_sections=True, follow_links=True):
+    def get_dwarf_info(self, relocate_dwarf_sections=True, follow_links=True, max_cu_cache_size = -1):
         """ Return a DWARFInfo object representing the debugging information in
             this file.
 
@@ -355,7 +355,8 @@ class ELFFile:
                 debug_rnglists_sec=debug_sections[debug_rnglists_sec_name],
                 debug_sup_sec=debug_sections[debug_sup_name],
                 gnu_debugaltlink_sec=debug_sections[gnu_debugaltlink_name],
-                debug_types_sec=debug_sections[debug_types_sec_name]
+                debug_types_sec=debug_sections[debug_types_sec_name],
+                max_cu_cache_size = max_cu_cache_size
                 )
         if follow_links:
             dwarfinfo.supplementary_dwarfinfo = self.get_supplementary_dwarfinfo(dwarfinfo)


### PR DESCRIPTION
# Issue:
Iterated CUs (along side with each CU's DIEs cache) are kept in cache as long as DARWF object is alive, While cache can be useful for hitting DIEs shared be CUs and other use cases

A simple loop over CUs and their DIEs keeps all DIEs of ELF stored in memory until DWARF object is no longer referenced.
For a big ELF file ours is ~100 MBs this causes all DIEs of all CUs to stay in memory while we only need to parse DIEs of current CU and then we no longer need to keep those DIE in memory leading to memory leak as we will never use those DIEs on previous CUs (except for interleaved DIE case).

This leads to excessive memory usage it reaches 7 GBs, We parse 5 files in parallel this leads to 35 GBs memory usage

# Fix:

Add possibly to set max cache size on cached CU, Purge Chace FIFO on reaching max size
Kept behavior same as before cache size is unlimited

# Results:
Reduced memory usage by 90%

Memory usage for our 100MB ELF file 
  #### Before: 4GB
<img width="806" height="160" alt="image" src="https://github.com/user-attachments/assets/4a472ee1-8cd9-4d3b-bcc3-df7594b2e75b" />

  #### After: 350 MBs
<img width="467" height="146" alt="image" src="https://github.com/user-attachments/assets/84b1e194-eba2-4b6d-a48a-5a2721733cde" />

  #### Used test case:
<img width="445" height="344" alt="image" src="https://github.com/user-attachments/assets/0618bd46-2791-4d24-a05c-22755c4b6c8d" />

