### PR TITLE
Cleanup before typing

### DIFF
--- a/elftools/common/utils.py
+++ b/elftools/common/utils.py
@@ -127,7 +127,7 @@ def iterbytes(b):
 def bytes2hex(b, sep=''):
     if not sep:
         return b.hex()
-    return sep.join(map('{:02x}'.format, b))
+    return sep.join(f'{o:02x}' for o in b)
 
 #------------------------- PRIVATE -------------------------
 

--- a/elftools/dwarf/datatype_cpp.py
+++ b/elftools/dwarf/datatype_cpp.py
@@ -29,7 +29,7 @@ def parse_cpp_datatype(var_die):
     """
     t = TypeDesc()
 
-    if not 'DW_AT_type' in var_die.attributes:
+    if 'DW_AT_type' not in var_die.attributes:
         t.tag = ''
         return t
 
@@ -40,7 +40,7 @@ def parse_cpp_datatype(var_die):
     while type_die.tag in ('DW_TAG_const_type', 'DW_TAG_volatile_type', 'DW_TAG_pointer_type', 'DW_TAG_reference_type'):
         modifier = _strip_type_tag(type_die) # const/volatile/reference/pointer
         mods.insert(0, modifier)
-        if not 'DW_AT_type' in type_die.attributes: # void* is encoded as a pointer to nothing
+        if 'DW_AT_type' not in type_die.attributes: # void* is encoded as a pointer to nothing
             t.name = t.tag = "void"
             t.modifiers = tuple(mods)
             return t

--- a/elftools/dwarf/descriptions.py
+++ b/elftools/dwarf/descriptions.py
@@ -609,20 +609,20 @@ class ExprDumper:
         )
 
     def _init_lookups(self):
-        self._ops_with_decimal_arg = set([
+        self._ops_with_decimal_arg = {
             'DW_OP_const1u', 'DW_OP_const1s', 'DW_OP_const2u', 'DW_OP_const2s',
             'DW_OP_const4u', 'DW_OP_const4s', 'DW_OP_const8u', 'DW_OP_const8s',
             'DW_OP_constu', 'DW_OP_consts', 'DW_OP_pick', 'DW_OP_plus_uconst',
             'DW_OP_bra', 'DW_OP_skip', 'DW_OP_fbreg', 'DW_OP_piece',
-            'DW_OP_deref_size', 'DW_OP_xderef_size', 'DW_OP_regx',])
+            'DW_OP_deref_size', 'DW_OP_xderef_size', 'DW_OP_regx'}
 
         for n in range(0, 32):
             self._ops_with_decimal_arg.add('DW_OP_breg%s' % n)
 
-        self._ops_with_two_decimal_args = set(['DW_OP_bregx'])
+        self._ops_with_two_decimal_args = {'DW_OP_bregx'}
 
-        self._ops_with_hex_arg = set(
-            ['DW_OP_addr', 'DW_OP_call2', 'DW_OP_call4', 'DW_OP_call_ref'])
+        self._ops_with_hex_arg = {
+            'DW_OP_addr', 'DW_OP_call2', 'DW_OP_call4', 'DW_OP_call_ref'}
 
     def _dump_to_string(self, opcode, opcode_name, args, cu_offset=None):
         # Some GNU ops contain an offset from the current CU as an argument,

--- a/elftools/dwarf/descriptions.py
+++ b/elftools/dwarf/descriptions.py
@@ -500,7 +500,7 @@ _EXTRA_INFO_DESCRIPTION_MAP = defaultdict(
     lambda: _make_extra_string(''), # default_factory
 
     DW_AT_inline=_make_extra_mapper(
-        _DESCR_DW_INL, '(Unknown inline attribute value: %x',
+        _DESCR_DW_INL, '(Unknown inline attribute value: %x)',
         default_interpolate_value=True),
     DW_AT_language=_make_extra_mapper(
         _DESCR_DW_LANG, '(Unknown: %x)', default_interpolate_value=True),

--- a/elftools/dwarf/dwarf_util.py
+++ b/elftools/dwarf/dwarf_util.py
@@ -19,7 +19,7 @@ def _get_base_offset(cu, base_attribute_name):
     encoded objects - range lists, location lists, strings, addresses.
     """
     cu_top_die = cu.get_top_DIE()
-    if not base_attribute_name in cu_top_die.attributes:
+    if base_attribute_name not in cu_top_die.attributes:
         raise DWARFError("The CU at offset 0x%x needs %s" % (cu.cu_offset, base_attribute_name))
     return cu_top_die.attributes[base_attribute_name].value
 

--- a/elftools/elf/sections.py
+++ b/elftools/elf/sections.py
@@ -117,10 +117,7 @@ class Section:
         return self.header[name]
 
     def __eq__(self, other):
