### PR TITLE
Typing fixes and improvements to construct

### DIFF
--- a/elftools/common/construct_utils.py
+++ b/elftools/common/construct_utils.py
@@ -20,7 +20,7 @@ class RepeatUntilExcluding(Subconstruct):
 
         P.S. removed some code duplication
     """
-    __slots__ = ["predicate"]
+    __slots__ = ("predicate",)
     def __init__(self, predicate, subcon):
         Subconstruct.__init__(self, subcon)
         self.predicate = predicate
@@ -88,7 +88,7 @@ class StreamOffset(Construct):
     Example:
     StreamOffset("item_offset")
     """
-    __slots__ = []
+    __slots__ = ()
     def __init__(self, name):
         Construct.__init__(self, name)
         self._set_flag(self.FLAG_DYNAMIC)

--- a/elftools/construct/__init__.py
+++ b/elftools/construct/__init__.py
@@ -59,6 +59,7 @@ Embed = Embedded
 #===============================================================================
 import functools
 import warnings
+from types import FunctionType
 from typing import TYPE_CHECKING, TypeVar
 
 if TYPE_CHECKING:
@@ -71,6 +72,7 @@ if TYPE_CHECKING:
 
 
 def deprecated(f: Callable[_P, _T]) -> Callable[_P, _T]:
