### PR TITLE
Support for DW_FORM_strx

### DIFF
--- a/elftools/dwarf/structs.py
+++ b/elftools/dwarf/structs.py
@@ -299,6 +299,7 @@ class DWARFStructs:
             DW_FORM_strp=self.the_Dwarf_offset,
             DW_FORM_strp_sup=self.the_Dwarf_offset,
             DW_FORM_line_strp=self.the_Dwarf_offset,
+            DW_FORM_strx=self.the_Dwarf_uleb128,
             DW_FORM_strx1=self.the_Dwarf_uint8,
             DW_FORM_strx2=self.the_Dwarf_uint16,
             DW_FORM_strx3=self.Dwarf_uint24(''),
@@ -317,7 +318,7 @@ class DWARFStructs:
 
             DW_FORM_indirect=self.the_Dwarf_uleb128,
 
-            # Treated separatedly while parsing, but here so that all forms resovle
+            # Treated separatedly while parsing, but here so that all forms resolve
             DW_FORM_implicit_const=None,
 
             # New forms in DWARFv4


### PR DESCRIPTION
Fixes #629 

Do we need a test file for this? The OP's case came from Xcode, which doesn't build ELF files. You can still read DWARF in Mach-O binaries on that, but it will be ugly.