-        try:
-            return self.header == other.header
-        except AttributeError:
-            return False
+        return isinstance(other, Section) and self.header == other.header
 
     def __hash__(self):
         return hash(self.header)

--- a/scripts/readelf.py
+++ b/scripts/readelf.py
@@ -1416,7 +1416,7 @@ class ReadElf:
         """ Dump the aranges table
         """
         aranges_table = self._dwarfinfo.get_aranges()
-        if aranges_table == None:
+        if aranges_table is None:
             return
         # Seems redundant, but we need to get the unsorted set of entries
         # to match system readelf.

--- a/scripts/readelf.py
+++ b/scripts/readelf.py
@@ -1031,7 +1031,7 @@ class ReadElf:
 
         symbol = self._versioninfo['versym'].get_symbol(nsym)
         index = symbol.entry['ndx']
-        if not index in ('VER_NDX_LOCAL', 'VER_NDX_GLOBAL'):
+        if index not in ('VER_NDX_LOCAL', 'VER_NDX_GLOBAL'):
             index = int(index)
 
             if self._versioninfo['type'] == 'GNU':
@@ -1172,7 +1172,7 @@ class ReadElf:
 
                     attr_desc = describe_attr_value(attr, die, section_offset)
 
-                    if 'DW_OP_fbreg' in attr_desc and current_function and not 'DW_AT_frame_base' in current_function.attributes:
+                    if 'DW_OP_fbreg' in attr_desc and current_function and 'DW_AT_frame_base' not in current_function.attributes:
                         postfix = ' [without dw_at_frame_base]'
                     else:
                         postfix = ''

--- a/test/run_dwarfdump_tests.py
+++ b/test/run_dwarfdump_tests.py
@@ -157,7 +157,7 @@ def main():
     args = argparser.parse_args()
 
     if args.parallel:
-        if args.verbose or args.keep_going == False:
+        if args.verbose or not args.keep_going:
             print('WARNING: parallel mode disables verbosity and always keeps going')
 
     if args.verbose:

--- a/test/run_readelf_tests.py
+++ b/test/run_readelf_tests.py
@@ -282,7 +282,7 @@ def main():
     args = argparser.parse_args()
 
     if args.parallel:
-        if args.verbose or args.keep_going == False:
+        if args.verbose or not args.keep_going:
             print('WARNING: parallel mode disables verbosity and always keeps going')
 
     if args.verbose:

--- a/test/test_corpus_naming.py
+++ b/test/test_corpus_naming.py
@@ -8,7 +8,6 @@ import unittest
 import os
 
 from elftools.elf.elffile import ELFFile
-from elftools.elf.segments import NoteSegment
 
 class TestCorpusNaming(unittest.TestCase):
     def scan_under(self, subdir):

--- a/test/test_debuglink.py
+++ b/test/test_debuglink.py
@@ -90,6 +90,7 @@ class TestDebuglink(unittest.TestCase):
         elf = ELFFile.load_from_path('test/testfiles_for_unittests/debuglink')
         subprograms = self.subprograms_from_debuglink(elf)
         self.assertEqual(subprograms, {b'main': (0x1161, 0x52), b'addNumbers': (0x1149, 0x18)})
+        elf.close()
 
     def test_relative_loader_rejects_path_traversal(self):
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/test/test_dwarf_aranges.py
+++ b/test/test_dwarf_aranges.py
@@ -3,8 +3,8 @@ import unittest
 
 from elftools.elf.elffile import ELFFile
 
-address_a = 0x112f;
-address_b = 0x1154;
+address_a = 0x112f
+address_b = 0x1154
 
 class TestRangeLists(unittest.TestCase):
     def test_arange_absent(self):

--- a/test/test_dwarf_cu_and_die_cache.py
+++ b/test/test_dwarf_cu_and_die_cache.py
@@ -31,9 +31,9 @@ class TestCacheLUTandDIEref(unittest.TestCase):
             for (k, v) in pt.items():
                 ndie = dwarf.get_DIE_from_lut_entry(v)
                 self.dprint(ndie)
-                if not 'DW_AT_type' in ndie.attributes:
+                if 'DW_AT_type' not in ndie.attributes:
                     continue
-                if not 'DW_AT_name' in ndie.attributes:
+                if 'DW_AT_name' not in ndie.attributes:
                     continue
                 tlist = []
                 tdie = ndie


### PR DESCRIPTION
This is the _cleanup part_ from https://github.com/eliben/pyelftools/pull/611#issuecomment-4337985938
- several things found (and fixed) by `ruff check [--fix [--unsafe-fixes]]`
- re-implement `__eq__()` to also check the type
- re-implement `bytes2hex()` to confuse `pyrefly` (and me) less
- add missing closing parenthesis to `DW_AT_inline` message
- explicitly close file in unit-test