+    assert isinstance(f, (FunctionType, type))
     @functools.wraps(f)
     def wrapper(*args: _P.args, **kwargs: _P.kwargs) -> _T:
         warnings.warn(

--- a/elftools/construct/adapters.py
+++ b/elftools/construct/adapters.py
@@ -1,14 +1,14 @@
 from __future__ import annotations
 
 from io import BytesIO
-from typing import TYPE_CHECKING, Any, Callable, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 from .core import Adapter, AdaptationError, Pass
 from .lib import int_to_bin, bin_to_int, swap_bytes
 from .lib import FlagsContainer, HexString
 
 if TYPE_CHECKING:
-    from collections.abc import Hashable, Mapping, Sized
+    from collections.abc import Callable, Hashable, Mapping, Sized
 
     from .core import Construct, _Pass
     from .lib import Container, ListContainer

--- a/elftools/construct/adapters.py
+++ b/elftools/construct/adapters.py
@@ -256,7 +256,8 @@ class CStringAdapter(StringAdapter):
         self.terminators = terminators
     def _encode(self, obj: bytes | str, context: Container) -> bytes:
         return StringAdapter._encode(self, obj, context) + self.terminators[0:1]
-    def _decode(self, obj: list[bytes], context: Container) -> bytes | str:  # type: ignore[override]
+    def _decode(self, obj: list[bytes], context: Container) -> bytes | str:  # type: ignore[override] # ty: ignore[invalid-method-override]
+        # This violates the Liskov Substitution Principle: should be `obj: bytes`, but RepeatUntil() converts `bytes` to `list[byte]`
         return StringAdapter._decode(self, b''.join(obj[:-1]), context)
 
 class TunnelAdapter(Adapter):

--- a/elftools/construct/adapters.py
+++ b/elftools/construct/adapters.py
@@ -27,15 +27,15 @@ __all__ = [
 # exceptions
 #===============================================================================
 class BitIntegerError(AdaptationError):
-    __slots__: list[str] = []
+    __slots__ = ()
 class MappingError(AdaptationError):
-    __slots__: list[str] = []
+    __slots__ = ()
 class ConstError(AdaptationError):
-    __slots__: list[str] = []
+    __slots__ = ()
 class ValidationError(AdaptationError):
-    __slots__: list[str] = []
+    __slots__ = ()
 class PaddingError(AdaptationError):
-    __slots__: list[str] = []
+    __slots__ = ()
 
 #===============================================================================
 # adapters
@@ -55,7 +55,7 @@ class BitIntegerAdapter(Adapter):
     * bytesize - number of bits per byte, used for byte-swapping (if swapped).
       default is 8.
     """
-    __slots__: list[str] = ["width", "swapped", "signed", "bytesize"]
+    __slots__ = ("width", "swapped", "signed", "bytesize")
     def __init__(self, subcon: Construct, width: int, swapped: bool = False, signed: bool = False,
             bytesize: int = 8) -> None:
         Adapter.__init__(self, subcon)
@@ -92,7 +92,7 @@ class MappingAdapter(Adapter):
       in the encoding mapping. if no object is given, an exception is raised.
       if `Pass` is used, the unmapped object will be passed as-is
     """
-    __slots__: list[str] = ["encoding", "decoding", "encdefault", "decdefault"]
+    __slots__ = ("encoding", "decoding", "encdefault", "decdefault")
     def __init__(self, subcon: Construct, decoding: Mapping[Any, Any], encoding: Mapping[Any, Any],
             decdefault: Hashable | _Pass = NotImplemented,
             encdefault: Hashable | _Pass = NotImplemented,
@@ -133,7 +133,7 @@ class FlagsAdapter(Adapter):
     * subcon - the subcon to extract
     * flags - a dictionary mapping flag-names to their value
     """
-    __slots__: list[str] = ["flags"]
+    __slots__ = ("flags",)
     def __init__(self, subcon: Construct, flags: dict[str, int]) -> None:
         Adapter.__init__(self, subcon)
         self.flags = flags
@@ -160,7 +160,7 @@ class StringAdapter(Adapter):
     * encoding - the character encoding name (e.g., "utf8"), or None to
       return raw bytes (usually 8-bit ASCII).
     """
-    __slots__: list[str] = ["encoding"]
+    __slots__ = ("encoding",)
     def __init__(self, subcon: Construct, encoding: str | None = None) -> None:
         Adapter.__init__(self, subcon)
         self.encoding = encoding
@@ -189,7 +189,7 @@ class PaddedStringAdapter(Adapter):
       "left"). the default is "right". trimming is only meaningful for
       building, when the given string is too long.
     """
-    __slots__: list[str] = ["padchar", "paddir", "trimdir"]
+    __slots__ = ("padchar", "paddir", "trimdir")
     def __init__(self, subcon: Construct, padchar: bytes = b"\x00", paddir: Literal["right", "left", "center"] = "right",
             trimdir: Literal["right", "left"] = "right"):
         if paddir not in ("right", "left", "center"):
@@ -233,7 +233,7 @@ class LengthValueAdapter(Adapter):
     Parameters:
     * subcon - the subcon returning a length-value pair
     """
-    __slots__: list[str] = []
+    __slots__ = ()
     def _encode(self, obj: Sized, context: Container) -> tuple[int, Sized]:
         return (len(obj), obj)
     def _decode(self, obj: tuple[int, Sized] | ListContainer, context: Container) -> Sized:
@@ -250,7 +250,7 @@ class CStringAdapter(StringAdapter):
       return raw-bytes. the terminator characters are not affected by the
       encoding.
     """
-    __slots__: list[str] = ["terminators"]
+    __slots__ = ("terminators",)
     def __init__(self, subcon: Construct, terminators: bytes = b"\x00", encoding: str | None = None) -> None:
         StringAdapter.__init__(self, subcon, encoding = encoding)
         self.terminators = terminators
@@ -281,7 +281,7 @@ class TunnelAdapter(Adapter):
         GreedyRange(UBInt16("elements"))
     )
     """
-    __slots__: list[str] = ["inner_subcon"]
+    __slots__ = ("inner_subcon",)
     def __init__(self, subcon: Construct, inner_subcon: Construct) -> None:
         Adapter.__init__(self, subcon)
         self.inner_subcon = inner_subcon
@@ -311,7 +311,7 @@ class ExprAdapter(Adapter):
         decoder = lambda obj, ctx: obj * 4,
     )
     """
-    __slots__: list[str] = ["__encode", "__decode"]
+    __slots__ = ("__encode", "__decode")
     def __init__(self, subcon: Construct, encoder: Callable[[Any, Container], bytes], decoder: Callable[[bytes, Container], Any]) -> None:
         Adapter.__init__(self, subcon)
         self.__encode = encoder
@@ -325,7 +325,7 @@ class HexDumpAdapter(Adapter):
     """
     Adapter for hex-dumping strings. It returns a HexString, which is a string
     """
-    __slots__: list[str] = ["linesize"]
+    __slots__ = ("linesize",)
     def __init__(self, subcon: Construct, linesize: int = 16) -> None:
         Adapter.__init__(self, subcon)
         self.linesize = linesize
@@ -346,7 +346,7 @@ class ConstAdapter(Adapter):
     Example:
     Const(Field("signature", 2), "MZ")
     """
-    __slots__ = ["value"]
+    __slots__ = ("value",)
     def __init__(self, subcon: Construct, value: object) -> None:
         Adapter.__init__(self, subcon)
         self.value = value
@@ -370,7 +370,7 @@ class SlicingAdapter(Adapter):
     * stop - stop index (or None for up-to-end)
     * step - step (or None for every element)
     """
-    __slots__: list[str] = ["start", "stop", "step"]
+    __slots__ = ("start", "stop", "step")
     def __init__(self, subcon: Construct, start: int, stop: int | None = None) -> None:
         Adapter.__init__(self, subcon)
         self.start = start
@@ -390,7 +390,7 @@ class IndexingAdapter(Adapter):
     * subcon - the subcon to index
     * index - the index of the list to get
     """
-    __slots__: list[str] = ["index"]
+    __slots__ = ("index",)
     def __init__(self, subcon: Construct, index: int) -> None:
         Adapter.__init__(self, subcon)
         if type(index) is not int:
@@ -411,7 +411,7 @@ class PaddingAdapter(Adapter):
     * strict - whether or not to verify, during parsing, that the given
       padding matches the padding pattern. default is False (unstrict)
     """
-    __slots__: list[str] = ["pattern", "strict"]
+    __slots__ = ("pattern", "strict")
     def __init__(self, subcon: Construct, pattern: bytes = b"\x00", strict: bool = False) -> None:
         Adapter.__init__(self, subcon)
         self.pattern = pattern
@@ -437,7 +437,7 @@ class Validator(Adapter):
     Parameters:
     * subcon - the subcon to validate
     """
-    __slots__: list[str] = []
+    __slots__ = ()
     def _decode(self, obj: object, context: Container) -> object:
         if not self._validate(obj, context):
             raise ValidationError("invalid object", obj)
@@ -469,7 +469,7 @@ class OneOf(Validator):
         ...
     ValidationError: ('invalid object', 9)
     """
-    __slots__: list[str] = ["valids"]
+    __slots__ = ("valids",)
     def __init__(self, subcon: Construct, valids: list[object]) -> None:
         Validator.__init__(self, subcon)
         self.valids = valids
@@ -491,7 +491,7 @@ class NoneOf(Validator):
         ...
     ValidationError: ('invalid object', 6)
     """
-    __slots__: list[str] = ["invalids"]
+    __slots__ = ("invalids",)
     def __init__(self, subcon: Construct, invalids: list[object]) -> None:
         Validator.__init__(self, subcon)
         self.invalids = invalids

--- a/elftools/construct/core.py
+++ b/elftools/construct/core.py
@@ -837,7 +837,7 @@ class Switch(Construct, Generic[_T]):
 
     __slots__ = ("subcons", "keyfunc", "cases", "default", "include_key")
 
-    def __init__(self, name: str | None, keyfunc: Callable[[Container], _T | None], cases: Mapping[_T | None, Construct], default: Construct = NoDefault,
+    def __init__(self, name: str | None, keyfunc: Callable[[Container], _T], cases: Mapping[_T, Construct], default: Construct = NoDefault,
             include_key: bool = False) -> None:
         Construct.__init__(self, name)
         self._inherit_flags(*cases.values())
@@ -854,7 +854,7 @@ class Switch(Construct, Generic[_T]):
             return key, obj
         else:
             return obj
-    def _build(self, obj: tuple[_T | None, Construct] | Construct, stream: IO[bytes], context: Container) -> None:
+    def _build(self, obj: tuple[_T, Construct] | Construct, stream: IO[bytes], context: Container) -> None:
         if self.include_key:
             assert isinstance(obj, tuple)
             key, obj = obj

--- a/elftools/construct/core.py
+++ b/elftools/construct/core.py
@@ -7,13 +7,14 @@ from typing import IO, TYPE_CHECKING, Any, Final, Generic, Literal, NoReturn, Ty
 from .lib import Container, ListContainer, LazyContainer
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Iterable
-    from typing import Self  # 3.11+
+    from collections.abc import Callable, Iterable, Mapping
+
+    from typing_extensions import Self  # 3.11+
 
     from .lib.bitstream import BitStream
 
-_T = TypeVar("_T")
 
+_T = TypeVar("_T")
 
 __all__ = [
     "ConstructError", "FieldError", "SizeofError", "AdaptationError", "ArrayError", "RangeError", "SwitchError", "SelectError", "TerminatorError",
@@ -835,7 +836,7 @@ class Switch(Construct, Generic[_T]):
 
     __slots__: list[str] = ["subcons", "keyfunc", "cases", "default", "include_key"]
 
-    def __init__(self, name: str | None, keyfunc: Callable[[Container], _T | None], cases: dict[_T | None, Construct], default: Construct = NoDefault,
+    def __init__(self, name: str | None, keyfunc: Callable[[Container], _T | None], cases: Mapping[_T | None, Construct], default: Construct = NoDefault,
             include_key: bool = False) -> None:
         Construct.__init__(self, name)
         self._inherit_flags(*cases.values())

--- a/elftools/construct/core.py
+++ b/elftools/construct/core.py
@@ -32,23 +32,23 @@ __all__ = [
 # exceptions
 #===============================================================================
 class ConstructError(Exception):
-    __slots__: list[str] = []
+    __slots__ = ()
 class FieldError(ConstructError):
-    __slots__: list[str] = []
+    __slots__ = ()
 class SizeofError(ConstructError):
-    __slots__: list[str] = []
+    __slots__ = ()
 class AdaptationError(ConstructError):
-    __slots__: list[str] = []
+    __slots__ = ()
 class ArrayError(ConstructError):
-    __slots__: list[str] = []
+    __slots__ = ()
 class RangeError(ConstructError):
-    __slots__: list[str] = []
+    __slots__ = ()
 class SwitchError(ConstructError):
-    __slots__: list[str] = []
+    __slots__ = ()
 class SelectError(ConstructError):
-    __slots__: list[str] = []
+    __slots__ = ()
 class TerminatorError(ConstructError):
-    __slots__: list[str] = []
+    __slots__ = ()
 
 #===============================================================================
 # abstract constructs
@@ -113,7 +113,7 @@ class Construct:
     FLAG_EMBED                 = 0x0004
     FLAG_NESTING               = 0x0008
 
-    __slots__: list[str] = ["name", "conflags"]
+    __slots__ = ("name", "conflags")
     def __init__(self, name: str | None, flags: int = 0) -> None:
         if name is not None:
             if type(name) is not str:
@@ -277,7 +277,7 @@ class Subconstruct(Construct):
     Parameters:
     * subcon - the construct to wrap
     """
-    __slots__: list[str] = ["subcon"]
+    __slots__ = ("subcon",)
     def __init__(self, subcon: Construct) -> None:
         Construct.__init__(self, subcon.name, subcon.conflags)
         self.subcon = subcon
@@ -295,7 +295,7 @@ class Adapter(Subconstruct):
     Parameters:
     * subcon - the construct to wrap
     """
-    __slots__: list[str] = []
+    __slots__ = ()
     def _parse(self, stream: IO[bytes], context: Container) -> Any:
         return self._decode(self.subcon._parse(stream, context), context)
     def _build(self, obj: Any, stream: IO[bytes], context: Container) -> None:
@@ -332,7 +332,7 @@ class StaticField(Construct):
     :param int length: number of bytes in the field
     """
 
-    __slots__: list[str] = ["length"]
+    __slots__ = ("length",)
     def __init__(self, name: str | None, length: int) -> None:
         Construct.__init__(self, name)
         self.length = length
@@ -354,7 +354,7 @@ class FormatField(StaticField, Generic[_T]):
     :param str format: a single format character
     """
 
-    __slots__: list[str] = ["packer"]
+    __slots__ = ("packer",)
     if TYPE_CHECKING:
         name: str
     def __init__(self, name: str, endianity: Literal["<", ">", "="], format: str) -> None:
@@ -403,7 +403,7 @@ class MetaField(Construct):
     Container({'length': 4, 'data': b'ABCD'})
     """
 
-    __slots__: list[str] = ["lengthfunc"]
+    __slots__ = ("lengthfunc",)
     def __init__(self, name: str | None, lengthfunc: Callable[[Container], int]) -> None:
         Construct.__init__(self, name)
         self.lengthfunc = lengthfunc
@@ -433,7 +433,7 @@ class MetaArray(Subconstruct):
     Example:
     MetaArray(lambda ctx: 5, UBInt8("foo"))
     """
-    __slots__: list[str] = ["countfunc"]
+    __slots__ = ("countfunc",)
     def __init__(self, countfunc: Callable[[Container], int], subcon: Construct) -> None:
         Subconstruct.__init__(self, subcon)
         self.countfunc = countfunc
@@ -512,7 +512,7 @@ class Range(Subconstruct):
     RangeError: expected 3..7, found 8
     """
 
-    __slots__: list[str] = ["mincount", "maxcout"]
+    __slots__ = ("mincount", "maxcout")
     def __init__(self, mincount: int, maxcout: int, subcon: Construct) -> None:
         Subconstruct.__init__(self, subcon)
         self.mincount = mincount
@@ -581,7 +581,7 @@ class RepeatUntil(Subconstruct):
         Field("chars", 1)
     )
     """
-    __slots__: list[str] = ["predicate"]
+    __slots__ = ("predicate",)
     def __init__(self, predicate: Callable[[Any, Container], bool], subcon: Construct) -> None:
         Subconstruct.__init__(self, subcon)
         self.predicate = predicate
@@ -650,7 +650,7 @@ class Struct(Construct):
         UBInt8("third_element"),
     )
     """
-    __slots__: list[str] = ["subcons", "nested"]
+    __slots__ = ("subcons", "nested",)
     def __init__(self, name: str | None, *subcons: Construct, nested: bool = True) -> None:
         self.nested = nested
         Construct.__init__(self, name)
@@ -716,7 +716,7 @@ class Sequence(Struct):
         UBInt8("third_element"),
     )
     """
-    __slots__: list[str] = []
+    __slots__ = ()
     def _parse(self, stream: IO[bytes], context: Container) -> ListContainer:  # type: ignore[override]
         if "<obj>" in context:
             obj = context["<obj>"]
@@ -776,7 +776,7 @@ class Union(Construct):
         ),
     )
     """
-    __slots__: list[str] = ["parser", "builder"]
+    __slots__ = ("parser", "builder")
     def __init__(self, name: str | None, master: Construct, *subcons: Construct) -> None:
         Construct.__init__(self, name)
         args: list[Construct] = [Peek(sc) for sc in subcons]
@@ -834,7 +834,7 @@ class Switch(Construct, Generic[_T]):
             raise SwitchError("no default case defined")
     NoDefault: Final = _NoDefault("No default value specified")
 
-    __slots__: list[str] = ["subcons", "keyfunc", "cases", "default", "include_key"]
+    __slots__ = ("subcons", "keyfunc", "cases", "default", "include_key")
 
     def __init__(self, name: str | None, keyfunc: Callable[[Container], _T | None], cases: Mapping[_T | None, Construct], default: Construct = NoDefault,
             include_key: bool = False) -> None:
@@ -888,7 +888,7 @@ class Select(Construct):
         UBInt8("tiny"),
     )
     """
-    __slots__: list[str] = ["subcons", "include_name"]
+    __slots__ = ("subcons", "include_name")
     def __init__(self, name: str | None, *subcons: Construct, include_name: bool = False) -> None:
         Construct.__init__(self, name)
         self.subcons = subcons
@@ -960,7 +960,7 @@ class Pointer(Subconstruct):
         )
     )
     """
-    __slots__: list[str] = ["offsetfunc"]
+    __slots__ = ("offsetfunc",)
     def __init__(self, offsetfunc: Callable[[Container], int], subcon: Construct) -> None:
         Subconstruct.__init__(self, subcon)
         self.offsetfunc = offsetfunc
@@ -997,7 +997,7 @@ class Peek(Subconstruct):
     Example:
     Peek(UBInt8("foo"))
     """
