### PR TITLE
Cleanup some tests builing bytes data

### DIFF
--- a/test/test_callframe.py
+++ b/test/test_callframe.py
@@ -27,40 +27,40 @@ class TestCallFrame(unittest.TestCase):
     def test_spec_sample_d6(self):
         # D.6 sample in DWARFv3
         s = BytesIO()
-        data = (b'' +
+        data = (
             # first comes the CIE
-            b'\x20\x00\x00\x00' +        # length
-            b'\xff\xff\xff\xff' +        # CIE_id
-            b'\x03\x00\x04\x7c' +        # version, augmentation, caf, daf
-            b'\x08' +                    # return address
-            b'\x0c\x07\x00' +
-            b'\x08\x00' +
-            b'\x07\x01' +
-            b'\x07\x02' +
-            b'\x07\x03' +
-            b'\x08\x04' +
-            b'\x08\x05' +
-            b'\x08\x06' +
-            b'\x08\x07' +
-            b'\x09\x08\x01' +
-            b'\x00' +
+            b'\x20\x00\x00\x00'        # length
+            b'\xff\xff\xff\xff'        # CIE_id
+            b'\x03\x00\x04\x7c'        # version, augmentation, caf, daf
+            b'\x08'                    # return address
+            b'\x0c\x07\x00'
+            b'\x08\x00'
+            b'\x07\x01'
+            b'\x07\x02'
+            b'\x07\x03'
+            b'\x08\x04'
+            b'\x08\x05'
+            b'\x08\x06'
+            b'\x08\x07'
+            b'\x09\x08\x01'
+            b'\x00'
 
             # then comes the FDE
-            b'\x28\x00\x00\x00' +        # length
-            b'\x00\x00\x00\x00' +        # CIE_pointer (to CIE at 0)
-            b'\x44\x33\x22\x11' +        # initial_location
-            b'\x54\x00\x00\x00' +        # address range
-            b'\x41' +
-            b'\x0e\x0c' + b'\x41' +
-            b'\x88\x01' + b'\x41' +
-            b'\x86\x02' + b'\x41' +
-            b'\x0d\x06' + b'\x41' +
-            b'\x84\x03' + b'\x4b' +
-            b'\xc4' + b'\x41' +
-            b'\xc6' +
-            b'\x0d\x07' + b'\x41' +
-            b'\xc8' + b'\x41' +
-            b'\x0e\x00' +
+            b'\x28\x00\x00\x00'        # length
+            b'\x00\x00\x00\x00'        # CIE_pointer (to CIE at 0)
+            b'\x44\x33\x22\x11'        # initial_location
+            b'\x54\x00\x00\x00'        # address range
+            b'\x41'
+            b'\x0e\x0c' b'\x41'
+            b'\x88\x01' b'\x41'
+            b'\x86\x02' b'\x41'
+            b'\x0d\x06' b'\x41'
+            b'\x84\x03' b'\x4b'
+            b'\xc4' b'\x41'
+            b'\xc6'
+            b'\x0d\x07' b'\x41'
+            b'\xc8' b'\x41'
+            b'\x0e\x00'
             b'\x00\x00'
             )
         s.write(data)
@@ -131,12 +131,12 @@ class TestCallFrame(unittest.TestCase):
 
     def test_describe_CFI_instructions(self):
         # The data here represents a single CIE
-        data = (b'' +
-            b'\x16\x00\x00\x00' +        # length
-            b'\xff\xff\xff\xff' +        # CIE_id
-            b'\x03\x00\x04\x7c' +        # version, augmentation, caf, daf
-            b'\x08' +                    # return address
-            b'\x0c\x07\x02' +
+        data = (
+            b'\x16\x00\x00\x00'        # length
+            b'\xff\xff\xff\xff'        # CIE_id
+            b'\x03\x00\x04\x7c'        # version, augmentation, caf, daf
+            b'\x08'                    # return address
+            b'\x0c\x07\x02'
             b'\x10\x02\x07\x03\x01\x02\x00\x00\x06\x06')
         s = BytesIO(data)
 
@@ -146,7 +146,7 @@ class TestCallFrame(unittest.TestCase):
 
         set_global_machine_arch('x86')
         self.assertEqual(describe_CFI_instructions(entries[0]),
-            (   '  DW_CFA_def_cfa: r7 (edi) ofs 2\n' +
+            (   '  DW_CFA_def_cfa: r7 (edi) ofs 2\n'
                 '  DW_CFA_expression: r2 (edx) (DW_OP_addr: 201; DW_OP_deref; DW_OP_deref)\n'))
 
     def test_CFIEntry_get_decoded(self):
@@ -172,33 +172,33 @@ class TestCallFrame(unittest.TestCase):
     def test_ehframe_fde_with_lsda_pointer(self):
         # CIE and FDE dumped from exceptions_0, offset 0xcc0
         # binary is at https://github.com/angr/binaries/blob/master/tests/x86_64/exceptions_0
-        data = (b'' +
+        data = (
             # CIE
-            b'\x1c\x00\x00\x00' +       # length
-            b'\x00\x00\x00\x00' +       # ID
-            b'\x01' +                   # version
-            b'\x7a\x50\x4c\x52\x00' +   # augmentation string
-            b'\x01' +                   # code alignment
-            b'\x78' +                   # data alignment
-            b'\x10' +                   # return address register
-            b'\x07' +                   # augmentation data length
-            b'\x9b' +                   # personality function pointer encoding
-            b'\x3d\x13\x20\x00' +       # personality function pointer
-            b'\x1b' +                   # LSDA pointer encoding
-            b'\x1b' +                   # FDE encoding
-            b'\x0c\x07\x08\x90' +       # initial instructions
-            b'\x01\x00\x00' +
+            b'\x1c\x00\x00\x00'       # length
+            b'\x00\x00\x00\x00'       # ID
+            b'\x01'                   # version
+            b'\x7a\x50\x4c\x52\x00'   # augmentation string
+            b'\x01'                   # code alignment
+            b'\x78'                   # data alignment
+            b'\x10'                   # return address register
+            b'\x07'                   # augmentation data length
+            b'\x9b'                   # personality function pointer encoding
+            b'\x3d\x13\x20\x00'       # personality function pointer
+            b'\x1b'                   # LSDA pointer encoding
+            b'\x1b'                   # FDE encoding
+            b'\x0c\x07\x08\x90'       # initial instructions
+            b'\x01\x00\x00'
             # FDE
-            b'\x24\x00\x00\x00' +       # length
-            b'\x24\x00\x00\x00' +       # CIE reference pointer
-            b'\x62\xfd\xff\xff' +       # pc begin
-            b'\x89\x00\x00\x00' +       # pc range
-            b'\x04' +                   # augmentation data length
-            b'\xb7\x00\x00\x00' +       # LSDA pointer
-            b'\x41\x0e\x10\x86' +       # initial instructions
-            b'\x02\x43\x0d\x06' +
-            b'\x45\x83\x03\x02' +
-            b'\x7f\x0c\x07\x08' +
+            b'\x24\x00\x00\x00'       # length
+            b'\x24\x00\x00\x00'       # CIE reference pointer
+            b'\x62\xfd\xff\xff'       # pc begin
+            b'\x89\x00\x00\x00'       # pc range
+            b'\x04'                   # augmentation data length
+            b'\xb7\x00\x00\x00'       # LSDA pointer
+            b'\x41\x0e\x10\x86'       # initial instructions
+            b'\x02\x43\x0d\x06'
+            b'\x45\x83\x03\x02'
+            b'\x7f\x0c\x07\x08'
             b'\x00\x00\x00'
             )
         s = BytesIO(data)

--- a/test/test_callframe.py
+++ b/test/test_callframe.py
@@ -26,8 +26,7 @@ class TestCallFrame(unittest.TestCase):
 
     def test_spec_sample_d6(self):
         # D.6 sample in DWARFv3
-        s = BytesIO()
-        data = (
+        s = BytesIO(
             # first comes the CIE
             b'\x20\x00\x00\x00'        # length
             b'\xff\xff\xff\xff'        # CIE_id
@@ -63,10 +62,9 @@ class TestCallFrame(unittest.TestCase):
             b'\x0e\x00'
             b'\x00\x00'
             )
-        s.write(data)
 
         structs = DWARFStructs(little_endian=True, dwarf_format=32, address_size=4)
-        cfi = CallFrameInfo(s, len(data), 0, structs)
+        cfi = CallFrameInfo(s, len(s.getbuffer()), 0, structs)
         entries = cfi.get_entries()
 
         self.assertEqual(len(entries), 2)
@@ -131,17 +129,16 @@ class TestCallFrame(unittest.TestCase):
 
     def test_describe_CFI_instructions(self):
         # The data here represents a single CIE
-        data = (
+        s = BytesIO(
             b'\x16\x00\x00\x00'        # length
             b'\xff\xff\xff\xff'        # CIE_id
             b'\x03\x00\x04\x7c'        # version, augmentation, caf, daf
             b'\x08'                    # return address
             b'\x0c\x07\x02'
             b'\x10\x02\x07\x03\x01\x02\x00\x00\x06\x06')
-        s = BytesIO(data)
 
         structs = DWARFStructs(little_endian=True, dwarf_format=32, address_size=4)
-        cfi = CallFrameInfo(s, len(data), 0, structs)
+        cfi = CallFrameInfo(s, len(s.getbuffer()), 0, structs)
         entries = cfi.get_entries()
 
         set_global_machine_arch('x86')
@@ -172,7 +169,7 @@ class TestCallFrame(unittest.TestCase):
     def test_ehframe_fde_with_lsda_pointer(self):
         # CIE and FDE dumped from exceptions_0, offset 0xcc0
         # binary is at https://github.com/angr/binaries/blob/master/tests/x86_64/exceptions_0
-        data = (
+        s = BytesIO(
             # CIE
             b'\x1c\x00\x00\x00'       # length
             b'\x00\x00\x00\x00'       # ID
@@ -201,10 +198,9 @@ class TestCallFrame(unittest.TestCase):
             b'\x7f\x0c\x07\x08'
             b'\x00\x00\x00'
             )
-        s = BytesIO(data)
 
         structs = DWARFStructs(little_endian=True, dwarf_format=32, address_size=8)
-        cfi = CallFrameInfo(s, len(data), 0, structs, for_eh_frame=True)
+        cfi = CallFrameInfo(s, len(s.getbuffer()), 0, structs, for_eh_frame=True)
         entries = cfi.get_entries()
 
         self.assertEqual(len(entries), 2)

--- a/test/test_dwarf_lineprogram.py
+++ b/test/test_dwarf_lineprogram.py
@@ -45,8 +45,7 @@ class TestLineProgram(unittest.TestCase):
 
     def test_spec_sample_59(self):
         # Sample in figure 59 of DWARFv3
-        s = BytesIO()
-        s.write(
+        s = BytesIO(
             b'\x02\xb9\x04'
             b'\x0b'
             b'\x38'
@@ -74,8 +73,7 @@ class TestLineProgram(unittest.TestCase):
 
     def test_spec_sample_60(self):
         # Sample in figure 60 of DWARFv3
-        s = BytesIO()
-        s.write(
+        s = BytesIO(
             b'\x09\x39\x02'
             b'\x0b'
             b'\x09\x03\x00'

--- a/test/test_dwarf_lineprogram.py
+++ b/test/test_dwarf_lineprogram.py
@@ -18,18 +18,18 @@ class TestLineProgram(unittest.TestCase):
         """
         ds = DWARFStructs(little_endian=True, dwarf_format=32, address_size=4)
         header = ds.Dwarf_lineprog_header.parse(
-            b'\x04\x10\x00\x00' +    # initial length
-            b'\x03\x00' +            # version
-            b'\x20\x00\x00\x00' +    # header length
-            b'\x01\x01\x01\x0F' +    # flags
-            b'\x0A' +                # opcode_base
-            b'\x00\x01\x04\x08\x0C\x01\x01\x01\x00' + # standard_opcode_lengths
+            b'\x04\x10\x00\x00'    # initial length
+            b'\x03\x00'            # version
+            b'\x20\x00\x00\x00'    # header length
+            b'\x01\x01\x01\x0F'    # flags
+            b'\x0A'                # opcode_base
+            b'\x00\x01\x04\x08\x0C\x01\x01\x01\x00' # standard_opcode_lengths
             # 2 dir names followed by a NULL
-            b'\x61\x62\x00\x70\x00\x00' +
+            b'\x61\x62\x00\x70\x00\x00'
             # a file entry
-            b'\x61\x72\x00\x0C\x0D\x0F' +
+            b'\x61\x72\x00\x0C\x0D\x0F'
             # and another entry
-            b'\x45\x50\x51\x00\x86\x12\x07\x08' +
+            b'\x45\x50\x51\x00\x86\x12\x07\x08'
             # followed by NULL
             b'\x00')
 
@@ -47,12 +47,12 @@ class TestLineProgram(unittest.TestCase):
         # Sample in figure 59 of DWARFv3
         s = BytesIO()
         s.write(
-            b'\x02\xb9\x04' +
-            b'\x0b' +
-            b'\x38' +
-            b'\x82' +
-            b'\x73' +
-            b'\x02\x02' +
+            b'\x02\xb9\x04'
+            b'\x0b'
+            b'\x38'
+            b'\x82'
+            b'\x73'
+            b'\x02\x02'
             b'\x00\x01\x01')
 
         lp = self._make_program_in_stream(s)
@@ -76,15 +76,15 @@ class TestLineProgram(unittest.TestCase):
         # Sample in figure 60 of DWARFv3
         s = BytesIO()
         s.write(
-            b'\x09\x39\x02' +
-            b'\x0b' +
-            b'\x09\x03\x00' +
-            b'\x0b' +
-            b'\x09\x08\x00' +
-            b'\x0a' +
-            b'\x09\x07\x00' +
-            b'\x0a' +
-            b'\x09\x02\x00' +
+            b'\x09\x39\x02'
+            b'\x0b'
+            b'\x09\x03\x00'
+            b'\x0b'
+            b'\x09\x08\x00'
+            b'\x0a'
+            b'\x09\x07\x00'
+            b'\x0a'
+            b'\x09\x02\x00'
             b'\x00\x01\x01')
 
         lp = self._make_program_in_stream(s)

--- a/test/test_dwarf_structs.py
+++ b/test/test_dwarf_structs.py
@@ -14,18 +14,18 @@ class TestDWARFStructs(unittest.TestCase):
         ds = DWARFStructs(little_endian=True, dwarf_format=32, address_size=4)
 
         c = ds.Dwarf_lineprog_header.parse(
-            b'\x04\x10\x00\x00' +    # initial length
-            b'\x02\x00' +            # version
-            b'\x20\x00\x00\x00' +    # header length
-            b'\x05\x10\x40\x50' +    # until and including line_range
-            b'\x06' +                # opcode_base
-            b'\x00\x01\x04\x08\x0C' + # standard_opcode_lengths
+            b'\x04\x10\x00\x00'    # initial length
+            b'\x02\x00'            # version
+            b'\x20\x00\x00\x00'    # header length
+            b'\x05\x10\x40\x50'    # until and including line_range
+            b'\x06'                # opcode_base
+            b'\x00\x01\x04\x08\x0C' # standard_opcode_lengths
             # 2 dir names followed by a NULL
-            b'\x61\x62\x00\x70\x00\x00' +
+            b'\x61\x62\x00\x70\x00\x00'
             # a file entry
-            b'\x61\x72\x00\x0C\x0D\x0F' +
+            b'\x61\x72\x00\x0C\x0D\x0F'
             # and another entry
-            b'\x45\x50\x51\x00\x86\x12\x07\x08' +
+            b'\x45\x50\x51\x00\x86\x12\x07\x08'
             # followed by NULL
             b'\x00')
         self.assertEqual(c.version, 2)


### PR DESCRIPTION
Some more cleanup to `test/` while working on https://github.com/eliben/pyelftools/pull/611
- Use explicit sting/byte concatenation
- Get rid of intermediate variable `data` and initialize `BytesIO()` directly