### PR TITLE
Python 9 out Python 14 in

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         os: [ubuntu-latest]
 
     steps:


### PR DESCRIPTION
Keeping up with the Python compatibility chart. Also, they've obsoleted a bunch of stuff in py14.