-    __slots__: list[str] = ["perform_build"]
+    __slots__ = ("perform_build",)
     def __init__(self, subcon: Construct, perform_build: bool = False) -> None:
         Subconstruct.__init__(self, subcon)
         self.perform_build = perform_build
@@ -1039,7 +1039,7 @@ class OnDemand(Subconstruct):
     Example:
     OnDemand(Array(10000, UBInt8("foo"))
     """
-    __slots__: list[str] = ["advance_stream", "force_build"]
+    __slots__ = ("advance_stream", "force_build")
     def __init__(self, subcon: Construct, advance_stream: bool = True, force_build: bool = True) -> None:
         Subconstruct.__init__(self, subcon)
         self.advance_stream = advance_stream
@@ -1082,7 +1082,7 @@ class Buffered(Subconstruct):
         resizer = lambda size: size / 8,
     )
     """
-    __slots__: list[str] = ["encoder", "decoder", "resizer"]
+    __slots__ = ("encoder", "decoder", "resizer")
     def __init__(self, subcon: Construct, decoder: Callable[[bytes], bytes], encoder: Callable[[bytes], bytes], resizer: Callable[[int], int]) -> None:
         Subconstruct.__init__(self, subcon)
         self.encoder = encoder
@@ -1132,7 +1132,7 @@ class Restream(Subconstruct):
         resizer = lambda size: size / 8,
     )
     """
-    __slots__: list[str] = ["stream_reader", "stream_writer", "resizer"]
+    __slots__ = ("stream_reader", "stream_writer", "resizer")
     def __init__(self, subcon: Construct, stream_reader: type[BitStream], stream_writer: type[BitStream], resizer: Callable[[int], int]) -> None:
         Subconstruct.__init__(self, subcon)
         self.stream_reader = stream_reader
@@ -1168,7 +1168,7 @@ class Reconfig(Subconstruct):
     Example:
     Reconfig("foo", UBInt8("bar"))
     """
