### PR TITLE
Typing unrelated fixes

### DIFF
--- a/elftools/dwarf/datatype_cpp.py
+++ b/elftools/dwarf/datatype_cpp.py
@@ -98,8 +98,8 @@ def parse_cpp_datatype(var_die):
 
     # Check the nesting - important for parameters
     parent = type_die.get_parent()
-    scopes = list()
-    while parent.tag in ('DW_TAG_class_type', 'DW_TAG_structure_type', 'DW_TAG_union_type', 'DW_TAG_namespace'):
+    scopes = []
+    while parent and parent.tag in ('DW_TAG_class_type', 'DW_TAG_structure_type', 'DW_TAG_union_type', 'DW_TAG_namespace'):
         scopes.insert(0, safe_DIE_name(parent, _strip_type_tag(parent) + " "))
         # If unnamed scope, fall back to scope type - like "structure "
         parent = parent.get_parent()
@@ -199,7 +199,7 @@ def get_class_spec_if_member(func_spec, the_func):
     parent = func_spec.get_parent()
 
     scopes = []
-    while parent.tag in ("DW_TAG_class_type", "DW_TAG_structure_type", "DW_TAG_namespace"):
+    while parent and parent.tag in ("DW_TAG_class_type", "DW_TAG_structure_type", "DW_TAG_namespace"):
         scopes.insert(0, DIE_name(parent))
         parent = parent.get_parent()
     if scopes:

--- a/elftools/dwarf/datatype_cpp.py
+++ b/elftools/dwarf/datatype_cpp.py
@@ -224,7 +224,7 @@ def DIE_is_ptr_to_member_struct(type_die):
 
 def _strip_type_tag(die):
     """Given a DIE with DW_TAG_foo_type, returns foo"""
-    if isinstance(die.tag, int): # User-defined tag
+    if not isinstance(die.tag, str): # User-defined tag
         return ""
     return die.tag[7:-5]
 

--- a/elftools/dwarf/die.py
+++ b/elftools/dwarf/die.py
@@ -261,7 +261,9 @@ class DIE:
                     (form, raw_value, indirection_length) = self._resolve_indirect()
                     value = self._translate_attr_value(form, raw_value)
                 else:
-                    raw_value = structs.Dwarf_dw_form[form].parse_stream(stream)
+                    dw_form = structs.Dwarf_dw_form[form]
+                    assert dw_form is not None
+                    raw_value = dw_form.parse_stream(stream)
                     value = self._translate_attr_value(form, raw_value)
                 self.attributes[name] = AttributeValue(
                     name=name,
@@ -288,7 +290,9 @@ class DIE:
             except KeyError:
                 raise DWARFError('Found DW_FORM_indirect with unknown real form 0x%x' % real_form_code)
 
-            raw_value = struct_parse(structs.Dwarf_dw_form[real_form], self.stream)
+            dw_form = structs.Dwarf_dw_form[real_form]
+            assert dw_form is not None
+            raw_value: int = struct_parse(dw_form, self.stream)
 
             if real_form != 'DW_FORM_indirect': # Happy path: one level of indirection
                 return (real_form, raw_value, length)

--- a/elftools/dwarf/die.py
+++ b/elftools/dwarf/die.py
@@ -198,7 +198,7 @@ class DIE:
                     prev = child
 
             # We also need to check the offset of the terminator DIE
-            if search.has_children and search._terminator.offset <= self.offset:
+            if search.has_children and search._terminator and search._terminator.offset <= self.offset:
                     prev = search._terminator
 
             # If we didn't find a closer parent, give up, don't loop.

--- a/elftools/dwarf/locationlists.py
+++ b/elftools/dwarf/locationlists.py
@@ -312,8 +312,7 @@ class LocationParser:
                 # We might get it without a full tree traversal using
                 # attr.offset as a key, but we assume a good DWARF5
                 # aware consumer would pass a DIE along.
-        else:
-            raise ValueError("Attribute does not have location information")
+        raise ValueError("Attribute does not have location information")
 
     #------ PRIVATE ------#
 

--- a/elftools/ehabi/ehabiinfo.py
+++ b/elftools/ehabi/ehabiinfo.py
@@ -48,7 +48,7 @@ class EHABIInfo:
         """ Get the exception handler entry at index #n. (EHABIEntry object or a subclass)
         """
         if n >= self.num_entry():
-            raise IndexError('Invalid entry %d/%d' % (n, self._num_entry))
+            raise IndexError('Invalid entry %d/%d' % (n, self.num_entry()))
         eh_index_entry_offset = self.section_offset() + n * EHABI_INDEX_ENTRY_SIZE
         eh_index_data = struct_parse(self._struct.EH_index_struct, self._arm_idx_section.stream, eh_index_entry_offset)
         word0, word1 = eh_index_data['word0'], eh_index_data['word1']

--- a/elftools/elf/descriptions.py
+++ b/elftools/elf/descriptions.py
@@ -58,7 +58,7 @@ def describe_e_version_numeric(x):
 
 def describe_p_type(x):
     if x in _DESCR_P_TYPE:
-        return _DESCR_P_TYPE.get(x)
+        return _DESCR_P_TYPE[x]
     elif x >= ENUM_P_TYPE_BASE['PT_LOOS'] and x <= ENUM_P_TYPE_BASE['PT_HIOS']:
         return 'LOOS+%lx' % (x - ENUM_P_TYPE_BASE['PT_LOOS'])
     else:
@@ -90,7 +90,7 @@ def describe_rh_flags(x):
 
 def describe_sh_type(x):
     if x in _DESCR_SH_TYPE:
-        return _DESCR_SH_TYPE.get(x)
+        return _DESCR_SH_TYPE[x]
     elif (x >= ENUM_SH_TYPE_BASE['SHT_LOOS'] and
           x < ENUM_SH_TYPE_BASE['SHT_GNU_versym']):
         return 'loos+0x%lx' % (x - ENUM_SH_TYPE_BASE['SHT_LOOS'])

--- a/elftools/elf/dynamic.py
+++ b/elftools/elf/dynamic.py
@@ -187,6 +187,8 @@ class Dynamic:
                 self._num_tags = n + 1
                 return self._num_tags
 
+        return None
+
     def get_relocation_tables(self):
         """ Load all available relocation tables from DYNAMIC tags.
 

--- a/elftools/elf/elffile.py
+++ b/elftools/elf/elffile.py
@@ -139,7 +139,9 @@ class ELFFile:
         # sh_size field of the section header at index 0 (otherwise, the sh_size
         # member of the initial entry contains 0)."
         if self['e_shnum'] == 0:
-            return self._get_section_header(0)['sh_size']
+            section_header = self._get_section_header(0)
+            assert section_header is not None
+            return section_header['sh_size']
         return self['e_shnum']
 
     def get_section(self, n, type=None):
@@ -159,7 +161,9 @@ class ELFFile:
         section_header = self._get_section_header(n)
         if section_header['sh_type'] not in ('SHT_SYMTAB', 'SHT_DYNSYM'):
             raise ELFError("Section points at section %d of type %s, expected SHT_SYMTAB/SHT_DYNSYM" % (n, section_header['sh_type']))
-        return self._make_section(section_header)
+        section = self._make_section(section_header)
+        assert isinstance(section, SymbolTableSection)
+        return section
 
     def _get_linked_strtab_section(self, n):
         """ Get the section at index #n from the file, throws
@@ -169,7 +173,9 @@ class ELFFile:
         section_header = self._get_section_header(n)
         if section_header['sh_type'] != 'SHT_STRTAB':
             raise ELFError("SHT_SYMTAB section points at section %d of type %s, expected SHT_STRTAB" % (n, section_header['sh_type']))
-        return self._make_section(section_header)
+        section = self._make_section(section_header)
+        assert isinstance(section, StringTableSection)
+        return section
 
     def get_section_by_name(self, name):
         """ Get a section from the file, by name. Return None if no such
@@ -623,7 +629,9 @@ class ELFFile:
         if self['e_shstrndx'] != SHN_INDICES.SHN_XINDEX:
             return self['e_shstrndx']
         else:
-            return self._get_section_header(0)['sh_link']
+            section_header = self._get_section_header(0)
+            assert section_header is not None
+            return section_header['sh_link']
 
     #-------------------------------- PRIVATE --------------------------------#
 

--- a/elftools/elf/hash.py
+++ b/elftools/elf/hash.py
@@ -63,7 +63,7 @@ class ELFHashTable:
         symndx = self.params['buckets'][hval]
         while symndx != 0:
             sym = self._symboltable.get_symbol(symndx)
-            if sym.name == name:
+            if sym and sym.name == name:
                 return sym
             symndx = self.params['chains'][symndx]
         return None
@@ -171,7 +171,7 @@ class GNUHashTable:
             cur_hash = struct.unpack(hash_format, self.elffile.stream.read(self._wordsize))[0]
             if cur_hash | 1 == namehash | 1:
                 symbol = self._symboltable.get_symbol(symidx)
-                if name == symbol.name:
+                if symbol and name == symbol.name:
                     return symbol
 
             if cur_hash & 1:


### PR DESCRIPTION
While working on https://github.com/eliben/pyelftools/pull/611#issuecomment-4337985938 I found several potential bugs or issues, which complicate type-checking
- using wrong format string
- missing check for `None`
- checking `Union` for _wrong_ branch
- not returning `None` explicitly
- not raising `ValueError` in all cases