### PR TITLE
Convert to enum.IntEnum

### DIFF
--- a/elftools/dwarf/callframe.py
+++ b/elftools/dwarf/callframe.py
@@ -14,7 +14,7 @@ from ..common.utils import (
 from ..construct import Struct, Switch
 from .enums import DW_EH_encoding_flags
 from .structs import DWARFStructs
-from .constants import *
+from .constants import DW_CFA
 
 
 class CallFrameInfo:
@@ -188,52 +188,52 @@ class CallFrameInfo:
 
             primary = opcode & _PRIMARY_MASK
             primary_arg = opcode & _PRIMARY_ARG_MASK
-            if primary == DW_CFA_advance_loc:
+            if primary == DW_CFA.advance_loc:
                 args = [primary_arg]
-            elif primary == DW_CFA_offset:
+            elif primary == DW_CFA.offset:
                 args = [
                     primary_arg,
                     struct_parse(structs.the_Dwarf_uleb128, self.stream)]
-            elif primary == DW_CFA_restore:
+            elif primary == DW_CFA.restore:
                 args = [primary_arg]
             # primary == 0 and real opcode is extended
-            elif opcode in (DW_CFA_nop, DW_CFA_remember_state,
-                            DW_CFA_restore_state, DW_CFA_AARCH64_negate_ra_state):
+            elif opcode in (DW_CFA.nop, DW_CFA.remember_state,
+                            DW_CFA.restore_state, DW_CFA.AARCH64_negate_ra_state):
                 args = []
-            elif opcode == DW_CFA_set_loc:
+            elif opcode == DW_CFA.set_loc:
                 args = [
                     struct_parse(structs.the_Dwarf_target_addr, self.stream)]
-            elif opcode == DW_CFA_advance_loc1:
+            elif opcode == DW_CFA.advance_loc1:
                 args = [struct_parse(structs.the_Dwarf_uint8, self.stream)]
-            elif opcode == DW_CFA_advance_loc2:
+            elif opcode == DW_CFA.advance_loc2:
                 args = [struct_parse(structs.the_Dwarf_uint16, self.stream)]
-            elif opcode == DW_CFA_advance_loc4:
+            elif opcode == DW_CFA.advance_loc4:
                 args = [struct_parse(structs.the_Dwarf_uint32, self.stream)]
-            elif opcode in (DW_CFA_offset_extended, DW_CFA_register,
-                            DW_CFA_def_cfa, DW_CFA_val_offset):
+            elif opcode in (DW_CFA.offset_extended, DW_CFA.register,
+                            DW_CFA.def_cfa, DW_CFA.val_offset):
                 args = [
                     struct_parse(structs.the_Dwarf_uleb128, self.stream),
                     struct_parse(structs.the_Dwarf_uleb128, self.stream)]
-            elif opcode in (DW_CFA_restore_extended, DW_CFA_undefined,
-                            DW_CFA_same_value, DW_CFA_def_cfa_register,
-                            DW_CFA_def_cfa_offset):
+            elif opcode in (DW_CFA.restore_extended, DW_CFA.undefined,
+                            DW_CFA.same_value, DW_CFA.def_cfa_register,
+                            DW_CFA.def_cfa_offset):
                 args = [struct_parse(structs.the_Dwarf_uleb128, self.stream)]
-            elif opcode == DW_CFA_def_cfa_offset_sf:
+            elif opcode == DW_CFA.def_cfa_offset_sf:
                 args = [struct_parse(structs.the_Dwarf_sleb128, self.stream)]
-            elif opcode == DW_CFA_def_cfa_expression:
+            elif opcode == DW_CFA.def_cfa_expression:
                 args = [struct_parse(
                     structs.Dwarf_dw_form['DW_FORM_block'], self.stream)]
-            elif opcode in (DW_CFA_expression, DW_CFA_val_expression):
+            elif opcode in (DW_CFA.expression, DW_CFA.val_expression):
                 args = [
                     struct_parse(structs.the_Dwarf_uleb128, self.stream),
                     struct_parse(
                         structs.Dwarf_dw_form['DW_FORM_block'], self.stream)]
-            elif opcode in (DW_CFA_offset_extended_sf,
-                            DW_CFA_def_cfa_sf, DW_CFA_val_offset_sf):
+            elif opcode in (DW_CFA.offset_extended_sf,
+                            DW_CFA.def_cfa_sf, DW_CFA.val_offset_sf):
                 args = [
                     struct_parse(structs.the_Dwarf_uleb128, self.stream),
                     struct_parse(structs.the_Dwarf_sleb128, self.stream)]
-            elif opcode == DW_CFA_GNU_args_size:
+            elif opcode == DW_CFA.GNU_args_size:
                 args = [struct_parse(structs.the_Dwarf_uleb128, self.stream)]
 
             else:
@@ -531,12 +531,12 @@ class CFIEntry:
 
         table = []
 
-        # Keeps a stack for the use of DW_CFA_{remember|restore}_state
+        # Keeps a stack for the use of DW_CFA.{remember|restore}_state
         # instructions.
         line_stack = []
 
         def _add_to_order(regnum):
-            # DW_CFA_restore and others remove registers from cur_line,
+            # DW_CFA.restore and others remove registers from cur_line,
             #  but they stay in reg_order. Avoid duplicates.
             if regnum not in reg_order:
                 reg_order.append(regnum)
@@ -724,10 +724,8 @@ _PRIMARY_MASK = 0b11000000
 _PRIMARY_ARG_MASK = 0b00111111
 
 # This dictionary is filled by automatically scanning the constants module
-# for DW_CFA_* instructions, and mapping their values to names. Since all
-# names were imported from constants with `import *`, we look in globals()
+# for DW_CFA instructions, and mapping their values to names.
 _OPCODE_NAME_MAP = {
-    value: name
-    for name, value in globals().items()
-    if name.startswith('DW_CFA')
+    member.value: f"DW_CFA_{member.name}"
+    for member in DW_CFA.__members__.values()
 }

--- a/elftools/dwarf/callframe.py
+++ b/elftools/dwarf/callframe.py
@@ -9,6 +9,8 @@
 import copy
 import os
 from collections import namedtuple
+from warnings import warn
+
 from ..common.utils import (
     struct_parse, dwarf_assert, preserve_stream_pos, iterbytes)
 from ..construct import Struct, Switch
@@ -183,23 +185,19 @@ class CallFrameInfo:
         """
         instructions = []
         while offset < end_offset:
-            opcode = struct_parse(structs.the_Dwarf_uint8, self.stream, offset)
-            args = []
+            raw_opcode = struct_parse(structs.the_Dwarf_uint8, self.stream, offset)
 
-            primary = opcode & _PRIMARY_MASK
-            primary_arg = opcode & _PRIMARY_ARG_MASK
-            if primary == DW_CFA.advance_loc:
-                args = [primary_arg]
-            elif primary == DW_CFA.offset:
-                args = [
-                    primary_arg,
-                    struct_parse(structs.the_Dwarf_uleb128, self.stream)]
-            elif primary == DW_CFA.restore:
-                args = [primary_arg]
+            opcode, *args = DW_CFA.parse_raw_opcode(raw_opcode)
+            if opcode == DW_CFA.advance_loc:
+                pass
+            elif opcode == DW_CFA.offset:
+                args += [ struct_parse(structs.the_Dwarf_uleb128, self.stream)]
+            elif opcode == DW_CFA.restore:
+                pass
             # primary == 0 and real opcode is extended
             elif opcode in (DW_CFA.nop, DW_CFA.remember_state,
                             DW_CFA.restore_state, DW_CFA.AARCH64_negate_ra_state):
-                args = []
+                pass
             elif opcode == DW_CFA.set_loc:
                 args = [
                     struct_parse(structs.the_Dwarf_target_addr, self.stream)]
@@ -447,11 +445,8 @@ class CallFrameInfo:
 def instruction_name(opcode):
     """ Given an opcode, return the instruction name.
     """
-    primary = opcode & _PRIMARY_MASK
-    if primary == 0:
-        return _OPCODE_NAME_MAP[opcode]
-    else:
-        return _OPCODE_NAME_MAP[primary]
+    warn("Switch to DW_CFA.FQN", DeprecationWarning, stacklevel=2)
+    return opcode.FQN
 
 
 class CallFrameInstruction:
@@ -465,8 +460,7 @@ class CallFrameInstruction:
         self.args = args
 
     def __repr__(self):
-        return '%s (0x%x): %s' % (
-            instruction_name(self.opcode), self.opcode, self.args)
+        return f"{self.opcode.FQN} ({self.opcode.value:#02x}): {self.args}"
 
 
 class CFIEntry:
@@ -716,16 +710,3 @@ class CFARule:
 #
 DecodedCallFrameTable = namedtuple(
     'DecodedCallFrameTable', 'table reg_order')
-
-
-#---------------- PRIVATE ----------------#
-
-_PRIMARY_MASK = 0b11000000
-_PRIMARY_ARG_MASK = 0b00111111
-
-# This dictionary is filled by automatically scanning the constants module
-# for DW_CFA instructions, and mapping their values to names.
-_OPCODE_NAME_MAP = {
-    member.value: f"DW_CFA_{member.name}"
-    for member in DW_CFA.__members__.values()
-}

--- a/elftools/dwarf/callframe.py
+++ b/elftools/dwarf/callframe.py
@@ -188,54 +188,45 @@ class CallFrameInfo:
             raw_opcode = struct_parse(structs.the_Dwarf_uint8, self.stream, offset)
 
             opcode, *args = DW_CFA.parse_raw_opcode(raw_opcode)
-            if opcode == DW_CFA.advance_loc:
-                pass
-            elif opcode == DW_CFA.offset:
-                args += [ struct_parse(structs.the_Dwarf_uleb128, self.stream)]
-            elif opcode == DW_CFA.restore:
-                pass
-            # primary == 0 and real opcode is extended
-            elif opcode in (DW_CFA.nop, DW_CFA.remember_state,
-                            DW_CFA.restore_state, DW_CFA.AARCH64_negate_ra_state):
-                pass
-            elif opcode == DW_CFA.set_loc:
-                args = [
-                    struct_parse(structs.the_Dwarf_target_addr, self.stream)]
-            elif opcode == DW_CFA.advance_loc1:
-                args = [struct_parse(structs.the_Dwarf_uint8, self.stream)]
-            elif opcode == DW_CFA.advance_loc2:
-                args = [struct_parse(structs.the_Dwarf_uint16, self.stream)]
-            elif opcode == DW_CFA.advance_loc4:
-                args = [struct_parse(structs.the_Dwarf_uint32, self.stream)]
-            elif opcode in (DW_CFA.offset_extended, DW_CFA.register,
-                            DW_CFA.def_cfa, DW_CFA.val_offset):
-                args = [
-                    struct_parse(structs.the_Dwarf_uleb128, self.stream),
-                    struct_parse(structs.the_Dwarf_uleb128, self.stream)]
-            elif opcode in (DW_CFA.restore_extended, DW_CFA.undefined,
-                            DW_CFA.same_value, DW_CFA.def_cfa_register,
-                            DW_CFA.def_cfa_offset):
-                args = [struct_parse(structs.the_Dwarf_uleb128, self.stream)]
-            elif opcode == DW_CFA.def_cfa_offset_sf:
-                args = [struct_parse(structs.the_Dwarf_sleb128, self.stream)]
-            elif opcode == DW_CFA.def_cfa_expression:
-                args = [struct_parse(
-                    structs.Dwarf_dw_form['DW_FORM_block'], self.stream)]
-            elif opcode in (DW_CFA.expression, DW_CFA.val_expression):
-                args = [
-                    struct_parse(structs.the_Dwarf_uleb128, self.stream),
-                    struct_parse(
-                        structs.Dwarf_dw_form['DW_FORM_block'], self.stream)]
-            elif opcode in (DW_CFA.offset_extended_sf,
-                            DW_CFA.def_cfa_sf, DW_CFA.val_offset_sf):
-                args = [
-                    struct_parse(structs.the_Dwarf_uleb128, self.stream),
-                    struct_parse(structs.the_Dwarf_sleb128, self.stream)]
-            elif opcode == DW_CFA.GNU_args_size:
-                args = [struct_parse(structs.the_Dwarf_uleb128, self.stream)]
-
-            else:
-                dwarf_assert(False, 'Unknown CFI opcode: 0x%x' % opcode)
+            match opcode:
+                case DW_CFA.advance_loc | DW_CFA.restore | DW_CFA.nop | DW_CFA.remember_state | DW_CFA.restore_state | DW_CFA.AARCH64_negate_ra_state:
+                    pass
+                case DW_CFA.offset:
+                    args += [struct_parse(structs.the_Dwarf_uleb128, self.stream)]
+                case DW_CFA.set_loc:
+                    args = [struct_parse(structs.the_Dwarf_target_addr, self.stream)]
+                case DW_CFA.advance_loc1:
+                    args = [struct_parse(structs.the_Dwarf_uint8, self.stream)]
+                case DW_CFA.advance_loc2:
+                    args = [struct_parse(structs.the_Dwarf_uint16, self.stream)]
+                case DW_CFA.advance_loc4:
+                    args = [struct_parse(structs.the_Dwarf_uint32, self.stream)]
+                case DW_CFA.offset_extended | DW_CFA.register | DW_CFA.def_cfa | DW_CFA.val_offset:
+                    args = [
+                        struct_parse(structs.the_Dwarf_uleb128, self.stream),
+                        struct_parse(structs.the_Dwarf_uleb128, self.stream)]
+                case DW_CFA.restore_extended | DW_CFA.undefined | DW_CFA.same_value | DW_CFA.def_cfa_register | DW_CFA.def_cfa_offset:
+                    args = [struct_parse(structs.the_Dwarf_uleb128, self.stream)]
+                case DW_CFA.def_cfa_offset_sf:
+                    args = [struct_parse(structs.the_Dwarf_sleb128, self.stream)]
+                case DW_CFA.def_cfa_expression:
+                    struct = structs.Dwarf_dw_form['DW_FORM_block']
+                    assert struct is not None
+                    args = [struct_parse(struct, self.stream)]
+                case DW_CFA.expression | DW_CFA.val_expression:
+                    struct = structs.Dwarf_dw_form['DW_FORM_block']
+                    assert struct is not None
+                    args = [
+                        struct_parse(structs.the_Dwarf_uleb128, self.stream),
+                        struct_parse(struct, self.stream)]
+                case DW_CFA.offset_extended_sf | DW_CFA.def_cfa_sf | DW_CFA.val_offset_sf:
+                    args = [
+                        struct_parse(structs.the_Dwarf_uleb128, self.stream),
+                        struct_parse(structs.the_Dwarf_sleb128, self.stream)]
+                case DW_CFA.GNU_args_size:
+                    args = [struct_parse(structs.the_Dwarf_uleb128, self.stream)]
+                case _:
+                    dwarf_assert(False, f'Unknown CFI opcode: {raw_opcode:#04x}')
 
             instructions.append(CallFrameInstruction(opcode=opcode, args=args))
             offset = self.stream.tell()
@@ -539,85 +530,86 @@ class CFIEntry:
             # Throughout this loop, cur_line is the current line. Some
             # instructions add it to the table, but most instructions just
             # update it without adding it to the table.
-
-            name = instruction_name(instr.opcode)
-
-            if name == 'DW_CFA_set_loc':
-                table.append(copy.copy(cur_line))
-                cur_line['pc'] = instr.args[0]
-            elif name in (  'DW_CFA_advance_loc1', 'DW_CFA_advance_loc2',
-                            'DW_CFA_advance_loc4', 'DW_CFA_advance_loc'):
-                table.append(copy.copy(cur_line))
-                cur_line['pc'] += instr.args[0] * cie['code_alignment_factor']
-            elif name == 'DW_CFA_def_cfa':
-                cur_line['cfa'] = CFARule(
-                    reg=instr.args[0],
-                    offset=instr.args[1])
-            elif name == 'DW_CFA_def_cfa_sf':
-                cur_line['cfa'] = CFARule(
-                    reg=instr.args[0],
-                    offset=instr.args[1] * cie['code_alignment_factor'])
-            elif name == 'DW_CFA_def_cfa_register':
-                cur_line['cfa'] = CFARule(
-                    reg=instr.args[0],
-                    offset=cur_line['cfa'].offset)
-            elif name == 'DW_CFA_def_cfa_offset':
-                cur_line['cfa'] = CFARule(
-                    reg=cur_line['cfa'].reg,
-                    offset=instr.args[0])
-            elif name == 'DW_CFA_def_cfa_offset_sf':
-                cur_line['cfa'] = CFARule(
-                    reg=cur_line['cfa'].reg,
-                    offset=instr.args[0] * cie['data_alignment_factor'])
-            elif name == 'DW_CFA_def_cfa_expression':
-                cur_line['cfa'] = CFARule(expr=instr.args[0])
-            elif name == 'DW_CFA_undefined':
-                _add_to_order(instr.args[0])
-                cur_line[instr.args[0]] = RegisterRule(RegisterRule.UNDEFINED)
-            elif name == 'DW_CFA_same_value':
-                _add_to_order(instr.args[0])
-                cur_line[instr.args[0]] = RegisterRule(RegisterRule.SAME_VALUE)
-            elif name in (  'DW_CFA_offset', 'DW_CFA_offset_extended',
-                            'DW_CFA_offset_extended_sf'):
-                _add_to_order(instr.args[0])
-                cur_line[instr.args[0]] = RegisterRule(
-                    RegisterRule.OFFSET,
-                    instr.args[1] * cie['data_alignment_factor'])
-            elif name in ('DW_CFA_val_offset', 'DW_CFA_val_offset_sf'):
-                _add_to_order(instr.args[0])
-                cur_line[instr.args[0]] = RegisterRule(
-                    RegisterRule.VAL_OFFSET,
-                    instr.args[1] * cie['data_alignment_factor'])
-            elif name == 'DW_CFA_register':
-                _add_to_order(instr.args[0])
-                cur_line[instr.args[0]] = RegisterRule(
-                    RegisterRule.REGISTER,
-                    instr.args[1])
-            elif name == 'DW_CFA_expression':
-                _add_to_order(instr.args[0])
-                cur_line[instr.args[0]] = RegisterRule(
-                    RegisterRule.EXPRESSION,
-                    instr.args[1])
-            elif name == 'DW_CFA_val_expression':
-                _add_to_order(instr.args[0])
-                cur_line[instr.args[0]] = RegisterRule(
-                    RegisterRule.VAL_EXPRESSION,
-                    instr.args[1])
-            elif name in ('DW_CFA_restore', 'DW_CFA_restore_extended'):
-                _add_to_order(instr.args[0])
-                dwarf_assert(
-                    isinstance(self, FDE),
-                    '%s instruction must be in a FDE' % name)
-                if instr.args[0] in last_line_in_CIE:
-                    cur_line[instr.args[0]] = last_line_in_CIE[instr.args[0]]
-                else:
-                    cur_line.pop(instr.args[0], None)
-            elif name == 'DW_CFA_remember_state':
-                line_stack.append(copy.deepcopy(cur_line))
-            elif name == 'DW_CFA_restore_state':
-                pc = cur_line['pc']
-                cur_line = line_stack.pop()
-                cur_line['pc'] = pc
+            match instr.opcode:
+                case DW_CFA.set_loc:
+                    table.append(copy.copy(cur_line))
+                    cur_line['pc'] = instr.args[0]
+                case DW_CFA.advance_loc1 | DW_CFA.advance_loc2 | DW_CFA.advance_loc4 | DW_CFA.advance_loc:
+                    table.append(copy.copy(cur_line))
+                    cur_line['pc'] += instr.args[0] * cie['code_alignment_factor']
+                case DW_CFA.def_cfa:
+                    cur_line['cfa'] = CFARule(
+                        reg=instr.args[0],
+                        offset=instr.args[1])
+                case DW_CFA.def_cfa_sf:
+                    cur_line['cfa'] = CFARule(
+                        reg=instr.args[0],
+                        offset=instr.args[1] * cie['code_alignment_factor'])
+                case DW_CFA.def_cfa_register:
+                    cur_line['cfa'] = CFARule(
+                        reg=instr.args[0],
+                        offset=cur_line['cfa'].offset)
+                case DW_CFA.def_cfa_offset:
+                    cur_line['cfa'] = CFARule(
+                        reg=cur_line['cfa'].reg,
+                        offset=instr.args[0])
+                case DW_CFA.def_cfa_offset_sf:
+                    cur_line['cfa'] = CFARule(
+                        reg=cur_line['cfa'].reg,
+                        offset=instr.args[0] * cie['data_alignment_factor'])
+                case DW_CFA.def_cfa_expression:
+                    cur_line['cfa'] = CFARule(expr=instr.args[0])
+                case DW_CFA.undefined:
+                    _add_to_order(instr.args[0])
+                    cur_line[instr.args[0]] = RegisterRule(RegisterRule.UNDEFINED)
+                case DW_CFA.same_value:
+                    _add_to_order(instr.args[0])
+                    cur_line[instr.args[0]] = RegisterRule(RegisterRule.SAME_VALUE)
+                case DW_CFA.offset | DW_CFA.offset_extended | DW_CFA.offset_extended_sf:
+                    _add_to_order(instr.args[0])
+                    cur_line[instr.args[0]] = RegisterRule(
+                        RegisterRule.OFFSET,
+                        instr.args[1] * cie['data_alignment_factor'])
+                case DW_CFA.val_offset | DW_CFA.val_offset_sf:
+                    _add_to_order(instr.args[0])
+                    cur_line[instr.args[0]] = RegisterRule(
+                        RegisterRule.VAL_OFFSET,
+                        instr.args[1] * cie['data_alignment_factor'])
+                case DW_CFA.register:
+                    _add_to_order(instr.args[0])
+                    cur_line[instr.args[0]] = RegisterRule(
+                        RegisterRule.REGISTER,
+                        instr.args[1])
+                case DW_CFA.expression:
+                    _add_to_order(instr.args[0])
+                    cur_line[instr.args[0]] = RegisterRule(
+                        RegisterRule.EXPRESSION,
+                        instr.args[1])
+                case DW_CFA.val_expression:
+                    _add_to_order(instr.args[0])
+                    cur_line[instr.args[0]] = RegisterRule(
+                        RegisterRule.VAL_EXPRESSION,
+                        instr.args[1])
+                case DW_CFA.restore | DW_CFA.restore_extended as cfa:
+                    _add_to_order(instr.args[0])
+                    dwarf_assert(
+                        isinstance(self, FDE),
+                        f'{cfa.FQN} instruction must be in a FDE')
+                    assert last_line_in_CIE is not None
+                    if instr.args[0] in last_line_in_CIE:
+                        cur_line[instr.args[0]] = last_line_in_CIE[instr.args[0]]
+                    else:
+                        cur_line.pop(instr.args[0], None)
+                case DW_CFA.remember_state:
+                    line_stack.append(copy.deepcopy(cur_line))
+                case DW_CFA.restore_state:
+                    pc: int = cur_line['pc']
+                    cur_line = line_stack.pop()
+                    cur_line['pc'] = pc
+                case DW_CFA.nop | DW_CFA.AARCH64_negate_ra_state:
+                    pass
+                case _:
+                    dwarf_assert(False, f"Unknown CFI opcode: {instr.opcode:#02x}")
 
         # The current line is appended to the table after all instructions
         # have ended, if there were instructions.

--- a/elftools/dwarf/constants.py
+++ b/elftools/dwarf/constants.py
@@ -234,6 +234,13 @@ class DW_CFA(_IntEnum):
     GNU_window_save = 0x2d  # Used on SPARC, not in the corpus
     GNU_args_size = 0x2e
 
+    @classmethod
+    def parse_raw_opcode(cls, /, opcode, *, __MASK = 0b11_00_0000):
+        """Extract primary or extended opcode from raw byte."""
+        if primary := opcode & __MASK:
+            return (cls(primary), opcode & ~__MASK)
+        return (cls(opcode),)
+
 
 class DW_UT(_IntEnum):
     """

--- a/elftools/dwarf/constants.py
+++ b/elftools/dwarf/constants.py
@@ -6,225 +6,259 @@
 # Eli Bendersky (eliben@gmail.com)
 # This code is in the public domain
 #-------------------------------------------------------------------------------
-
-# Inline codes
-#
-DW_INL_not_inlined = 0
-DW_INL_inlined = 1
-DW_INL_declared_not_inlined = 2
-DW_INL_declared_inlined = 3
+from enum import Enum
 
 
-# Source languages
-#
-DW_LANG_C89 = 0x0001
-DW_LANG_C = 0x0002
-DW_LANG_Ada83 = 0x0003
-DW_LANG_C_plus_plus = 0x0004
-DW_LANG_Cobol74 = 0x0005
-DW_LANG_Cobol85 = 0x0006
-DW_LANG_Fortran77 = 0x0007
-DW_LANG_Fortran90 = 0x0008
-DW_LANG_Pascal83 = 0x0009
-DW_LANG_Modula2 = 0x000a
-DW_LANG_Java = 0x000b
-DW_LANG_C99 = 0x000c
-DW_LANG_Ada95 = 0x000d
-DW_LANG_Fortran95 = 0x000e
-DW_LANG_PLI = 0x000f
-DW_LANG_ObjC = 0x0010
-DW_LANG_ObjC_plus_plus = 0x0011
-DW_LANG_UPC = 0x0012
-DW_LANG_D = 0x0013
-DW_LANG_Python = 0x0014
-DW_LANG_OpenCL = 0x0015
-DW_LANG_Go = 0x0016
-DW_LANG_Modula3 = 0x0017
-DW_LANG_Haskell = 0x0018
-DW_LANG_C_plus_plus_03 = 0x0019
-DW_LANG_C_plus_plus_11 = 0x001a
-DW_LANG_OCaml = 0x001b
-DW_LANG_Rust = 0x001c
-DW_LANG_C11 = 0x001d
-DW_LANG_Swift = 0x001e
-DW_LANG_Julia = 0x001f
-DW_LANG_Dylan = 0x0020
-DW_LANG_C_plus_plus_14 = 0x0021
-DW_LANG_Fortran03 = 0x0022
-DW_LANG_Fortran08 = 0x0023
-DW_LANG_RenderScript = 0x0024
-DW_LANG_BLISS = 0x0025
-DW_LANG_Mips_Assembler = 0x8001
-DW_LANG_Upc = 0x8765
-DW_LANG_HP_Bliss = 0x8003
-DW_LANG_HP_Basic91 = 0x8004
-DW_LANG_HP_Pascal91 = 0x8005
-DW_LANG_HP_IMacro = 0x8006
-DW_LANG_HP_Assembler = 0x8007
-DW_LANG_GOOGLE_RenderScript = 0x8e57
-DW_LANG_BORLAND_Delphi = 0xb000
+class _IntEnum(int, Enum):  # Py3.11: enum.ReprEnum
+    def __repr__(self):
+        return int.__str__(self.value)
+
+    @property  # Py3.11+: enum.property
+    def FQN(self):
+        return f"{self.__class__.__name__}_{self.name}"
 
 
-# Encoding
-#
-DW_ATE_void = 0x0
-DW_ATE_address = 0x1
-DW_ATE_boolean = 0x2
-DW_ATE_complex_float = 0x3
-DW_ATE_float = 0x4
-DW_ATE_signed = 0x5
-DW_ATE_signed_char = 0x6
-DW_ATE_unsigned = 0x7
-DW_ATE_unsigned_char = 0x8
-DW_ATE_imaginary_float = 0x9
-DW_ATE_packed_decimal = 0xa
-DW_ATE_numeric_string = 0xb
-DW_ATE_edited = 0xc
-DW_ATE_signed_fixed = 0xd
-DW_ATE_unsigned_fixed = 0xe
-DW_ATE_decimal_float = 0xf
-DW_ATE_UTF = 0x10
-DW_ATE_UCS = 0x11
-DW_ATE_ASCII = 0x12
-DW_ATE_lo_user = 0x80
-DW_ATE_hi_user = 0xff
-DW_ATE_HP_float80 = 0x80
-DW_ATE_HP_complex_float80 = 0x81
-DW_ATE_HP_float128 = 0x82
-DW_ATE_HP_complex_float128 = 0x83
-DW_ATE_HP_floathpintel = 0x84
-DW_ATE_HP_imaginary_float80 = 0x85
-DW_ATE_HP_imaginary_float128 = 0x86
+class DW_INL(_IntEnum):
+    """Inline codes."""
+    not_inlined = 0
+    inlined = 1
+    declared_not_inlined = 2
+    declared_inlined = 3
 
 
-# Access
-#
-DW_ACCESS_public = 1
-DW_ACCESS_protected = 2
-DW_ACCESS_private = 3
+class DW_LANG(_IntEnum):
+    """Source languages."""
+    C89 = 0x0001
+    C = 0x0002
+    Ada83 = 0x0003
+    C_plus_plus = 0x0004
+    Cobol74 = 0x0005
+    Cobol85 = 0x0006
+    Fortran77 = 0x0007
+    Fortran90 = 0x0008
+    Pascal83 = 0x0009
+    Modula2 = 0x000a
+    Java = 0x000b
+    C99 = 0x000c
+    Ada95 = 0x000d
+    Fortran95 = 0x000e
+    PLI = 0x000f
+    ObjC = 0x0010
+    ObjC_plus_plus = 0x0011
+    UPC = 0x0012
+    D = 0x0013
+    Python = 0x0014
+    OpenCL = 0x0015
+    Go = 0x0016
+    Modula3 = 0x0017
+    Haskell = 0x0018
+    C_plus_plus_03 = 0x0019
+    C_plus_plus_11 = 0x001a
+    OCaml = 0x001b
+    Rust = 0x001c
+    C11 = 0x001d
+    Swift = 0x001e
+    Julia = 0x001f
+    Dylan = 0x0020
+    C_plus_plus_14 = 0x0021
+    Fortran03 = 0x0022
+    Fortran08 = 0x0023
+    RenderScript = 0x0024
+    BLISS = 0x0025
+    Mips_Assembler = 0x8001
+    Upc = 0x8765
+    HP_Bliss = 0x8003
+    HP_Basic91 = 0x8004
+    HP_Pascal91 = 0x8005
+    HP_IMacro = 0x8006
+    HP_Assembler = 0x8007
+    GOOGLE_RenderScript = 0x8e57
+    BORLAND_Delphi = 0xb000
 
 
-# Visibility
-#
-DW_VIS_local = 1
-DW_VIS_exported = 2
-DW_VIS_qualified = 3
+class DW_ATE(_IntEnum):
+    """Encodings."""
+    void = 0x0
+    address = 0x1
+    boolean = 0x2
+    complex_float = 0x3
+    float = 0x4
+    signed = 0x5
+    signed_char = 0x6
+    unsigned = 0x7
+    unsigned_char = 0x8
+    imaginary_float = 0x9
+    packed_decimal = 0xa
+    numeric_string = 0xb
+    edited = 0xc
+    signed_fixed = 0xd
+    unsigned_fixed = 0xe
+    decimal_float = 0xf
+    UTF = 0x10
+    UCS = 0x11
+    ASCII = 0x12
+    lo_user = 0x80
+    hi_user = 0xff
+    HP_float80 = 0x80
+    HP_complex_float80 = 0x81
+    HP_float128 = 0x82
+    HP_complex_float128 = 0x83
+    HP_floathpintel = 0x84
+    HP_imaginary_float80 = 0x85
+    HP_imaginary_float128 = 0x86
 
 
-# Virtuality
-#
-DW_VIRTUALITY_none = 0
-DW_VIRTUALITY_virtual = 1
-DW_VIRTUALITY_pure_virtual = 2
+class DW_ACCESS(_IntEnum):
+    """Access."""
+    public = 1
+    protected = 2
+    private = 3
 
 
-# ID case
-#
-DW_ID_case_sensitive = 0
-DW_ID_up_case = 1
-DW_ID_down_case = 2
-DW_ID_case_insensitive = 3
+class DW_VIS(_IntEnum):
+    """Visibility."""
+    local = 1
+    exported = 2
+    qualified = 3
 
 
-# Calling convention
-#
-DW_CC_normal = 0x1
-DW_CC_program = 0x2
-DW_CC_nocall = 0x3
-DW_CC_pass_by_reference = 0x4
-DW_CC_pass_by_valuee = 0x5
+class DW_VIRTUALITY(_IntEnum):
+    """Virtuality."""
+    none = 0
+    virtual = 1
+    pure_virtual = 2
 
 
-# Ordering
-#
-DW_ORD_row_major = 0
-DW_ORD_col_major = 1
+class DW_ID(_IntEnum):
+    """ID cases."""
+    case_sensitive = 0
+    up_case = 1
+    down_case = 2
+    case_insensitive = 3
 
 
-# Line program opcodes
-#
-DW_LNS_copy = 0x01
-DW_LNS_advance_pc = 0x02
-DW_LNS_advance_line = 0x03
-DW_LNS_set_file = 0x04
-DW_LNS_set_column = 0x05
-DW_LNS_negate_stmt = 0x06
-DW_LNS_set_basic_block = 0x07
-DW_LNS_const_add_pc = 0x08
-DW_LNS_fixed_advance_pc = 0x09
-DW_LNS_set_prologue_end = 0x0a
-DW_LNS_set_epilogue_begin = 0x0b
-DW_LNS_set_isa = 0x0c
-DW_LNE_end_sequence = 0x01
-DW_LNE_set_address = 0x02
-DW_LNE_define_file = 0x03
-DW_LNE_set_discriminator = 0x04
-DW_LNE_lo_user = 0x80
-DW_LNE_hi_user = 0xff
-
-# Line program header content types
-#
-DW_LNCT_path = 0x01
-DW_LNCT_directory_index = 0x02
-DW_LNCT_timestamp = 0x03
-DW_LNCT_size = 0x04
-DW_LNCT_MD5 = 0x05
-DW_LNCT_lo_user = 0x2000
-DW_LNCT_LLVM_source = 0x2001
-DW_LNCT_LLVM_is_MD5 = 0x2002
-DW_LNCT_hi_user = 0x3fff
-
-# Call frame instructions
-#
-# Note that the first 3 instructions have the so-called "primary opcode"
-# (as described in DWARFv3 7.23), so only their highest 2 bits take part
-# in the opcode decoding. They are kept as constants with the low bits masked
-# out, and the callframe module knows how to handle this.
-# The other instructions use an "extended opcode" encoded just in the low 6
-# bits, with the high 2 bits, so these constants are exactly as they would
-# appear in an actual file.
-#
-DW_CFA_advance_loc = 0b01000000
-DW_CFA_offset = 0b10000000
-DW_CFA_restore = 0b11000000
-DW_CFA_nop = 0x00
-DW_CFA_set_loc = 0x01
-DW_CFA_advance_loc1 = 0x02
-DW_CFA_advance_loc2 = 0x03
-DW_CFA_advance_loc4 = 0x04
-DW_CFA_offset_extended = 0x05
-DW_CFA_restore_extended = 0x06
-DW_CFA_undefined = 0x07
-DW_CFA_same_value = 0x08
-DW_CFA_register = 0x09
-DW_CFA_remember_state = 0x0a
-DW_CFA_restore_state = 0x0b
-DW_CFA_def_cfa = 0x0c
-DW_CFA_def_cfa_register = 0x0d
-DW_CFA_def_cfa_offset = 0x0e
-DW_CFA_def_cfa_expression = 0x0f
-DW_CFA_expression = 0x10
-DW_CFA_offset_extended_sf = 0x11
-DW_CFA_def_cfa_sf = 0x12
-DW_CFA_def_cfa_offset_sf = 0x13
-DW_CFA_val_offset = 0x14
-DW_CFA_val_offset_sf = 0x15
-DW_CFA_val_expression = 0x16
-DW_CFA_GNU_window_save = 0x2d # Used on SPARC, not in the corpus
-DW_CFA_AARCH64_negate_ra_state = 0x2d
-DW_CFA_GNU_args_size = 0x2e
+class DW_CC(_IntEnum):
+    """Calling conventions."""
+    normal = 0x1
+    program = 0x2
+    nocall = 0x3
+    pass_by_reference = 0x4
+    pass_by_valuee = 0x5
 
 
-# Compilation unit types
-#
-# DWARFv5 introduces the "unit_type" field to each CU header, allowing
-# individual CUs to indicate whether they're complete, partial, and so forth.
-# See DWARFv5 3.1 ("Unit Entries") and 7.5.1 ("Unit Headers").
-DW_UT_compile = 0x01
-DW_UT_type = 0x02
-DW_UT_partial = 0x03
-DW_UT_skeleton = 0x04
-DW_UT_split_compile = 0x05
-DW_UT_split_type = 0x06
-DW_UT_lo_user = 0x80
-DW_UT_hi_user = 0xff
+class DW_ORD(_IntEnum):
+    """Orderings."""
+    row_major = 0
+    col_major = 1
+
+
+class DW_LNS(_IntEnum):
+    """Line program opcodes."""
+    copy = 0x01
+    advance_pc = 0x02
+    advance_line = 0x03
+    set_file = 0x04
+    set_column = 0x05
+    negate_stmt = 0x06
+    set_basic_block = 0x07
+    const_add_pc = 0x08
+    fixed_advance_pc = 0x09
+    set_prologue_end = 0x0a
+    set_epilogue_begin = 0x0b
+    set_isa = 0x0c
+
+
+class DW_LNE(_IntEnum):
+    """Line program extended opcodes."""
+    end_sequence = 0x01
+    set_address = 0x02
+    define_file = 0x03
+    set_discriminator = 0x04
+    lo_user = 0x80
+    hi_user = 0xff
+
+
+class DW_LNCT(_IntEnum):
+    """Line program header content types."""
+    path = 0x01
+    directory_index = 0x02
+    timestamp = 0x03
+    size = 0x04
+    MD5 = 0x05
+    lo_user = 0x2000
+    LLVM_source = 0x2001
+    LLVM_is_MD5 = 0x2002
+    hi_user = 0x3fff
+
+
+class DW_CFA(_IntEnum):
+    """
+    Call frame instructions.
+
+    Note that the first 3 instructions have the so-called "primary opcode"
+    (as described in DWARFv3 7.23), so only their highest 2 bits take part
+    in the opcode decoding. They are kept as constants with the low bits masked
+    out, and the callframe module knows how to handle this.
+    The other instructions use an "extended opcode" encoded just in the low 6
+    bits, with the high 2 bits, so these constants are exactly as they would
+    appear in an actual file.
+    """
+    advance_loc = 0b01000000
+    offset = 0b10000000
+    restore = 0b11000000
+
+    nop = 0x00
+    set_loc = 0x01
+    advance_loc1 = 0x02
+    advance_loc2 = 0x03
+    advance_loc4 = 0x04
+    offset_extended = 0x05
+    restore_extended = 0x06
+    undefined = 0x07
+    same_value = 0x08
+    register = 0x09
+    remember_state = 0x0a
+    restore_state = 0x0b
+    def_cfa = 0x0c
+    def_cfa_register = 0x0d
+    def_cfa_offset = 0x0e
+    def_cfa_expression = 0x0f
+    expression = 0x10
+    offset_extended_sf = 0x11
+    def_cfa_sf = 0x12
+    def_cfa_offset_sf = 0x13
+    val_offset = 0x14
+    val_offset_sf = 0x15
+    val_expression = 0x16
+    AARCH64_negate_ra_state = 0x2d
+    GNU_window_save = 0x2d  # Used on SPARC, not in the corpus
+    GNU_args_size = 0x2e
+
+
+class DW_UT(_IntEnum):
+    """
+    Compilation unit types.
+
+    DWARFv5 introduces the "unit_type" field to each CU header, allowing
+    individual CUs to indicate whether they're complete, partial, and so forth.
+    See DWARFv5 3.1 ("Unit Entries") and 7.5.1 ("Unit Headers").
+    """
+    compile = 0x01
+    type = 0x02
+    partial = 0x03
+    skeleton = 0x04
+    split_compile = 0x05
+    split_type = 0x06
+    lo_user = 0x80
+    hi_user = 0xff
+
+
+# Add back legacy names `DW_UT_type = DW_UT.type` for `from .constants import *`.
+# These are invisible to typing as the members are added dynamically by code!
+# Use __members__ to also add aliases like DW_CFA.{AARCH64_negate_ra_state,GNU_window_save}.
+globals().update({
+    f"{enum_name}_{member_name}": member.value
+    for enum_name, enum in globals().items()
+    if enum_name.startswith("DW_") and issubclass(enum, _IntEnum)
+    for member_name, member in enum.__members__.items()
+})

--- a/elftools/dwarf/descriptions.py
+++ b/elftools/dwarf/descriptions.py
@@ -9,7 +9,7 @@
 from collections import defaultdict
 
 from .constants import (
-    DW_ACCESS, DW_ATE, DW_CC, DW_ID, DW_INL, DW_LANG, DW_ORD, DW_VIRTUALITY, DW_VIS,
+    DW_ACCESS, DW_ATE, DW_CC, DW_CFA, DW_ID, DW_INL, DW_LANG, DW_ORD, DW_VIRTUALITY, DW_VIS,
     )
 from .dwarf_expr import DWARFExprParser
 from .die import DIE
@@ -65,56 +65,53 @@ def describe_CFI_instructions(entry):
     s = ''
     for instr in entry.instructions:
         name = instr.opcode.FQN
-
-        if name in ('DW_CFA_offset',
-                    'DW_CFA_offset_extended', 'DW_CFA_offset_extended_sf',
-                    'DW_CFA_val_offset', 'DW_CFA_val_offset_sf'):
-            s += '  %s: %s at cfa%+d\n' % (
-                name, _full_reg_name(instr.args[0]),
-                instr.args[1] * cie['data_alignment_factor'])
-        elif name in (  'DW_CFA_restore', 'DW_CFA_restore_extended',
-                        'DW_CFA_undefined', 'DW_CFA_same_value',
-                        'DW_CFA_def_cfa_register'):
-            s += '  %s: %s\n' % (name, _full_reg_name(instr.args[0]))
-        elif name == 'DW_CFA_register':
-            s += '  %s: %s in %s' % (
-                name, _full_reg_name(instr.args[0]),
-                _full_reg_name(instr.args[1]))
-        elif name == 'DW_CFA_set_loc':
-            pc = instr.args[0]
-            s += '  %s: %08x\n' % (name, pc)
-        elif name in (  'DW_CFA_advance_loc1', 'DW_CFA_advance_loc2',
-                        'DW_CFA_advance_loc4', 'DW_CFA_advance_loc'):
-            _assert_FDE_instruction(instr)
-            factored_offset = instr.args[0] * cie['code_alignment_factor']
-            s += '  %s: %s to %08x\n' % (
-                name, factored_offset, factored_offset + pc)
-            pc += factored_offset
-        elif name in (  'DW_CFA_remember_state', 'DW_CFA_restore_state',
-                        'DW_CFA_nop', 'DW_CFA_AARCH64_negate_ra_state'):
-            s += '  %s\n' % name
-        elif name == 'DW_CFA_def_cfa':
-            s += '  %s: %s ofs %s\n' % (
-                name, _full_reg_name(instr.args[0]), instr.args[1])
-        elif name == 'DW_CFA_def_cfa_sf':
-            s += '  %s: %s ofs %s\n' % (
-                name, _full_reg_name(instr.args[0]),
-                instr.args[1] * cie['data_alignment_factor'])
-        elif name in ('DW_CFA_def_cfa_offset', 'DW_CFA_GNU_args_size'):
-            s += '  %s: %s\n' % (name, instr.args[0])
-        elif name == 'DW_CFA_def_cfa_offset_sf':
-            s += '  %s: %s\n' % (name, instr.args[0]*entry.cie['data_alignment_factor'])
-        elif name == 'DW_CFA_def_cfa_expression':
-            expr_dumper = ExprDumper(entry.structs)
-            # readelf output is missing a colon for DW_CFA.def_cfa_expression
-            s += '  %s (%s)\n' % (name, expr_dumper.dump_expr(instr.args[0]))
-        elif name == 'DW_CFA_expression':
-            expr_dumper = ExprDumper(entry.structs)
-            s += '  %s: %s (%s)\n' % (
-                name, _full_reg_name(instr.args[0]),
-                                     expr_dumper.dump_expr(instr.args[1]))
-        else:
-            s += '  %s: <??>\n' % name
+        match instr.opcode:
+            case DW_CFA.offset | DW_CFA.offset_extended | DW_CFA.offset_extended_sf | DW_CFA.val_offset | DW_CFA.val_offset_sf:
+                s += '  %s: %s at cfa%+d\n' % (
+                    name, _full_reg_name(instr.args[0]),
+                    instr.args[1] * cie['data_alignment_factor'])
+            case DW_CFA.restore | DW_CFA.restore_extended | DW_CFA.undefined | DW_CFA.same_value | DW_CFA.def_cfa_register:
+                s += '  %s: %s\n' % (name, _full_reg_name(instr.args[0]))
+            case DW_CFA.register:
+                s += '  %s: %s in %s' % (
+                    name, _full_reg_name(instr.args[0]),
+                    _full_reg_name(instr.args[1]))
+            case DW_CFA.set_loc:
+                pc = instr.args[0]
+                assert pc is not None
+                s += '  %s: %08x\n' % (name, pc)
+            case DW_CFA.advance_loc1 | DW_CFA.advance_loc2 | DW_CFA.advance_loc4 | DW_CFA.advance_loc:
+                _assert_FDE_instruction(instr)
+                assert pc is not None
+                factored_offset: int = instr.args[0] * cie['code_alignment_factor']
+                s += '  %s: %s to %08x\n' % (
+                    name, factored_offset, factored_offset + pc)
+                pc += factored_offset
+            case DW_CFA.remember_state | DW_CFA.restore_state | DW_CFA.nop | DW_CFA.AARCH64_negate_ra_state:
+                s += '  %s\n' % name
+            case DW_CFA.def_cfa:
+                s += '  %s: %s ofs %s\n' % (
+                    name, _full_reg_name(instr.args[0]), instr.args[1])
+            case DW_CFA.def_cfa_sf:
+                s += '  %s: %s ofs %s\n' % (
+                    name, _full_reg_name(instr.args[0]),
+                    instr.args[1] * cie['data_alignment_factor'])
+            case DW_CFA.def_cfa_offset | DW_CFA.GNU_args_size:
+                s += '  %s: %s\n' % (name, instr.args[0])
+            case DW_CFA.def_cfa_offset_sf:
+                assert entry.cie is not None
+                s += '  %s: %s\n' % (name, instr.args[0]*entry.cie['data_alignment_factor'])
+            case DW_CFA.def_cfa_expression:
+                expr_dumper = ExprDumper(entry.structs)
+                # readelf output is missing a colon for DW_CFA.def_cfa_expression
+                s += '  %s (%s)\n' % (name, expr_dumper.dump_expr(instr.args[0]))
+            case DW_CFA.expression:
+                expr_dumper = ExprDumper(entry.structs)
+                s += '  %s: %s (%s)\n' % (
+                    name, _full_reg_name(instr.args[0]),
+                                         expr_dumper.dump_expr(instr.args[1]))
+            case _:
+                s += '  %s: <??>\n' % name
 
     return s
 

--- a/elftools/dwarf/descriptions.py
+++ b/elftools/dwarf/descriptions.py
@@ -8,7 +8,9 @@
 #-------------------------------------------------------------------------------
 from collections import defaultdict
 
-from .constants import *
+from .constants import (
+    DW_ACCESS, DW_ATE, DW_CC, DW_ID, DW_INL, DW_LANG, DW_ORD, DW_VIRTUALITY, DW_VIS,
+    )
 from .dwarf_expr import DWARFExprParser
 from .die import DIE
 from ..common.utils import preserve_stream_pos, dwarf_assert, bytes2str
@@ -104,7 +106,7 @@ def describe_CFI_instructions(entry):
             s += '  %s: %s\n' % (name, instr.args[0]*entry.cie['data_alignment_factor'])
         elif name == 'DW_CFA_def_cfa_expression':
             expr_dumper = ExprDumper(entry.structs)
-            # readelf output is missing a colon for DW_CFA_def_cfa_expression
+            # readelf output is missing a colon for DW_CFA.def_cfa_expression
             s += '  %s (%s)\n' % (name, expr_dumper.dump_expr(instr.args[0]))
         elif name == 'DW_CFA_expression':
             expr_dumper = ExprDumper(entry.structs)
@@ -170,9 +172,9 @@ def describe_reg_name(regnum, machine_arch=None, default=True):
 def describe_form_class(form):
     """For a given form name, determine its value class.
 
-    For example, given 'DW_FORM_data1' returns 'constant'.
+    For example, given 'DW_FORM.data1' returns 'constant'.
 
-    For some forms, like DW_FORM_indirect and DW_FORM_sec_offset, the class is
+    For some forms, like DW_FORM.indirect and DW_FORM.sec_offset, the class is
     not hard-coded and extra information is required. For these, None is
     returned.
     """
@@ -297,121 +299,121 @@ _FORM_CLASS = dict(
 )
 
 _DESCR_DW_INL = {
-    DW_INL_not_inlined: '(not inlined)',
-    DW_INL_inlined: '(inlined)',
-    DW_INL_declared_not_inlined: '(declared as inline but ignored)',
-    DW_INL_declared_inlined: '(declared as inline and inlined)',
+    DW_INL.not_inlined: '(not inlined)',
+    DW_INL.inlined: '(inlined)',
+    DW_INL.declared_not_inlined: '(declared as inline but ignored)',
+    DW_INL.declared_inlined: '(declared as inline and inlined)',
 }
 
 _DESCR_DW_LANG = {
-    DW_LANG_C89: '(ANSI C)',
-    DW_LANG_C: '(non-ANSI C)',
-    DW_LANG_Ada83: '(Ada)',
-    DW_LANG_C_plus_plus: '(C++)',
-    DW_LANG_Cobol74: '(Cobol 74)',
-    DW_LANG_Cobol85: '(Cobol 85)',
-    DW_LANG_Fortran77: '(FORTRAN 77)',
-    DW_LANG_Fortran90: '(Fortran 90)',
-    DW_LANG_Pascal83: '(ANSI Pascal)',
-    DW_LANG_Modula2: '(Modula 2)',
-    DW_LANG_Java: '(Java)',
-    DW_LANG_C99: '(ANSI C99)',
-    DW_LANG_Ada95: '(ADA 95)',
-    DW_LANG_Fortran95: '(Fortran 95)',
-    DW_LANG_PLI: '(PLI)',
-    DW_LANG_ObjC: '(Objective C)',
-    DW_LANG_ObjC_plus_plus: '(Objective C++)',
-    DW_LANG_UPC: '(Unified Parallel C)',
-    DW_LANG_D: '(D)',
-    DW_LANG_Python: '(Python)',
-    DW_LANG_OpenCL: '(OpenCL)',
-    DW_LANG_Go: '(Go)',
-    DW_LANG_Modula3: '(Modula 3)',
-    DW_LANG_Haskell: '(Haskell)',
-    DW_LANG_C_plus_plus_03: '(C++03)',
-    DW_LANG_C_plus_plus_11: '(C++11)',
-    DW_LANG_OCaml: '(OCaml)',
-    DW_LANG_Rust: '(Rust)',
-    DW_LANG_C11: '(C11)',
-    DW_LANG_Swift: '(Swift)',
-    DW_LANG_Julia: '(Julia)',
-    DW_LANG_Dylan: '(Dylan)',
-    DW_LANG_C_plus_plus_14: '(C++14)',
-    DW_LANG_Fortran03: '(Fortran 03)',
-    DW_LANG_Fortran08: '(Fortran 08)',
-    DW_LANG_RenderScript: '(RenderScript)',
-    DW_LANG_BLISS: '(Bliss)', # Not in binutils
-    DW_LANG_Mips_Assembler: '(MIPS assembler)',
-    DW_LANG_HP_Bliss: '(HP Bliss)',
-    DW_LANG_HP_Basic91: '(HP Basic 91)',
-    DW_LANG_HP_Pascal91: '(HP Pascal 91)',
-    DW_LANG_HP_IMacro: '(HP IMacro)',
-    DW_LANG_HP_Assembler: '(HP assembler)'
+    DW_LANG.C89: '(ANSI C)',
+    DW_LANG.C: '(non-ANSI C)',
+    DW_LANG.Ada83: '(Ada)',
+    DW_LANG.C_plus_plus: '(C++)',
+    DW_LANG.Cobol74: '(Cobol 74)',
+    DW_LANG.Cobol85: '(Cobol 85)',
+    DW_LANG.Fortran77: '(FORTRAN 77)',
+    DW_LANG.Fortran90: '(Fortran 90)',
+    DW_LANG.Pascal83: '(ANSI Pascal)',
+    DW_LANG.Modula2: '(Modula 2)',
+    DW_LANG.Java: '(Java)',
+    DW_LANG.C99: '(ANSI C99)',
+    DW_LANG.Ada95: '(ADA 95)',
+    DW_LANG.Fortran95: '(Fortran 95)',
+    DW_LANG.PLI: '(PLI)',
+    DW_LANG.ObjC: '(Objective C)',
+    DW_LANG.ObjC_plus_plus: '(Objective C++)',
+    DW_LANG.UPC: '(Unified Parallel C)',
+    DW_LANG.D: '(D)',
+    DW_LANG.Python: '(Python)',
+    DW_LANG.OpenCL: '(OpenCL)',
+    DW_LANG.Go: '(Go)',
+    DW_LANG.Modula3: '(Modula 3)',
+    DW_LANG.Haskell: '(Haskell)',
+    DW_LANG.C_plus_plus_03: '(C++03)',
+    DW_LANG.C_plus_plus_11: '(C++11)',
+    DW_LANG.OCaml: '(OCaml)',
+    DW_LANG.Rust: '(Rust)',
+    DW_LANG.C11: '(C11)',
+    DW_LANG.Swift: '(Swift)',
+    DW_LANG.Julia: '(Julia)',
+    DW_LANG.Dylan: '(Dylan)',
+    DW_LANG.C_plus_plus_14: '(C++14)',
+    DW_LANG.Fortran03: '(Fortran 03)',
+    DW_LANG.Fortran08: '(Fortran 08)',
+    DW_LANG.RenderScript: '(RenderScript)',
+    DW_LANG.BLISS: '(Bliss)', # Not in binutils
+    DW_LANG.Mips_Assembler: '(MIPS assembler)',
+    DW_LANG.HP_Bliss: '(HP Bliss)',
+    DW_LANG.HP_Basic91: '(HP Basic 91)',
+    DW_LANG.HP_Pascal91: '(HP Pascal 91)',
+    DW_LANG.HP_IMacro: '(HP IMacro)',
+    DW_LANG.HP_Assembler: '(HP assembler)'
 }
 
 _DESCR_DW_ATE = {
-    DW_ATE_void: '(void)',
-    DW_ATE_address: '(machine address)',
-    DW_ATE_boolean: '(boolean)',
-    DW_ATE_complex_float: '(complex float)',
-    DW_ATE_float: '(float)',
-    DW_ATE_signed: '(signed)',
-    DW_ATE_signed_char: '(signed char)',
-    DW_ATE_unsigned: '(unsigned)',
-    DW_ATE_unsigned_char: '(unsigned char)',
-    DW_ATE_imaginary_float: '(imaginary float)',
-    DW_ATE_decimal_float: '(decimal float)',
-    DW_ATE_packed_decimal: '(packed_decimal)',
-    DW_ATE_numeric_string: '(numeric_string)',
-    DW_ATE_edited: '(edited)',
-    DW_ATE_signed_fixed: '(signed_fixed)',
-    DW_ATE_unsigned_fixed: '(unsigned_fixed)',
-    DW_ATE_UTF: '(unicode string)',
-    DW_ATE_HP_float80: '(HP_float80)',
-    DW_ATE_HP_complex_float80: '(HP_complex_float80)',
-    DW_ATE_HP_float128: '(HP_float128)',
-    DW_ATE_HP_complex_float128: '(HP_complex_float128)',
-    DW_ATE_HP_floathpintel: '(HP_floathpintel)',
-    DW_ATE_HP_imaginary_float80: '(HP_imaginary_float80)',
-    DW_ATE_HP_imaginary_float128: '(HP_imaginary_float128)',
+    DW_ATE.void: '(void)',
+    DW_ATE.address: '(machine address)',
+    DW_ATE.boolean: '(boolean)',
+    DW_ATE.complex_float: '(complex float)',
+    DW_ATE.float: '(float)',
+    DW_ATE.signed: '(signed)',
+    DW_ATE.signed_char: '(signed char)',
+    DW_ATE.unsigned: '(unsigned)',
+    DW_ATE.unsigned_char: '(unsigned char)',
+    DW_ATE.imaginary_float: '(imaginary float)',
+    DW_ATE.decimal_float: '(decimal float)',
+    DW_ATE.packed_decimal: '(packed_decimal)',
+    DW_ATE.numeric_string: '(numeric_string)',
+    DW_ATE.edited: '(edited)',
+    DW_ATE.signed_fixed: '(signed_fixed)',
+    DW_ATE.unsigned_fixed: '(unsigned_fixed)',
+    DW_ATE.UTF: '(unicode string)',
+    DW_ATE.HP_float80: '(HP_float80)',
+    DW_ATE.HP_complex_float80: '(HP_complex_float80)',
+    DW_ATE.HP_float128: '(HP_float128)',
+    DW_ATE.HP_complex_float128: '(HP_complex_float128)',
+    DW_ATE.HP_floathpintel: '(HP_floathpintel)',
+    DW_ATE.HP_imaginary_float80: '(HP_imaginary_float80)',
+    DW_ATE.HP_imaginary_float128: '(HP_imaginary_float128)',
 }
 
 _DESCR_DW_ACCESS = {
-    DW_ACCESS_public: '(public)',
-    DW_ACCESS_protected: '(protected)',
-    DW_ACCESS_private: '(private)',
+    DW_ACCESS.public: '(public)',
+    DW_ACCESS.protected: '(protected)',
+    DW_ACCESS.private: '(private)',
 }
 
 _DESCR_DW_VIS = {
-    DW_VIS_local: '(local)',
-    DW_VIS_exported: '(exported)',
-    DW_VIS_qualified: '(qualified)',
+    DW_VIS.local: '(local)',
+    DW_VIS.exported: '(exported)',
+    DW_VIS.qualified: '(qualified)',
 }
 
 _DESCR_DW_VIRTUALITY = {
-    DW_VIRTUALITY_none: '(none)',
-    DW_VIRTUALITY_virtual: '(virtual)',
-    DW_VIRTUALITY_pure_virtual: '(pure virtual)',
+    DW_VIRTUALITY.none: '(none)',
+    DW_VIRTUALITY.virtual: '(virtual)',
+    DW_VIRTUALITY.pure_virtual: '(pure virtual)',
 }
 
 _DESCR_DW_ID_CASE = {
-    DW_ID_case_sensitive: '(case_sensitive)',
-    DW_ID_up_case: '(up_case)',
-    DW_ID_down_case: '(down_case)',
-    DW_ID_case_insensitive: '(case_insensitive)',
+    DW_ID.case_sensitive: '(case_sensitive)',
+    DW_ID.up_case: '(up_case)',
+    DW_ID.down_case: '(down_case)',
+    DW_ID.case_insensitive: '(case_insensitive)',
 }
 
 _DESCR_DW_CC = {
-    DW_CC_normal: '(normal)',
-    DW_CC_program: '(program)',
-    DW_CC_nocall: '(nocall)',
-    DW_CC_pass_by_reference: '(pass by ref)',
-    DW_CC_pass_by_valuee: '(pass by value)',
+    DW_CC.normal: '(normal)',
+    DW_CC.program: '(program)',
+    DW_CC.nocall: '(nocall)',
+    DW_CC.pass_by_reference: '(pass by ref)',
+    DW_CC.pass_by_valuee: '(pass by value)',
 }
 
 _DESCR_DW_ORD = {
-    DW_ORD_row_major: '(row major)',
-    DW_ORD_col_major: '(column major)',
+    DW_ORD.row_major: '(row major)',
+    DW_ORD.col_major: '(column major)',
 }
 
 _DESCR_CFI_REGISTER_RULE_TYPE = dict(
@@ -451,7 +453,7 @@ _DWARF_EXPR_DUMPER_CACHE = {}
 def _location_list_extra(attr, die, section_offset):
     # According to section 2.6 of the DWARF spec v3, class loclistptr means
     # a location list, and class block means a location expression.
-    # DW_FORM_sec_offset is new in DWARFv4 as a section offset.
+    # DW_FORM.sec_offset is new in DWARFv4 as a section offset.
     if attr.form in ('DW_FORM_data4', 'DW_FORM_data8', 'DW_FORM_sec_offset'):
         return '(location list)'
     else:

--- a/elftools/dwarf/descriptions.py
+++ b/elftools/dwarf/descriptions.py
@@ -14,7 +14,7 @@ from .constants import (
 from .dwarf_expr import DWARFExprParser
 from .die import DIE
 from ..common.utils import preserve_stream_pos, dwarf_assert, bytes2str
-from .callframe import instruction_name, CIE, FDE
+from .callframe import CIE, FDE
 
 
 def set_global_machine_arch(machine_arch):
@@ -64,7 +64,7 @@ def describe_CFI_instructions(entry):
 
     s = ''
     for instr in entry.instructions:
-        name = instruction_name(instr.opcode)
+        name = instr.opcode.FQN
 
         if name in ('DW_CFA_offset',
                     'DW_CFA_offset_extended', 'DW_CFA_offset_extended_sf',

--- a/elftools/dwarf/lineprogram.py
+++ b/elftools/dwarf/lineprogram.py
@@ -11,7 +11,7 @@ import copy
 from collections import namedtuple
 
 from ..common.utils import struct_parse, dwarf_assert
-from .constants import *
+from .constants import DW_LNE, DW_LNS
 
 
 # LineProgramEntry - an entry in the line program.
@@ -20,8 +20,8 @@ from .constants import *
 #
 # command:
 #   The command/opcode - always numeric. For standard commands - it's the opcode
-#   that can be matched with one of the DW_LNS_* constants. For extended commands
-#   it's the extended opcode that can be matched with one of the DW_LNE_*
+#   that can be matched with one of the DW_LNS constants. For extended commands
+#   it's the extended opcode that can be matched with one of the DW_LNE
 #   constants. For special commands, it's the opcode itself.
 #
 # args:
@@ -85,7 +85,7 @@ class LineProgram:
         """
             header:
                 The header of this line program. Note: LineProgram may modify
-                its header by appending file entries if DW_LNE_define_file
+                its header by appending file entries if DW_LNE.define_file
                 instructions are encountered.
 
             stream:
@@ -180,23 +180,23 @@ class LineProgram:
                 ex_opcode = struct_parse(self.structs.the_Dwarf_uint8,
                                          self.stream)
 
-                if ex_opcode == DW_LNE_end_sequence:
+                if ex_opcode == DW_LNE.end_sequence:
                     state.end_sequence = True
                     state.is_stmt = 0
                     add_entry_new_state(ex_opcode, [], is_extended=True)
                     # reset state
                     state = LineState(self.header['default_is_stmt'])
-                elif ex_opcode == DW_LNE_set_address:
+                elif ex_opcode == DW_LNE.set_address:
                     operand = struct_parse(self.structs.the_Dwarf_target_addr,
                                            self.stream)
                     state.address = operand
                     add_entry_old_state(ex_opcode, [operand], is_extended=True)
-                elif ex_opcode == DW_LNE_define_file:
+                elif ex_opcode == DW_LNE.define_file:
                     operand = struct_parse(
                         self.structs.Dwarf_lineprog_file_entry, self.stream)
                     self['file_entry'].append(operand)
                     add_entry_old_state(ex_opcode, [operand], is_extended=True)
-                elif ex_opcode == DW_LNE_set_discriminator:
+                elif ex_opcode == DW_LNE.set_discriminator:
                     operand = struct_parse(self.structs.the_Dwarf_uleb128,
                                            self.stream)
                     state.discriminator = operand
@@ -208,53 +208,53 @@ class LineProgram:
                     self.stream.seek(inst_len - 1, os.SEEK_CUR)
             else: # 0 < opcode < opcode_base
                 # Standard opcode
-                if opcode == DW_LNS_copy:
+                if opcode == DW_LNS.copy:
                     add_entry_new_state(opcode, [])
-                elif opcode == DW_LNS_advance_pc:
+                elif opcode == DW_LNS.advance_pc:
                     operand = struct_parse(self.structs.the_Dwarf_uleb128,
                                            self.stream)
                     address_addend = (
                         operand * self.header['minimum_instruction_length'])
                     state.address += address_addend
                     add_entry_old_state(opcode, [address_addend])
-                elif opcode == DW_LNS_advance_line:
+                elif opcode == DW_LNS.advance_line:
                     operand = struct_parse(self.structs.the_Dwarf_sleb128,
                                            self.stream)
                     state.line += operand
-                elif opcode == DW_LNS_set_file:
+                elif opcode == DW_LNS.set_file:
                     operand = struct_parse(self.structs.the_Dwarf_uleb128,
                                            self.stream)
                     state.file = operand
                     add_entry_old_state(opcode, [operand])
-                elif opcode == DW_LNS_set_column:
+                elif opcode == DW_LNS.set_column:
                     operand = struct_parse(self.structs.the_Dwarf_uleb128,
                                            self.stream)
                     state.column = operand
                     add_entry_old_state(opcode, [operand])
-                elif opcode == DW_LNS_negate_stmt:
+                elif opcode == DW_LNS.negate_stmt:
                     state.is_stmt = not state.is_stmt
                     add_entry_old_state(opcode, [])
-                elif opcode == DW_LNS_set_basic_block:
+                elif opcode == DW_LNS.set_basic_block:
                     state.basic_block = True
                     add_entry_old_state(opcode, [])
-                elif opcode == DW_LNS_const_add_pc:
+                elif opcode == DW_LNS.const_add_pc:
                     adjusted_opcode = 255 - self['opcode_base']
                     address_addend = ((adjusted_opcode // self['line_range']) *
                                       self['minimum_instruction_length'])
                     state.address += address_addend
                     add_entry_old_state(opcode, [address_addend])
-                elif opcode == DW_LNS_fixed_advance_pc:
+                elif opcode == DW_LNS.fixed_advance_pc:
                     operand = struct_parse(self.structs.the_Dwarf_uint16,
                                            self.stream)
                     state.address += operand
                     add_entry_old_state(opcode, [operand])
-                elif opcode == DW_LNS_set_prologue_end:
+                elif opcode == DW_LNS.set_prologue_end:
                     state.prologue_end = True
                     add_entry_old_state(opcode, [])
-                elif opcode == DW_LNS_set_epilogue_begin:
+                elif opcode == DW_LNS.set_epilogue_begin:
                     state.epilogue_begin = True
                     add_entry_old_state(opcode, [])
-                elif opcode == DW_LNS_set_isa:
+                elif opcode == DW_LNS.set_isa:
                     operand = struct_parse(self.structs.the_Dwarf_uleb128,
                                            self.stream)
                     state.isa = operand

--- a/elftools/dwarf/structs.py
+++ b/elftools/dwarf/structs.py
@@ -7,6 +7,7 @@
 # Eli Bendersky (eliben@gmail.com)
 # This code is in the public domain
 #-------------------------------------------------------------------------------
+import elftools.dwarf.enums as e
 from ..construct import (
     UBInt8, UBInt16, UBInt32, UBInt64, ULInt8, ULInt16, ULInt32, ULInt64,
     SBInt8, SBInt16, SBInt32, SBInt64, SLInt8, SLInt16, SLInt32, SLInt64,
@@ -15,7 +16,6 @@ from ..construct import (
     )
 from ..common.construct_utils import (RepeatUntilExcluding, ULEB128, SLEB128,
     StreamOffset, ULInt24, UBInt24)
-from .enums import *
 
 
 class DWARFStructs:
@@ -220,7 +220,7 @@ class DWARFStructs:
             self.Dwarf_offset('type_offset')
         )
         dwarfv5_CU_header = Struct('',
-            Enum(self.Dwarf_uint8('unit_type'), **ENUM_DW_UT),
+            Enum(self.Dwarf_uint8('unit_type'), **e.ENUM_DW_UT),
             Embed(Switch('', lambda ctx: ctx.unit_type,
             {
                 'DW_UT_compile'       : dwarfv5_CP_CU_header,
@@ -249,14 +249,14 @@ class DWARFStructs:
 
     def _create_abbrev_declaration(self):
         self.Dwarf_abbrev_declaration = Struct('Dwarf_abbrev_entry',
-            Enum(self.Dwarf_uleb128('tag'), **ENUM_DW_TAG),
-            Enum(self.Dwarf_uint8('children_flag'), **ENUM_DW_CHILDREN),
+            Enum(self.Dwarf_uleb128('tag'), **e.ENUM_DW_TAG),
+            Enum(self.Dwarf_uint8('children_flag'), **e.ENUM_DW_CHILDREN),
             RepeatUntilExcluding(
                 lambda obj, ctx:
                     obj.name == 'DW_AT_null' and obj.form == 'DW_FORM_null',
                 Struct('attr_spec',
-                    Enum(self.Dwarf_uleb128('name'), **ENUM_DW_AT),
-                    Enum(self.Dwarf_uleb128('form'), **ENUM_DW_FORM),
+                    Enum(self.Dwarf_uleb128('name'), **e.ENUM_DW_AT),
+                    Enum(self.Dwarf_uleb128('form'), **e.ENUM_DW_FORM),
                     If(lambda ctx: ctx['form'] == 'DW_FORM_implicit_const',
                         self.Dwarf_sleb128('value')))))
 
@@ -427,8 +427,8 @@ class DWARFStructs:
             If(ver5,
                 PrefixedArray(
                     Struct('directory_entry_format',
-                        Enum(self.Dwarf_uleb128('content_type'), **ENUM_DW_LNCT),
-                        Enum(self.Dwarf_uleb128('form'), **ENUM_DW_FORM)),
+                        Enum(self.Dwarf_uleb128('content_type'), **e.ENUM_DW_LNCT),
+                        Enum(self.Dwarf_uleb128('form'), **e.ENUM_DW_FORM)),
                     self.Dwarf_uint8("directory_entry_format_count"))),
             If(ver5, # Name deliberately doesn't match the legacy object, since the format can't be made compatible
                 PrefixedArray(
@@ -437,8 +437,8 @@ class DWARFStructs:
             If(ver5,
                 PrefixedArray(
                     Struct('file_name_entry_format',
-                        Enum(self.Dwarf_uleb128('content_type'), **ENUM_DW_LNCT),
-                        Enum(self.Dwarf_uleb128('form'), **ENUM_DW_FORM)),
+                        Enum(self.Dwarf_uleb128('content_type'), **e.ENUM_DW_LNCT),
+                        Enum(self.Dwarf_uleb128('form'), **e.ENUM_DW_FORM)),
                     self.Dwarf_uint8("file_name_entry_format_count"))),
             If(ver5,
                 PrefixedArray(
@@ -508,7 +508,7 @@ class DWARFStructs:
             lambda obj, ctx: obj.entry_type == 'DW_LLE_end_of_list',
             Struct('entry',
                 StreamOffset('entry_offset'),
-                Enum(self.Dwarf_uint8('entry_type'), **ENUM_DW_LLE),
+                Enum(self.Dwarf_uint8('entry_type'), **e.ENUM_DW_LLE),
                 Embed(Switch('', lambda ctx: ctx.entry_type,
                 {
                     'DW_LLE_end_of_list'      : Struct('end_of_list'),
@@ -543,7 +543,7 @@ class DWARFStructs:
             lambda obj, ctx: obj.entry_type == 'DW_RLE_end_of_list',
             Struct('entry',
                 StreamOffset('entry_offset'),
-                Enum(self.Dwarf_uint8('entry_type'), **ENUM_DW_RLE),
+                Enum(self.Dwarf_uint8('entry_type'), **e.ENUM_DW_RLE),
                 Embed(Switch('', lambda ctx: ctx.entry_type,
                 {
                     'DW_RLE_end_of_list'      : Struct('end_of_list'),

--- a/elftools/elf/enums.py
+++ b/elftools/elf/enums.py
@@ -642,10 +642,11 @@ ENUMMAP_EXTRA_D_TAG_MACHINE = dict(
 
 # Here is the full combined mapping from tag name to value
 
-ENUM_D_TAG = dict(ENUM_D_TAG_COMMON)
-ENUM_D_TAG.update(ENUM_D_TAG_SOLARIS)
-for k in ENUMMAP_EXTRA_D_TAG_MACHINE:
-    ENUM_D_TAG.update(ENUMMAP_EXTRA_D_TAG_MACHINE[k])
+ENUM_D_TAG = merge_dicts(
+    ENUM_D_TAG_COMMON,
+    ENUM_D_TAG_SOLARIS,
+    *ENUMMAP_EXTRA_D_TAG_MACHINE.values(),
+)
 
 ENUM_DT_FLAGS = dict(
     DF_ORIGIN=0x1,

--- a/elftools/elf/structs.py
+++ b/elftools/elf/structs.py
@@ -7,6 +7,7 @@
 # Eli Bendersky (eliben@gmail.com)
 # This code is in the public domain
 #-------------------------------------------------------------------------------
+import elftools.elf .enums as e
 from ..construct import (
     UBInt8, UBInt16, UBInt32, UBInt64,
     ULInt8, ULInt16, ULInt32, ULInt64,
@@ -16,7 +17,6 @@ from ..construct import (
     )
 from ..common.construct_utils import ULEB128
 from ..common.utils import roundup
-from .enums import *
 
 
 class ELFStructs:
@@ -120,16 +120,16 @@ class ELFStructs:
         self.Elf_Ehdr = Struct('Elf_Ehdr',
             Struct('e_ident',
                 Array(4, self.Elf_byte('EI_MAG')),
-                Enum(self.Elf_byte('EI_CLASS'), **ENUM_EI_CLASS),
-                Enum(self.Elf_byte('EI_DATA'), **ENUM_EI_DATA),
-                Enum(self.Elf_byte('EI_VERSION'), **ENUM_E_VERSION),
-                Enum(self.Elf_byte('EI_OSABI'), **ENUM_EI_OSABI),
+                Enum(self.Elf_byte('EI_CLASS'), **e.ENUM_EI_CLASS),
+                Enum(self.Elf_byte('EI_DATA'), **e.ENUM_EI_DATA),
+                Enum(self.Elf_byte('EI_VERSION'), **e.ENUM_E_VERSION),
+                Enum(self.Elf_byte('EI_OSABI'), **e.ENUM_EI_OSABI),
                 self.Elf_byte('EI_ABIVERSION'),
                 Padding(7)
             ),
-            Enum(self.Elf_half('e_type'), **ENUM_E_TYPE),
-            Enum(self.Elf_half('e_machine'), **ENUM_E_MACHINE),
-            Enum(self.Elf_word('e_version'), **ENUM_E_VERSION),
+            Enum(self.Elf_half('e_type'), **e.ENUM_E_TYPE),
+            Enum(self.Elf_half('e_machine'), **e.ENUM_E_MACHINE),
+            Enum(self.Elf_word('e_version'), **e.ENUM_E_VERSION),
             self.Elf_addr('e_entry'),
             self.Elf_offset('e_phoff'),
             self.Elf_offset('e_shoff'),
@@ -149,15 +149,15 @@ class ELFStructs:
         self.Elf_ntbs = CString
 
     def _create_phdr(self):
-        p_type_dict = ENUM_P_TYPE_BASE
+        p_type_dict = e.ENUM_P_TYPE_BASE
         if self.e_machine == 'EM_ARM':
-            p_type_dict = ENUM_P_TYPE_ARM
+            p_type_dict = e.ENUM_P_TYPE_ARM
         elif self.e_machine == 'EM_AARCH64':
-            p_type_dict = ENUM_P_TYPE_AARCH64
+            p_type_dict = e.ENUM_P_TYPE_AARCH64
         elif self.e_machine == 'EM_MIPS':
-            p_type_dict = ENUM_P_TYPE_MIPS
+            p_type_dict = e.ENUM_P_TYPE_MIPS
         elif self.e_machine == 'EM_RISCV':
-            p_type_dict = ENUM_P_TYPE_RISCV
+            p_type_dict = e.ENUM_P_TYPE_RISCV
 
         if self.elfclass == 32:
             self.Elf_Phdr = Struct('Elf_Phdr',
@@ -187,17 +187,17 @@ class ELFStructs:
 
         Depends on e_machine because of machine-specific values in sh_type.
         """
-        sh_type_dict = ENUM_SH_TYPE_BASE
+        sh_type_dict = e.ENUM_SH_TYPE_BASE
         if self.e_machine == 'EM_ARM':
-            sh_type_dict = ENUM_SH_TYPE_ARM
+            sh_type_dict = e.ENUM_SH_TYPE_ARM
         elif self.e_machine == 'EM_AARCH64':
-            sh_type_dict = ENUM_SH_TYPE_AARCH64
+            sh_type_dict = e.ENUM_SH_TYPE_AARCH64
         elif self.e_machine == 'EM_X86_64':
-            sh_type_dict = ENUM_SH_TYPE_AMD64
+            sh_type_dict = e.ENUM_SH_TYPE_AMD64
         elif self.e_machine == 'EM_MIPS':
-            sh_type_dict = ENUM_SH_TYPE_MIPS
+            sh_type_dict = e.ENUM_SH_TYPE_MIPS
         if self.e_machine == 'EM_RISCV':
-            sh_type_dict = ENUM_SH_TYPE_RISCV
+            sh_type_dict = e.ENUM_SH_TYPE_RISCV
 
         self.Elf_Shdr = Struct('Elf_Shdr',
             self.Elf_word('sh_name'),
@@ -218,7 +218,7 @@ class ELFStructs:
         # Interface, Chapter 13 Object File Format, Section Compression:
         # https://docs.oracle.com/cd/E53394_01/html/E54813/section_compression.html
         fields = [
-            Enum(self.Elf_word('ch_type'), **ENUM_ELFCOMPRESS_TYPE),
+            Enum(self.Elf_word('ch_type'), **e.ENUM_ELFCOMPRESS_TYPE),
             self.Elf_xword('ch_size'),
             self.Elf_xword('ch_addralign'),
         ]
@@ -286,11 +286,11 @@ class ELFStructs:
         self.Elf_Relr = Struct('Elf_Relr', self.Elf_addr('r_offset'))
 
     def _create_dyn(self):
-        d_tag_dict = dict(ENUM_D_TAG_COMMON)
-        if self.e_machine in ENUMMAP_EXTRA_D_TAG_MACHINE:
-            d_tag_dict.update(ENUMMAP_EXTRA_D_TAG_MACHINE[self.e_machine])
+        d_tag_dict = dict(e.ENUM_D_TAG_COMMON)
+        if self.e_machine in e.ENUMMAP_EXTRA_D_TAG_MACHINE:
+            d_tag_dict.update(e.ENUMMAP_EXTRA_D_TAG_MACHINE[self.e_machine])
         elif self.e_ident_osabi == 'ELFOSABI_SOLARIS':
-            d_tag_dict.update(ENUM_D_TAG_SOLARIS)
+            d_tag_dict.update(e.ENUM_D_TAG_SOLARIS)
 
         self.Elf_Dyn = Struct('Elf_Dyn',
             Enum(self.Elf_sxword('d_tag'), **d_tag_dict),
@@ -302,16 +302,16 @@ class ELFStructs:
         # st_info is hierarchical. To access the type, use
         # container['st_info']['type']
         st_info_struct = BitStruct('st_info',
-            Enum(BitField('bind', 4), **ENUM_ST_INFO_BIND),
-            Enum(BitField('type', 4), **ENUM_ST_INFO_TYPE))
+            Enum(BitField('bind', 4), **e.ENUM_ST_INFO_BIND),
+            Enum(BitField('type', 4), **e.ENUM_ST_INFO_TYPE))
         # st_other is hierarchical. To access the visibility,
         # use container['st_other']['visibility']
         st_other_struct = BitStruct('st_other',
             # https://openpowerfoundation.org/wp-content/uploads/2016/03/ABI64BitOpenPOWERv1.1_16July2015_pub4.pdf
             # See 3.4.1 Symbol Values.
-            Enum(BitField('local', 3), **ENUM_ST_LOCAL),
+            Enum(BitField('local', 3), **e.ENUM_ST_LOCAL),
             Padding(2),
-            Enum(BitField('visibility', 3), **ENUM_ST_VISIBILITY))
+            Enum(BitField('visibility', 3), **e.ENUM_ST_VISIBILITY))
         if self.elfclass == 32:
             self.Elf_Sym = Struct('Elf_Sym',
                 self.Elf_word('st_name'),
@@ -319,21 +319,21 @@ class ELFStructs:
                 self.Elf_word('st_size'),
                 st_info_struct,
                 st_other_struct,
-                Enum(self.Elf_half('st_shndx'), **ENUM_ST_SHNDX),
+                Enum(self.Elf_half('st_shndx'), **e.ENUM_ST_SHNDX),
             )
         else:
             self.Elf_Sym = Struct('Elf_Sym',
                 self.Elf_word('st_name'),
                 st_info_struct,
                 st_other_struct,
-                Enum(self.Elf_half('st_shndx'), **ENUM_ST_SHNDX),
+                Enum(self.Elf_half('st_shndx'), **e.ENUM_ST_SHNDX),
                 self.Elf_addr('st_value'),
                 self.Elf_xword('st_size'),
             )
 
     def _create_sunw_syminfo(self):
         self.Elf_Sunw_Syminfo = Struct('Elf_Sunw_Syminfo',
-            Enum(self.Elf_half('si_boundto'), **ENUM_SUNW_SYMINFO_BOUNDTO),
+            Enum(self.Elf_half('si_boundto'), **e.ENUM_SUNW_SYMINFO_BOUNDTO),
             self.Elf_half('si_flags'),
         )
 
@@ -376,14 +376,14 @@ class ELFStructs:
         # Structure of "version symbol" entries are documented in
         # Oracle "Linker and Libraries Guide", Chapter 13 Object File Format
         self.Elf_Versym = Struct('Elf_Versym',
-            Enum(self.Elf_half('ndx'), **ENUM_VERSYM),
+            Enum(self.Elf_half('ndx'), **e.ENUM_VERSYM),
         )
 
     def _create_gnu_abi(self):
         # Structure of GNU ABI notes is documented in
         # https://code.woboq.org/userspace/glibc/csu/abi-note.S.html
         self.Elf_abi = Struct('Elf_abi',
-            Enum(self.Elf_word('abi_os'), **ENUM_NOTE_ABI_TAG_OS),
+            Enum(self.Elf_word('abi_os'), **e.ENUM_NOTE_ABI_TAG_OS),
             self.Elf_word('abi_major'),
             self.Elf_word('abi_minor'),
             self.Elf_word('abi_tiny'),
@@ -414,7 +414,7 @@ class ELFStructs:
             return (ctx.pr_type, ctx.pr_datasz, self.elfclass)
 
         self.Elf_Prop = Struct('Elf_Prop',
-            Enum(self.Elf_word('pr_type'), **ENUM_NOTE_GNU_PROPERTY_TYPE),
+            Enum(self.Elf_word('pr_type'), **e.ENUM_NOTE_GNU_PROPERTY_TYPE),
             self.Elf_word('pr_datasz'),
             Switch[tuple[str, int, int] | None]('pr_data', classify_pr_data, {
                     ('GNU_PROPERTY_STACK_SIZE', 4, 32): self.Elf_word('pr_data'),
@@ -448,8 +448,8 @@ class ELFStructs:
             self.Elf_word('n_namesz'),
             self.Elf_word('n_descsz'),
             Enum(self.Elf_word('n_type'),
-                 **(ENUM_NOTE_N_TYPE if e_type != "ET_CORE"
-                    else ENUM_CORE_NOTE_N_TYPE)),
+                 **(e.ENUM_NOTE_N_TYPE if e_type != "ET_CORE"
+                    else e.ENUM_CORE_NOTE_N_TYPE)),
         )
 
         # A process psinfo structure according to
@@ -528,14 +528,14 @@ class ELFStructs:
         # Structure of an ARM build attribute tag.
         self.Elf_Arm_Attribute_Tag = Struct('Elf_Arm_Attribute_Tag',
                                              Enum(self.Elf_uleb128('tag'),
-                                                  **ENUM_ATTR_TAG_ARM)
+                                                  **e.ENUM_ATTR_TAG_ARM)
         )
 
     def _create_riscv_attributes(self):
         # Structure of a RISC-V build attribute tag.
         self.Elf_RiscV_Attribute_Tag = Struct('Elf_RiscV_Attribute_Tag',
                                         Enum(self.Elf_uleb128('tag'),
-                                             **ENUM_ATTR_TAG_RISCV)
+                                             **e.ENUM_ATTR_TAG_RISCV)
         )
 
     def _create_elf_hash(self):

--- a/scripts/dwarfdump.py
+++ b/scripts/dwarfdump.py
@@ -29,7 +29,7 @@ from elftools.elf.elffile import ELFFile
 from elftools.dwarf.locationlists import LocationParser, LocationEntry, LocationExpr, BaseAddressEntry as LocBaseAddressEntry
 from elftools.dwarf.ranges import RangeEntry # ranges.BaseAddressEntry collides with the one above
 import elftools.dwarf.ranges
-from elftools.dwarf.enums import *
+import elftools.dwarf.enums as e
 from elftools.dwarf.dwarf_expr import DWARFExprParser, DWARFExprOp
 from elftools.dwarf.datatype_cpp import describe_cpp_datatype
 from elftools.dwarf.descriptions import describe_reg_name
@@ -318,11 +318,11 @@ def _desc_value(attr, die):
     return str(attr.value)
 
 ATTR_DESCRIPTIONS = dict(
-    DW_AT_language=lambda attr, die: _desc_enum(attr, ENUM_DW_LANG),
-    DW_AT_encoding=lambda attr, die: _desc_enum(attr, ENUM_DW_ATE),
-    DW_AT_accessibility=lambda attr, die: _desc_enum(attr, ENUM_DW_ACCESS),
-    DW_AT_inline=lambda attr, die: _desc_enum(attr, ENUM_DW_INL),
-    DW_AT_calling_convention=lambda attr, die: _desc_enum(attr, ENUM_DW_CC),
+    DW_AT_language=lambda attr, die: _desc_enum(attr, e.ENUM_DW_LANG),
+    DW_AT_encoding=lambda attr, die: _desc_enum(attr, e.ENUM_DW_ATE),
+    DW_AT_accessibility=lambda attr, die: _desc_enum(attr, e.ENUM_DW_ACCESS),
+    DW_AT_inline=lambda attr, die: _desc_enum(attr, e.ENUM_DW_INL),
+    DW_AT_calling_convention=lambda attr, die: _desc_enum(attr, e.ENUM_DW_CC),
     DW_AT_decl_file=_desc_decl_file,
     DW_AT_decl_line=_desc_value,
     DW_AT_ranges=_desc_ranges,
@@ -542,11 +542,11 @@ def main(stream=None):
         sys.exit(0)
 
     # A compatibility hack on top of a compatibility hack :(
-    del ENUM_DW_TAG["DW_TAG_template_type_param"]
-    del ENUM_DW_TAG["DW_TAG_template_value_param"]
-    ENUM_DW_TAG['DW_TAG_template_type_parameter'] = 0x2f
-    ENUM_DW_TAG['DW_TAG_template_value_parameter'] = 0x30
-    del ENUM_DW_TAG['DW_TAG_lo_user'] # dwarfdump dumps it as unknown
+    del e.ENUM_DW_TAG["DW_TAG_template_type_param"]
+    del e.ENUM_DW_TAG["DW_TAG_template_value_param"]
+    e.ENUM_DW_TAG['DW_TAG_template_type_parameter'] = 0x2f
+    e.ENUM_DW_TAG['DW_TAG_template_value_parameter'] = 0x30
+    del e.ENUM_DW_TAG['DW_TAG_lo_user'] # dwarfdump dumps it as unknown
 
     with open(args.file, 'rb') as file:
         try:

--- a/test/test_callframe.py
+++ b/test/test_callframe.py
@@ -8,8 +8,9 @@ import unittest
 from io import BytesIO
 
 from elftools.dwarf.callframe import (
-    CallFrameInfo, CIE, FDE, instruction_name, CallFrameInstruction,
+    CallFrameInfo, CIE, FDE, CallFrameInstruction,
     RegisterRule, DecodedCallFrameTable, CFARule)
+from elftools.dwarf.constants import DW_CFA
 from elftools.dwarf.structs import DWARFStructs
 from elftools.dwarf.descriptions import (describe_CFI_instructions,
     set_global_machine_arch)
@@ -19,9 +20,9 @@ from os.path import join
 
 
 class TestCallFrame(unittest.TestCase):
-    def assertInstruction(self, instr, name, args):
+    def assertInstruction(self, instr, op, args):
         self.assertIsInstance(instr, CallFrameInstruction)
-        self.assertEqual(instruction_name(instr.opcode), name)
+        self.assertEqual(instr.opcode, op)
         self.assertEqual(instr.args, args)
 
     def test_spec_sample_d6(self):
@@ -74,11 +75,11 @@ class TestCallFrame(unittest.TestCase):
         self.assertEqual(entries[0]['return_address_register'], 8)
         self.assertEqual(len(entries[0].instructions), 11)
         self.assertInstruction(entries[0].instructions[0],
-            'DW_CFA_def_cfa', [7, 0])
+            DW_CFA.def_cfa, [7, 0])
         self.assertInstruction(entries[0].instructions[8],
-            'DW_CFA_same_value', [7])
+            DW_CFA.same_value, [7])
         self.assertInstruction(entries[0].instructions[9],
-            'DW_CFA_register', [8, 1])
+            DW_CFA.register, [8, 1])
 
         self.assertTrue(isinstance(entries[1], FDE))
         self.assertEqual(entries[1]['length'], 40)
@@ -88,15 +89,15 @@ class TestCallFrame(unittest.TestCase):
         self.assertIs(entries[1].cie, entries[0])
         self.assertEqual(len(entries[1].instructions), 21)
         self.assertInstruction(entries[1].instructions[0],
-            'DW_CFA_advance_loc', [1])
+            DW_CFA.advance_loc, [1])
         self.assertInstruction(entries[1].instructions[1],
-            'DW_CFA_def_cfa_offset', [12])
+            DW_CFA.def_cfa_offset, [12])
         self.assertInstruction(entries[1].instructions[9],
-            'DW_CFA_offset', [4, 3])
+            DW_CFA.offset, [4, 3])
         self.assertInstruction(entries[1].instructions[18],
-            'DW_CFA_def_cfa_offset', [0])
+            DW_CFA.def_cfa_offset, [0])
         self.assertInstruction(entries[1].instructions[20],
-            'DW_CFA_nop', [])
+            DW_CFA.nop, [])
 
         # Now let's decode it...
         decoded_CIE = entries[0].get_decoded()