-    __slots__: list[str] = []
+    __slots__ = ()
     def __init__(self, name: str | None, subcon: Construct, setflags: int = 0, clearflags: int = 0) -> None:
         Construct.__init__(self, name, subcon.conflags)
         self.subcon = subcon
@@ -1199,7 +1199,7 @@ class Anchor(Construct):
         )
     )
     """
-    __slots__: list[str] = []
+    __slots__ = ()
     if TYPE_CHECKING:
         name: str
     def _parse(self, stream: IO[bytes], context: Container) -> int:
@@ -1224,7 +1224,7 @@ class Value(Construct, Generic[_T]):
         Value("total_pixels", lambda ctx: ctx.width * ctx.height),
     )
     """
-    __slots__: list[str] = ["func"]
+    __slots__ = ("func",)
     if TYPE_CHECKING:
         name: str
     def __init__(self, name: str, func: Callable[[Container], _T]) -> None:
@@ -1261,7 +1261,7 @@ class Value(Construct, Generic[_T]):
 #        Dynamic("spam", factory),
 #    )
 #    """
-#    __slots__: list[str] = ["factoryfunc"]
+#    __slots__ = ("factoryfunc",)
 #    def __init__(self, name: str, factoryfunc: Callable[[Container], Construct]) -> None:
 #        Construct.__init__(self, name, self.FLAG_COPY_CONTEXT)
 #        self.factoryfunc = factoryfunc
