### PR TITLE
construct: Harmonize remaining __slots__

### DIFF
--- a/elftools/construct/debug.py
+++ b/elftools/construct/debug.py
@@ -36,10 +36,10 @@ class Probe(Construct):
         UBInt8("b"),
     )
     """
-    __slots__ = [
+    __slots__ = (
         "printname", "show_stream", "show_context", "show_stack",
         "stream_lookahead"
-    ]
+    )
     counter = 0
 
     def __init__(self, name: str | None = None, show_stream: bool = True,
@@ -108,7 +108,7 @@ class Debugger(Subconstruct):
         )
     )
     """
-    __slots__ = ["retval"]
+    __slots__ = ("retval",)
     def _parse(self, stream: IO[bytes], context: Container) -> Any:
         try:
             return self.subcon._parse(stream, context)

--- a/elftools/construct/lib/container.py
+++ b/elftools/construct/lib/container.py
@@ -137,7 +137,7 @@ class ListContainer(list[Any]):
     A container for lists.
     """
 
-    __slots__ = ["__recursion_lock__"]
+    __slots__ = ("__recursion_lock__",)
 
     @recursion_lock("[...]")
     def __str__(self) -> str:
@@ -145,7 +145,7 @@ class ListContainer(list[Any]):
 
 class LazyContainer:
 
-    __slots__ = ["subcon", "stream", "pos", "context", "_value"]
+    __slots__ = ("subcon", "stream", "pos", "context", "_value")
 
     def __init__(self, subcon: Construct, stream: IO[bytes], pos: int, context: Container) -> None:
         self.subcon = subcon


### PR DESCRIPTION
This are the typing fixes related to the vendored `elftools/construct/` from https://github.com/eliben/pyelftools/pull/611#issuecomment-4337985938 — all of them have been found while working on making `mypy`/`pyright`/`pyrefly`/`ty` happy

-  Convert the remaining `__slots__` of 4 `class`es in 2 files from `list` to `tuple` for consistency – forgotten on #636