--- a/test/test_dwarf_lineprogram.py
+++ b/test/test_dwarf_lineprogram.py
@@ -9,7 +9,7 @@ from io import BytesIO
 
 from elftools.dwarf.lineprogram import LineProgram
 from elftools.dwarf.structs import DWARFStructs
-from elftools.dwarf.constants import *
+from elftools.dwarf.constants import DW_LNS
 
 
 class TestLineProgram(unittest.TestCase):
@@ -59,7 +59,7 @@ class TestLineProgram(unittest.TestCase):
 
         self.assertEqual(len(linetable), 7)
         self.assertIs(linetable[0].state, None)  # doesn't modify state
-        self.assertEqual(linetable[0].command, DW_LNS_advance_pc)
+        self.assertEqual(linetable[0].command, DW_LNS.advance_pc)
         self.assertEqual(linetable[0].args, [0x239])
         self.assertLineState(linetable[1].state, address=0x239, line=3)
         self.assertEqual(linetable[1].command, 0xb)
@@ -67,7 +67,7 @@ class TestLineProgram(unittest.TestCase):
         self.assertLineState(linetable[2].state, address=0x23c, line=5)
         self.assertLineState(linetable[3].state, address=0x244, line=6)
         self.assertLineState(linetable[4].state, address=0x24b, line=7, end_sequence=False)