@@ -1287,7 +1287,7 @@ class LazyBound(Construct):
         LazyBound("next", lambda: foo),
     )
     """
-    __slots__: list[str] = ["bindfunc", "bound"]
+    __slots__ = ("bindfunc", "bound")
     def __init__(self, name: str, bindfunc: Callable[[], Construct]) -> None:
         Construct.__init__(self, name)
         self.bound: Construct | None = None
@@ -1318,7 +1318,7 @@ class _Pass(Construct):
     Example:
     Pass
     """
-    __slots__: list[str] = []
+    __slots__ = ()
     def _parse(self, stream: IO[bytes], context: Container) -> None:
         pass
     def _build(self, obj: None, stream: IO[bytes], context: Container) -> None:
@@ -1343,7 +1343,7 @@ class _Terminator(Construct):
     Example:
     Terminator
     """
-    __slots__: list[str] = []
+    __slots__ = ()
     def _parse(self, stream: IO[bytes], context: Container) -> None:
         if stream.read(1):
             raise TerminatorError("expected end of stream")

--- a/elftools/construct/core.py
+++ b/elftools/construct/core.py
@@ -166,19 +166,15 @@ class Construct:
         Obtain a dictionary representing this construct's state.
         """
 
-        attrs = {}
-        if hasattr(self, "__dict__"):
-            attrs.update(self.__dict__)
-        slots = []
-        c: type[Construct] | None = self.__class__
-        while c is not None:
-            if hasattr(c, "__slots__"):
-                slots.extend(c.__slots__)
-            c = c.__base__
-        for name in slots:
-            if hasattr(self, name):
-                attrs[name] = getattr(self, name)
-        return attrs
+        slots = {
+            sym
+            for cls in type(self).__mro__
+            for sym in getattr(cls, "__slots__", ())
+        }
+        return {
+            **getattr(self, "__dict__", {}),
+            **{name: getattr(self, name) for name in slots if hasattr(self, name)},
+        }
 
     def __setstate__(self, attrs: dict[str, Any]) -> None:
         """

--- a/elftools/construct/core.py
+++ b/elftools/construct/core.py
@@ -717,7 +717,8 @@ class Sequence(Struct):
     )
     """
     __slots__ = ()
