### PR TITLE
More cleanups before adding type hints

### DIFF
--- a/elftools/dwarf/callframe.py
+++ b/elftools/dwarf/callframe.py
@@ -135,6 +135,8 @@ class CallFrameInfo:
 
         # If the augmentation string is not empty, hope to find a length field
         # in order to skip the data specified augmentation.
+        lsda_pointer = None
+        aug_dict = None
         if is_CIE:
             aug_bytes, aug_dict = self._parse_cie_augmentation(
                     header, entry_structs)
@@ -147,8 +149,6 @@ class CallFrameInfo:
                 lsda_pointer = self._parse_lsda_pointer(entry_structs,
                                                         self.stream.tell() - len(aug_bytes),
                                                         lsda_encoding)
-            else:
-                lsda_pointer = None
 
         # For convenience, compute the end offset for this entry
         end_offset = (
@@ -495,6 +495,7 @@ class CFIEntry:
         """ Decode the instructions contained in the given CFI entry and return
             a DecodedCallFrameTable.
         """
+        last_line_in_CIE = None
         if isinstance(self, CIE):
             # For a CIE, initialize cur_line to an "empty" line
             cie = self

--- a/elftools/dwarf/datatype_cpp.py
+++ b/elftools/dwarf/datatype_cpp.py
@@ -60,8 +60,11 @@ def parse_cpp_datatype(var_die):
             ptr_prefix = ''
 
         if t.tag == 'subroutine':
-            params = tuple(format_function_param(p, p) for p in type_die.iter_children() if p.tag in ("DW_TAG_formal_parameter", "DW_TAG_unspecified_parameters") and 'DW_AT_artificial' not in p.attributes)
-            params = ", ".join(params)
+            params = ", ".join(
+                format_function_param(p, p)
+                for p in type_die.iter_children()
+                if p.tag in ("DW_TAG_formal_parameter", "DW_TAG_unspecified_parameters") and 'DW_AT_artificial' not in p.attributes
+            )
             if 'DW_AT_type' in type_die.attributes:
                 datatype = parse_cpp_datatype(type_die)
                 is_pointer = datatype.modifiers and datatype.modifiers[-1] == 'pointer'

--- a/elftools/dwarf/datatype_cpp.py
+++ b/elftools/dwarf/datatype_cpp.py
@@ -63,9 +63,9 @@ def parse_cpp_datatype(var_die):
             params = tuple(format_function_param(p, p) for p in type_die.iter_children() if p.tag in ("DW_TAG_formal_parameter", "DW_TAG_unspecified_parameters") and 'DW_AT_artificial' not in p.attributes)
             params = ", ".join(params)
             if 'DW_AT_type' in type_die.attributes:
-                retval_type = parse_cpp_datatype(type_die)
-                is_pointer = retval_type.modifiers and retval_type.modifiers[-1] == 'pointer'
-                retval_type = str(retval_type)
+                datatype = parse_cpp_datatype(type_die)
+                is_pointer = datatype.modifiers and datatype.modifiers[-1] == 'pointer'
+                retval_type = str(datatype)
                 if not is_pointer:
                     retval_type += " "
             else:

--- a/elftools/dwarf/locationlists.py
+++ b/elftools/dwarf/locationlists.py
@@ -151,8 +151,7 @@ class LocationLists:
                             list_offset = attr.value
                             all_offsets.add(list_offset)
                             cu_map[list_offset] = cu
-        all_offsets = list(all_offsets)
-        all_offsets.sort()
+        sorted_offsets = sorted(all_offsets)
 
         if ver5:
             # Loclists section is organized as an array of CUs, each length prefixed.
@@ -172,7 +171,7 @@ class LocationLists:
 
                 while stream.tell() < cu_end_offset:
                     # Skip the gap to the next object
-                    next_offset = all_offsets[offset_index]
+                    next_offset = sorted_offsets[offset_index]
                     if next_offset == stream.tell(): # At an object, either a loc list or a loc view pair
                         locview_pairs = self._parse_locview_pairs(locviews)
                         entries = self._parse_location_list_from_stream_v5(cu_map[stream.tell()])
@@ -183,7 +182,7 @@ class LocationLists:
                             next_offset = cu_end_offset # And implicitly quit the loop within the CU
                         stream.seek(next_offset, os.SEEK_SET)
         else:
-            for offset in all_offsets:
+            for offset in sorted_offsets:
                 list_offset = locviews.get(offset, offset)
                 if cu_map[list_offset].header.version < 5:
                     stream.seek(offset, os.SEEK_SET)

--- a/elftools/dwarf/locationlists.py
+++ b/elftools/dwarf/locationlists.py
@@ -92,10 +92,12 @@ class LocationLists:
         Passing the die is only neccessary in DWARF5+, for decoding
         location entry encodings that contain references to other sections.
         """
-        if self.version >= 5 and die is None:
-            raise DWARFError("For this binary, \"die\" needs to be provided")
         self.stream.seek(offset, os.SEEK_SET)
-        return self._parse_location_list_from_stream_v5(die.cu) if self.version >= 5 else self._parse_location_list_from_stream()
+        if self.version >= 5:
+            if die is None:
+                raise DWARFError("For this binary, \"die\" needs to be provided")
+            return self._parse_location_list_from_stream_v5(die.cu)
+        return self._parse_location_list_from_stream()
 
     def iter_location_lists(self):
         """ Iterates through location lists and view pairs. Returns lists of

--- a/elftools/ehabi/ehabiinfo.py
+++ b/elftools/ehabi/ehabiinfo.py
@@ -154,11 +154,16 @@ class EHABIEntry:
             return None
 
     def __repr__(self):
-        return "<EHABIEntry function_offset=0x%x, personality=%d, %sbytecode=%s>" % (
-            self.function_offset,
-            self.personality,
-            "eh_table_offset=0x%x, " % self.eh_table_offset if self.eh_table_offset else "",
-            self.bytecode_array)
+        fo = self.function_offset
+        to = self.eh_table_offset
+        return (
+	    "<EHABIEntry"
+            f" function_offset={'' if fo is None else '{fo:#x}'}"
+            f", personaality={self.personality}"
+            f"{', eh_table_offset={to:#x}' if to else ''}"
+            f", bytecode={self.bytecode_array}"
+            ">"
+        )
 
 
 class CorruptEHABIEntry(EHABIEntry):

--- a/elftools/elf/descriptions.py
+++ b/elftools/elf/descriptions.py
@@ -327,12 +327,15 @@ def describe_note_gnu_properties(properties, machine):
                 prop_desc = ' <corrupt length: 0x%x>' % sz
             else:
                 prop_desc = describe_note_gnu_property_bitmap_and(_DESCR_NOTE_GNU_PROPERTY_RISCV_FEATURE_1_AND, 'RISC-V AND feature', d)
-        elif _DESCR_NOTE_GNU_PROPERTY_TYPE_LOPROC <= t <= _DESCR_NOTE_GNU_PROPERTY_TYPE_HIPROC:
-            prop_desc = '<processor-specific type 0x%x data: %s >' % (t, bytes2hex(d, sep=' '))
-        elif _DESCR_NOTE_GNU_PROPERTY_TYPE_LOUSER <= t <= _DESCR_NOTE_GNU_PROPERTY_TYPE_HIUSER:
-            prop_desc = '<application-specific type 0x%x data: %s >' % (t, bytes2hex(d, sep=' '))
+        elif isinstance(t, int):
+            if _DESCR_NOTE_GNU_PROPERTY_TYPE_LOPROC <= t <= _DESCR_NOTE_GNU_PROPERTY_TYPE_HIPROC:
+                prop_desc = f"<processor-specific type {t:#x} data: {bytes2hex(d, sep=' ')} >"
+            elif _DESCR_NOTE_GNU_PROPERTY_TYPE_LOUSER <= t <= _DESCR_NOTE_GNU_PROPERTY_TYPE_HIUSER:
+                prop_desc = f"<application-specific type {t:#x} data: {bytes2hex(d, sep=' ')} >"
+            else:
+                prop_desc = f"<unknown type {t:#x} data: {bytes2hex(d, sep=' ')} >"
         else:
-            prop_desc = '<unknown type 0x%x data: %s >' % (t, bytes2hex(d, sep=' '))
+            prop_desc = "<unknown type {t:r} data: {bytes2hex(d, sep=' ')} >"
         descriptions.append(prop_desc)
     return '\n        '.join(descriptions)
 

--- a/elftools/elf/elffile.py
+++ b/elftools/elf/elffile.py
@@ -309,20 +309,21 @@ class ELFFile:
                 # is relative to the other file's directory as opposed to this file's directory.
                 return ext_elffile.get_dwarf_info(relocate_dwarf_sections=relocate_dwarf_sections, follow_links=True)
 
-        section_names = ('.debug_info', '.debug_aranges', '.debug_abbrev',
+        section_names = ['.debug_info', '.debug_aranges', '.debug_abbrev',
                          '.debug_str', '.debug_line', '.debug_frame',
                          '.debug_loc', '.debug_ranges', '.debug_pubtypes',
                          '.debug_pubnames', '.debug_addr',
                          '.debug_str_offsets', '.debug_line_str',
                          '.debug_loclists', '.debug_rnglists',
-                         '.debug_sup', '.gnu_debugaltlink', '.debug_types')
+                         '.debug_sup', '.gnu_debugaltlink', '.debug_types',
+                         ]
 
         compressed = self.has_section('.zdebug_info')
         if compressed:
-            section_names = tuple(map(lambda x: '.z' + x[1:], section_names))
+            section_names = [f'.z{s[1:]}' for s in section_names]
 
         # As it is loaded in the process image, .eh_frame cannot be compressed
-        section_names += ('.eh_frame', )
+        section_names.append('.eh_frame')
 
         (debug_info_sec_name, debug_aranges_sec_name, debug_abbrev_sec_name,
          debug_str_sec_name, debug_line_sec_name, debug_frame_sec_name,

--- a/elftools/elf/sections.py
+++ b/elftools/elf/sections.py
@@ -90,9 +90,13 @@ class Section:
 
                 decomp = zlib.decompressobj()
                 result = decomp.decompress(compressed, self.data_size)
-            else:
+            elif isinstance(c_type, int):
                 raise ELFCompressionError(
                     'Unknown compression type: {:#0x}'.format(c_type)
+                )
+            else:
+                raise ELFCompressionError(
+                    'Unknown compression type: {!r}'.format(c_type)
                 )
 
             if len(result) != self._decompressed_size:

--- a/elftools/elf/sections.py
+++ b/elftools/elf/sections.py
@@ -302,9 +302,14 @@ class StabSection(Section):
 class Attribute:
     """ Attribute object - representing a build attribute of ELF files.
     """
-    def __init__(self, tag):
-        self._tag = tag
+
+    def __init__(self, structs, stream):
+        self._tag = self._parse(structs, stream)
         self.extra = None
+
+    @classmethod
+    def _parse(cls, structs, stream):
+        raise NotImplementedError
 
     @property
     def tag(self):
@@ -320,11 +325,10 @@ class Attribute:
 class AttributesSubsubsection(Section):
     """ Subsubsection of an ELF attribute section's subsection.
     """
-    def __init__(self, stream, structs, offset, attribute):
+    def __init__(self, stream, structs, offset):
         self.stream = stream
         self.offset = offset
         self.structs = structs
-        self.attribute = attribute
 
         self.header = self.attribute(self.structs, self.stream)
 
@@ -369,13 +373,14 @@ class AttributesSubsubsection(Section):
 class AttributesSubsection(Section):
     """ Subsection of an ELF attributes section.
     """
-    def __init__(self, stream, structs, offset, header, subsubsection):
+    subsubsection = AttributesSubsubsection
+
+    def __init__(self, stream, structs, offset):
         self.stream = stream
         self.offset = offset
         self.structs = structs
-        self.subsubsection = subsubsection
 
-        self.header = struct_parse(header, self.stream, self.offset)
+        self.header = struct_parse(structs.Elf_Attr_Subsection_Header, self.stream, self.offset)
 
         self.subsubsec_start = self.stream.tell()
 
@@ -426,9 +431,10 @@ class AttributesSubsection(Section):
 class AttributesSection(Section):
     """ ELF attributes section.
     """
-    def __init__(self, header, name, elffile, subsection):
+    subsection = AttributesSubsection
+
+    def __init__(self, header, name, elffile):
         super().__init__(header, name, elffile)
-        self.subsection = subsection
 
         fv = struct_parse(self.structs.Elf_byte('format_version'),
                           self.stream,
@@ -476,9 +482,13 @@ class AttributesSection(Section):
 class ARMAttribute(Attribute):
     """ ARM attribute object - representing a build attribute of ARM ELF files.
     """
+
+    @classmethod
+    def _parse(cls, structs, stream):
+        return struct_parse(structs.Elf_Arm_Attribute_Tag, stream)
+
     def __init__(self, structs, stream):
-        super().__init__(
-            struct_parse(structs.Elf_Arm_Attribute_Tag, stream))
+        super().__init__(structs, stream)
 
         if self.tag in ('TAG_FILE', 'TAG_SECTION', 'TAG_SYMBOL'):
             self.value = struct_parse(structs.Elf_word('value'), stream)
@@ -518,35 +528,31 @@ class ARMAttribute(Attribute):
 class ARMAttributesSubsubsection(AttributesSubsubsection):
     """ Subsubsection of an ELF .ARM.attributes section's subsection.
     """
-    def __init__(self, stream, structs, offset):
-        super().__init__(
-            stream, structs, offset, ARMAttribute)
+    attribute = ARMAttribute
 
 
 class ARMAttributesSubsection(AttributesSubsection):
     """ Subsection of an ELF .ARM.attributes section.
     """
-    def __init__(self, stream, structs, offset):
-        super().__init__(
-            stream, structs, offset,
-            structs.Elf_Attr_Subsection_Header,
-            ARMAttributesSubsubsection)
+    subsubsection = ARMAttributesSubsubsection
 
 
 class ARMAttributesSection(AttributesSection):
     """ ELF .ARM.attributes section.
     """
-    def __init__(self, header, name, elffile):
-        super().__init__(
-            header, name, elffile, ARMAttributesSubsection)
+    subsection = ARMAttributesSubsection
 
 
 class RISCVAttribute(Attribute):
     """ Attribute of an ELF .riscv.attributes section.
     """
+
+    @classmethod
+    def _parse(cls, structs, stream):
+        return struct_parse(structs.Elf_RiscV_Attribute_Tag, stream)
+
     def __init__(self, structs, stream):
-        super().__init__(
-            struct_parse(structs.Elf_RiscV_Attribute_Tag, stream))
+        super().__init__(structs, stream)
 
         if self.tag in ('TAG_FILE', 'TAG_SECTION', 'TAG_SYMBOL'):
             self.value = struct_parse(structs.Elf_word('value'), stream)
@@ -572,24 +578,16 @@ class RISCVAttribute(Attribute):
 class RISCVAttributesSubsubsection(AttributesSubsubsection):
     """ Subsubsection of an ELF .riscv.attributes subsection.
     """
-    def __init__(self, stream, structs, offset):
-        super().__init__(
-            stream, structs, offset, RISCVAttribute)
+    attribute = RISCVAttribute
 
 
 class RISCVAttributesSubsection(AttributesSubsection):
     """ Subsection of an ELF .riscv.attributes section.
     """
-    def __init__(self, stream, structs, offset):
-        super().__init__(
-            stream, structs, offset,
-            structs.Elf_Attr_Subsection_Header,
-            RISCVAttributesSubsubsection)
+    subsubsection = RISCVAttributesSubsubsection
 
 
 class RISCVAttributesSection(AttributesSection):
     """ ELF .riscv.attributes section.
     """
-    def __init__(self, header, name, elffile):
-        super().__init__(
-            header, name, elffile, RISCVAttributesSubsection)
+    subsection = RISCVAttributesSubsection

--- a/test/run_readelf_tests.py
+++ b/test/run_readelf_tests.py
@@ -116,13 +116,13 @@ def run_test_on_file(filename, verbose=False, opt=None):
         stdouts = []
         for exe_path in [READELF_PATH, 'scripts/readelf.py']:
             args = [option, filename]
-            if verbose: testlog.info("....executing: '%s %s'" % (
-                exe_path, ' '.join(args)))
+            cmd = " ".join((exe_path, *args))
+            if verbose: testlog.info("....executing: '%s'" % (cmd,))
             t1 = time.time()
             rc, stdout = run_exe(exe_path, args)
             if verbose: testlog.info("....elapsed: %s" % (time.time() - t1,))
             if rc != 0:
-                testlog.error("@@ aborting - '%s %s' returned '%s'" % (exe_path, option, rc))
+                testlog.error("@@ aborting - '%s' returned '%s'" % (cmd, rc))
                 return False
             stdouts.append(stdout)
         if verbose: testlog.info('....comparing output...')

--- a/test/test_debuglink.py
+++ b/test/test_debuglink.py
@@ -4,14 +4,15 @@
 # Gabriele Digregorio - Io_no
 # This code is in the public domain
 #-------------------------------------------------------------------------------
+from __future__ import annotations
 
-from elftools.elf.elffile import ELFFile
-from elftools.common.exceptions import ELFError
 import os
 import tempfile
 import unittest
-
 from typing import IO
+
+from elftools.common.exceptions import ELFError
+from elftools.elf.elffile import ELFFile
 
 
 class TestDebuglink(unittest.TestCase):
@@ -35,7 +36,7 @@ class TestDebuglink(unittest.TestCase):
         stream = open('test/testfiles_for_unittests/' + external_filename, 'rb')
         return stream
 
-    def subprograms_from_debuglink(self, elf: ELFFile) -> dict[str, (int, int)]:
+    def subprograms_from_debuglink(self, elf: ELFFile) -> dict[str, tuple[int, int]]:
         """Returns a dictionary containing the subprograms of the specified ELF file from the linked
         debug file.
         Args:


### PR DESCRIPTION
More from - fix some already existing types https://github.com/eliben/pyelftools/pull/611#issuecomment-4363868618
- fix some `printf` like output to handle all types, e.g. `None` or _not_ `int`
- rename some variables or change the code where variables are re-defined with a different type, which some type-checkers are allergic to.
- add many `assert` to make checks explicit where variables may be `None` or have multiple types
- Re-implement Attribute instantiation