### PR TITLE
Add more entries to ENUM_DW_LANG

### DIFF
--- a/elftools/dwarf/enums.py
+++ b/elftools/dwarf/enums.py
@@ -458,7 +458,9 @@ ENUM_DW_RLE = dict(
     DW_RLE_start_length  = 0x07
 )
 
+# See https://dwarfstd.org/languages.html
 ENUM_DW_LANG = dict(
+    # DWARF v5 and earlier
     DW_LANG_C89            = 0x0001,
     DW_LANG_C              = 0x0002,
     DW_LANG_Ada83          = 0x0003,
@@ -496,8 +498,59 @@ ENUM_DW_LANG = dict(
     DW_LANG_Fortran08      = 0x0023,
     DW_LANG_RenderScript   = 0x0024,
     DW_LANG_BLISS          = 0x0025,
+    # After DWARF v5
+    DW_LANG_Kotlin         = 0x0026,
+    DW_LANG_Zig            = 0x0027,
+    DW_LANG_Crystal        = 0x0028,
+    DW_LANG_C_plus_plus_17 = 0x002a,
+    DW_LANG_C_plus_plus_20 = 0x002b,
+    DW_LANG_C17            = 0x002c,
+    DW_LANG_Fortran18      = 0x002d,
+    DW_LANG_Ada2005        = 0x002e,
+    DW_LANG_Ada2012        = 0x002f,
+    DW_LANG_HIP            = 0x0030,
+    DW_LANG_Assembly       = 0x0031,
+    DW_LANG_C_sharp        = 0x0032,
+    DW_LANG_Mojo           = 0x0033,
+    DW_LANG_GLSL           = 0x0034,
+    DW_LANG_GLSL_ES        = 0x0035,
+    DW_LANG_HLSL           = 0x0036,
+    DW_LANG_OpenCL_CPP     = 0x0037,
+    DW_LANG_CPP_for_OpenCL = 0x0038,
+    DW_LANG_SYCL           = 0x0039,
+    DW_LANG_C_plus_plus_23 = 0x003a,
+    DW_LANG_Odin           = 0x003b,
+    DW_LANG_P4             = 0x003c,
+    DW_LANG_Metal          = 0x003d,
+    DW_LANG_C23            = 0x003e,
+    DW_LANG_Fortran23      = 0x003f,
+    DW_LANG_Ruby           = 0x0040,
+    DW_LANG_Move           = 0x0041,
+    DW_LANG_Hylo           = 0x0042,
+    DW_LANG_V              = 0x0043,
+    DW_LANG_Algol68        = 0x0044,
+    DW_LANG_Nim            = 0x0045,
+    DW_LANG_Erlang         = 0x0046,
+    DW_LANG_Elixir         = 0x0047,
+    DW_LANG_Gleam          = 0x0048,
+    # Vendor extensions range
     DW_LANG_lo_user        = 0x8000,
-    DW_LANG_hi_user        = 0xffff
+    DW_LANG_hi_user        = 0xffff,
+    # Note: in absense of official names, the naming of the following
+    # extensions follows what's done in the include/dwarf2.h file in the GCC
+    # repo.
+    # Mips extensions
+    DW_LANG_Mips_Assembler = 0x8001,
+    # UPC (Unified Parallel C) extensions
+    DW_LANG_Upc            = 0x8765, # Replaced by DW_LANG_UPC
+    # HP extensions
+    DW_LANG_HP_Bliss       = 0x8003,
+    DW_LANG_HP_Basic91     = 0x8004,
+    DW_LANG_HP_Pascal91    = 0x8005,
+    DW_LANG_HP_IMacro      = 0x8006,
+    DW_LANG_HP_Assembler   = 0x8007,
+    # Rust extensions
+    DW_LANG_Rust_old       = 0x9000 # Replaced by DW_LANG_Rust
 )
 
 ENUM_DW_ATE = dict(


### PR DESCRIPTION
Add Post DWARF v5 and vendor extension entries to ENUM_DW_LANG.

Fixes:
- https://github.com/eliben/pyelftools/issues/632