-    def _parse(self, stream: IO[bytes], context: Container) -> ListContainer:  # type: ignore[override]
+    def _parse(self, stream: IO[bytes], context: Container) -> ListContainer:  # type: ignore[override] # ty: ignore[invalid-method-override]
+        # This violates the Liskov Substitution Principle: `ListContainer` is no sub-class of `Container`; they're unrelated
         if "<obj>" in context:
             obj = context["<obj>"]
             del context["<obj>"]

--- a/elftools/construct/lib/bitstream.py
+++ b/elftools/construct/lib/bitstream.py
@@ -6,10 +6,8 @@ from typing import IO, TYPE_CHECKING
 from .binary import encode_bin, decode_bin
 
 if TYPE_CHECKING:
-    # Py3.12+ # from collections.abc import Buffer
-    from typing import Self  # 3.11+
-
-    from typing_extensions import Buffer
+    from typing_extensions import Buffer  # 3.12+
+    from typing_extensions import Self  # 3.11+
 
 
 class BitStream(io.RawIOBase, IO[bytes]):

--- a/elftools/construct/lib/bitstream.py
+++ b/elftools/construct/lib/bitstream.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
 
 class BitStream(io.RawIOBase, IO[bytes]):
 
-    __slots__: list[str] = ["substream"]
+    __slots__ = ("substream",)
 
     def __init__(self, substream: IO[bytes]) -> None:
         self.substream = substream