-        self.assertEqual(linetable[5].command, DW_LNS_advance_pc)
+        self.assertEqual(linetable[5].command, DW_LNS.advance_pc)
         self.assertEqual(linetable[5].args, [2])
         self.assertLineState(linetable[6].state, address=0x24d, line=7, end_sequence=True)
 
@@ -90,7 +90,7 @@ class TestLineProgram(unittest.TestCase):
 
         self.assertEqual(len(linetable), 10)
         self.assertIs(linetable[0].state, None)  # doesn't modify state
-        self.assertEqual(linetable[0].command, DW_LNS_fixed_advance_pc)
+        self.assertEqual(linetable[0].command, DW_LNS.fixed_advance_pc)
         self.assertEqual(linetable[0].args, [0x239])
         self.assertLineState(linetable[1].state, address=0x239, line=3)
         self.assertLineState(linetable[3].state, address=0x23c, line=5)
@@ -100,22 +100,22 @@ class TestLineProgram(unittest.TestCase):
 
     def test_lne_set_discriminator(self):
         """
-        Tests the handling of DWARFv4's new DW_LNE_set_discriminator opcode.
+        Tests the handling of DWARFv4's new DW_LNE.set_discriminator opcode.
         """
         s = BytesIO()
         s.write(
-            b'\x00\x02\x04\x05' +  # DW_LNE_set_discriminator (discriminator=0x05)
-            b'\x01' +              # DW_LNS_copy
-            b'\x00\x01\x01'        # DW_LNE_end_sequence
+            b'\x00\x02\x04\x05' +  # DW_LNE.set_discriminator (discriminator=0x05)
+            b'\x01' +              # DW_LNS.copy
+            b'\x00\x01\x01'        # DW_LNE.end_sequence
         )
 
         lp = self._make_program_in_stream(s)
         linetable = lp.get_entries()
 