@@ -23,7 +23,7 @@ class BitStream(io.RawIOBase, IO[bytes]):
 
 class BitStreamReader(BitStream):
 
-    __slots__: list[str] = ["buffer", "total_size"]
+    __slots__ = ("buffer", "total_size")
 
     def __init__(self, substream: IO[bytes]) -> None:
         super().__init__(substream)
@@ -69,7 +69,7 @@ class BitStreamReader(BitStream):
 
 class BitStreamWriter(BitStream):
 
-    __slots__: list[str] = ["buffer", "pos"]
+    __slots__ = ("buffer", "pos")
 
     def __init__(self, substream: IO[bytes]) -> None:
         super().__init__(substream)

--- a/elftools/construct/lib/container.py
+++ b/elftools/construct/lib/container.py
@@ -65,7 +65,7 @@ class Container(MutableMapping[str, Any]):
         "length",
         "n_descsz", "n_offset", "n_namesz",
         "sh_addralign", "sh_flags", "sh_size",
-        "bloom_size", "nbuckets",
+        "bloom_size", "nbuckets", "nchains",
     ]) -> int: ...
     @overload
     def __getitem__(self, name: Literal[
@@ -74,6 +74,10 @@ class Container(MutableMapping[str, Any]):
         "n_name", "n_type",
         "tag", "vendor_name",
     ]) -> str: ...
+    @overload
+    def __getitem__(self, name: Literal[
+        "buckets", "chains",
+    ]) -> list[int]: ...
     @overload
     def __getitem__(self, name: str) -> Any: ...
     def __getitem__(self, name: str) -> Any:

--- a/elftools/construct/lib/container.py
+++ b/elftools/construct/lib/container.py
@@ -155,10 +155,7 @@ class LazyContainer:
         self._value = NotImplemented
 
     def __eq__(self, other: object) -> bool:
-        try:
-            return self._value == other._value  # type: ignore[attr-defined]
-        except AttributeError:
-            return False
+        return isinstance(other, LazyContainer) and self._value == other._value
 
     def __ne__(self, other: object) -> bool:
         return not (self == other)

--- a/elftools/construct/lib/container.py
+++ b/elftools/construct/lib/container.py
@@ -6,13 +6,13 @@ from __future__ import annotations
 from collections.abc import MutableMapping
 from functools import wraps
 from pprint import pformat
-from typing import IO, TYPE_CHECKING, Any, Literal, TypeVar, overload
+from typing import IO, TYPE_CHECKING, Any, Literal, overload
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterator
-    from typing import Self  # 3.11+
+    from typing import Concatenate, ParamSpec, TypeVar
 
-    from typing_extensions import Concatenate, ParamSpec  # 3.10+
+    from typing_extensions import Self  # 3.11+
 
     from ..core import Construct
     from .hex import HexString

--- a/elftools/construct/lib/container.py
+++ b/elftools/construct/lib/container.py
@@ -4,6 +4,7 @@ Various containers.
 from __future__ import annotations
 
 from collections.abc import MutableMapping
+from functools import wraps
 from pprint import pformat
 from typing import IO, TYPE_CHECKING, Any, Literal, TypeVar, overload
 
@@ -35,6 +36,7 @@ def recursion_lock(
     def decorator(
         func: Callable[Concatenate[Any, _P], _T],
     ) -> Callable[Concatenate[Any, _P], _T | _R]:
+        @wraps(func)
         def wrapper(self: Any, *args: _P.args, **kw: _P.kwargs) -> _T | _R:
             if getattr(self, lock_name, False):
                 return retval
@@ -43,7 +45,6 @@ def recursion_lock(
                 return func(self, *args, **kw)
             finally:
                 setattr(self, lock_name, False)
-        wrapper.__name__ = func.__name__
         return wrapper
     return decorator
 

--- a/elftools/construct/lib/hex.py
+++ b/elftools/construct/lib/hex.py
@@ -7,8 +7,7 @@ if TYPE_CHECKING:
 
 
 # Map an integer in the inclusive range 0-255 to its string byte representation
-_printable = dict((i, ".") for i in range(256))
-_printable.update((i, chr(i)) for i in range(32, 128))
+_printable = {i: chr(i) if 32 <= i < 128 else "." for i in range(256)}
 
 
 def hexdump(data: bytes, linesize: int) -> list[str]:

--- a/elftools/construct/lib/hex.py
+++ b/elftools/construct/lib/hex.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing import Self  # 3.11+
+    from typing_extensions import Self  # 3.11+
 
 
 # Map an integer in the inclusive range 0-255 to its string byte representation

--- a/elftools/construct/macros.py
+++ b/elftools/construct/macros.py
@@ -1,9 +1,7 @@
 from __future__ import annotations
 
-from collections.abc import Callable
 from sys import maxsize
 from typing import TYPE_CHECKING, Any, Literal, TypedDict
-from typing import Union as TUnion
 
 from .lib import (BitStreamReader, BitStreamWriter, Container, encode_bin,
     decode_bin)
@@ -15,13 +13,14 @@ from .adapters import (BitIntegerAdapter, PaddingAdapter,
     PaddedStringAdapter, FlagsAdapter, StringAdapter, MappingAdapter)
 
 if TYPE_CHECKING:
-    from collections.abc import Hashable, Mapping
-    from typing import Unpack  # Py3.11+
+    from collections.abc import Callable, Hashable, Mapping
+
+    from typing_extensions import Unpack  # Py3.11+
 
     from .adapters import Adapter
     from .core import Construct, Subconstruct, _Pass
 
-Length = TUnion[int, Callable[[Container], int]]
+    Length = int | Callable[[Container], int]
 
 
 __all__ = [

--- a/elftools/construct/macros.py
+++ b/elftools/construct/macros.py
@@ -56,10 +56,10 @@ def Field(name: str | None, length: Length) -> MetaField | StaticField:
       (StaticField), or a function that takes the context as an argument and
       returns the length (MetaField)
     """
-    if callable(length):
-        return MetaField(name, length)
-    else:
+    if isinstance(length, int):
         return StaticField(name, length)
+    else:
+        return MetaField(name, length)
 
 def BitField(name: str, length: Length, swapped: bool = False, signed: bool = False, bytesize: int = 8) -> BitIntegerAdapter:
     r"""
@@ -278,11 +278,11 @@ def Array(count: Length, subcon: Construct) -> MetaArray:
     ArrayError: expected 4, found 5
     """
 
-    if callable(count):
-        con = MetaArray(count, subcon)
-    else:
+    if isinstance(count, int):
         con = MetaArray(lambda ctx: count, subcon)
         con._clear_flag(con.FLAG_DYNAMIC)
+    else:
+        con = MetaArray(count, subcon)
     return con
 
 def PrefixedArray(subcon: Construct, length_field: Construct = UBInt8("length")) -> LengthValueAdapter:

--- a/elftools/elf/structs.py
+++ b/elftools/elf/structs.py
@@ -416,7 +416,7 @@ class ELFStructs:
         self.Elf_Prop = Struct('Elf_Prop',
             Enum(self.Elf_word('pr_type'), **ENUM_NOTE_GNU_PROPERTY_TYPE),
             self.Elf_word('pr_datasz'),
-            Switch('pr_data', classify_pr_data, {
+            Switch[tuple[str, int, int] | None]('pr_data', classify_pr_data, {
                     ('GNU_PROPERTY_STACK_SIZE', 4, 32): self.Elf_word('pr_data'),
                     ('GNU_PROPERTY_STACK_SIZE', 8, 64): self.Elf_word64('pr_data'),
                     ('GNU_PROPERTY_X86_*', 4, 0): self.Elf_word('pr_data'),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ build-backend = "setuptools.build_meta"
 [project]
 dynamic = ["version"]
 name = "pyelftools"
-requires-python = ">= 3.9"
+requires-python = ">= 3.10"
 authors = [
     {name = "Eli Bendersky", email = "eliben@gmail.com"},
 ]
@@ -43,7 +43,12 @@ Repository = "https://github.com/eliben/pyelftools.git"
 Issues = "https://github.com/eliben/pyelftools/issues"
 
 [dependency-groups]
-typing = ["mypy[reports]", "pyright", "typeguard"]
+typing = [
+    "mypy[reports]",
+    "pyright",
+    "typeguard",
+    "typing_extensions",
+]
 
 [tool.setuptools]
 packages = [


### PR DESCRIPTION
This are the typing fixes related to the vendored `elftools/construct/` from https://github.com/eliben/pyelftools/pull/611#issuecomment-4337985938 — all of them have been found while working on making `mypy`/`pyright`/`pyrefly`/`ty` happy
- remove wrong and unneeded type-annotation for `__slots__`
- some minor fixes and improvements to existing type-annotation, which have been found wrong or missing
- extend `type: ignore` to equivalent `ty: ignore`
- re-implement `__getstate__()` to handle MRO and all variants of `__slots__`
- re-implement `__eq__()` to also check the type
- modernize some pre-Python-3.9 type hints not that Python>=3.10 is required
- fixed decorator `recusion_lock` to use `functools.wraps` to handle all details of wrapping.