-        # We expect two entries, since DW_LNE_set_discriminator does not add
+        # We expect two entries, since DW_LNE.set_discriminator does not add
         # an entry of its own.
         self.assertEqual(len(linetable), 2)
-        self.assertEqual(linetable[0].command, DW_LNS_copy)
+        self.assertEqual(linetable[0].command, DW_LNS.copy)
         self.assertLineState(linetable[0].state, discriminator=0x05)
         self.assertLineState(linetable[1].state, discriminator=0x00, end_sequence=True)
 


### PR DESCRIPTION
This is the part, which converts `elftools/dwarf/constants.py` to use `enum.IntEnum` from https://github.com/eliben/pyelftools/pull/611#issuecomment-4337985938
- this will allow future type improvements as those `IntEnum`-classes can be used instead of the more generic `int` in many places
- It also moves some code related to `DW_CFA` from `callframe.py` to `constants.py` to handle the nitty-gritty details of the encoding
- It converts several large `if-elfi` sequences to _structural pattern matching_, which makes the code a little bit nicer to read and understand. (it also allows to detect the _unhandled_ cases more easily)

There is more potential future work afterwards:
- There are many cases, where `DW_CFA`-constants are compared by their `str`-representation; this could be converted to `Enum`-comparison
- Part from `elftools/dwarf/descriptions.py` could be moved to `constants.py` to better keep both in-sync.