### PR TITLE
typing: Convert to NamedTuple

### DIFF
--- a/elftools/dwarf/aranges.py
+++ b/elftools/dwarf/aranges.py
@@ -6,7 +6,8 @@
 # Dorothy Chen (dorothchen@gmail.com)
 # This code is in the public domain
 #-------------------------------------------------------------------------------
-from collections import namedtuple
+from typing import NamedTuple
+
 from ..common.utils import struct_parse
 from bisect import bisect_right
 import math
@@ -16,8 +17,15 @@ import math
 # length: The length of the address range in this entry
 # info_offset: The CU's offset into .debug_info
 # see 6.1.2 in DWARF4 docs for explanation of the remaining fields
-ARangeEntry = namedtuple('ARangeEntry',
-    'begin_addr length info_offset unit_length version address_size segment_size')
+class ARangeEntry(NamedTuple):
+    begin_addr: int
+    length: int
+    info_offset: int
+    unit_length: int
+    version: int
+    address_size: int
+    segment_size: int
+
 
 class ARanges:
     """ ARanges table in DWARF

--- a/elftools/dwarf/callframe.py
+++ b/elftools/dwarf/callframe.py
@@ -8,7 +8,7 @@
 #-------------------------------------------------------------------------------
 import copy
 import os
-from collections import namedtuple
+from typing import Any, NamedTuple
 from warnings import warn
 
 from ..common.utils import (
@@ -701,5 +701,6 @@ class CFARule:
 # A list of register numbers that are described in the table by the order of
 # their appearance.
 #
-DecodedCallFrameTable = namedtuple(
-    'DecodedCallFrameTable', 'table reg_order')
+class DecodedCallFrameTable(NamedTuple):
+    table: list[dict[str, Any]]
+    reg_order: list[int]

--- a/elftools/dwarf/die.py
+++ b/elftools/dwarf/die.py
@@ -6,8 +6,8 @@
 # Eli Bendersky (eliben@gmail.com)
 # This code is in the public domain
 #-------------------------------------------------------------------------------
-from collections import namedtuple
 import os
+from typing import Any, NamedTuple
 
 from ..common.exceptions import DWARFError, ELFParseError
 from ..common.utils import bytes2str, struct_parse
@@ -40,8 +40,13 @@ from ..construct import ConstructError
 #   If the form of the attribute is DW_FORM_indirect, the form will contain
 #   the resolved form, and this will contain the length of the indirection chain.
 #   0 means no indirection.
-AttributeValue = namedtuple(
-    'AttributeValue', 'name form value raw_value offset indirection_length')
+class AttributeValue(NamedTuple):
+    name: str
+    form: str
+    value: Any
+    raw_value: int
+    offset: int
+    indirection_length: int
 
 
 class DIE:

--- a/elftools/dwarf/dwarf_expr.py
+++ b/elftools/dwarf/dwarf_expr.py
@@ -6,8 +6,8 @@
 # Eli Bendersky (eliben@gmail.com)
 # This code is in the public domain
 #-------------------------------------------------------------------------------
-from collections import namedtuple
 from io import BytesIO
+from typing import Any, NamedTuple
 
 from ..common.utils import struct_parse, read_blob
 from ..common.exceptions import DWARFError
@@ -120,7 +120,11 @@ DW_OP_opcode2name = {v: k for k, v in DW_OP_name2opcode.items()}
 
 # Each parsed DWARF expression is returned as this type with its numeric opcode,
 # op name (as a string) and a list of arguments.
-DWARFExprOp = namedtuple('DWARFExprOp', 'op op_name args offset')
+class DWARFExprOp(NamedTuple):
+    op: int
+    op_name: str
+    args: list[Any]
+    offset: int
 
 
 class DWARFExprParser:

--- a/elftools/dwarf/dwarfinfo.py
+++ b/elftools/dwarf/dwarfinfo.py
@@ -6,8 +6,8 @@
 # Eli Bendersky (eliben@gmail.com)
 # This code is in the public domain
 #-------------------------------------------------------------------------------
-from collections import namedtuple
 from bisect import bisect_right
+from typing import IO, NamedTuple
 
 from ..construct.lib.container import Container
 from ..common.exceptions import DWARFError
@@ -38,8 +38,12 @@ from .dwarf_util import _get_base_offset
 # aren't strictly required for the DWARF parsing to work. 'address' is required
 # to properly decode the special '.eh_frame' format.
 #
-DebugSectionDescriptor = namedtuple('DebugSectionDescriptor',
-    'stream name global_offset size address')
+class DebugSectionDescriptor(NamedTuple):
+    stream: IO[bytes]
+    name: str
+    global_offset: int | None
+    size: int
+    address: int
 
 
 # Some configuration parameters for the DWARF reader. This exists to allow
@@ -54,8 +58,10 @@ DebugSectionDescriptor = namedtuple('DebugSectionDescriptor',
 # default_address_size:
 #   The default address size for the container file (sizeof pointer, in bytes)
 #
-DwarfConfig = namedtuple('DwarfConfig',
-    'little_endian machine_arch default_address_size')
+class DwarfConfig(NamedTuple):
+    little_endian: bool
+    machine_arch: str
+    default_address_size: int
 
 
 class DWARFInfo:

--- a/elftools/dwarf/lineprogram.py
+++ b/elftools/dwarf/lineprogram.py
@@ -6,9 +6,11 @@
 # Eli Bendersky (eliben@gmail.com)
 # This code is in the public domain
 #-------------------------------------------------------------------------------
+from __future__ import annotations
+
 import os
 import copy
-from collections import namedtuple
+from typing import NamedTuple
 
 from ..common.utils import struct_parse, dwarf_assert
 from .constants import DW_LNE, DW_LNS
@@ -36,8 +38,11 @@ from .constants import DW_LNE, DW_LNS
 #   For commands that add a new state, it's the relevant LineState object.
 #   For commands that don't add a new state, it's None.
 #
-LineProgramEntry = namedtuple(
-    'LineProgramEntry', 'command is_extended args state')
+class LineProgramEntry(NamedTuple):
+    command: int
+    is_extended: bool
+    args: list[int]
+    state: LineState | None
 
 
 class LineState:

--- a/elftools/dwarf/locationlists.py
+++ b/elftools/dwarf/locationlists.py
@@ -7,15 +7,37 @@
 # This code is in the public domain
 #-------------------------------------------------------------------------------
 import os
-from collections import namedtuple
+from typing import NamedTuple
+
 from ..common.exceptions import DWARFError
 from ..common.utils import struct_parse
 from .dwarf_util import _iter_CUs_in_section
 
-LocationExpr = namedtuple('LocationExpr', 'loc_expr')
-LocationEntry = namedtuple('LocationEntry', 'entry_offset entry_length begin_offset end_offset loc_expr is_absolute')
-BaseAddressEntry = namedtuple('BaseAddressEntry', 'entry_offset entry_length base_address')
-LocationViewPair = namedtuple('LocationViewPair', 'entry_offset begin end')
+
+class LocationExpr(NamedTuple):
+    loc_expr: list[int]
+
+
+class LocationEntry(NamedTuple):
+    entry_offset: int
+    entry_length: int
+    begin_offset: int
+    end_offset: int
+    loc_expr: list[int]
+    is_absolute: bool
+
+
+class BaseAddressEntry(NamedTuple):
+    entry_offset: int
+    entry_length: int
+    base_address: int
+
+
+class LocationViewPair(NamedTuple):
+    entry_offset: int
+    begin: int
+    end: int
+
 
 def _translate_startx_length(e, cu):
     start_offset = cu.dwarfinfo.get_addr(cu, e.start_index)

--- a/elftools/dwarf/namelut.py
+++ b/elftools/dwarf/namelut.py
@@ -6,12 +6,17 @@
 # Vijay Ramasami (rvijayc@gmail.com)
 # This code is in the public domain
 #-------------------------------------------------------------------------------
-import collections
 from collections.abc import Mapping
+from typing import NamedTuple
+
 from ..common.utils import struct_parse
 from ..construct import CString, Struct, If
 
-NameLUTEntry = collections.namedtuple('NameLUTEntry', 'cu_ofs die_ofs')
+
+class NameLUTEntry(NamedTuple):
+    cu_ofs: int
+    die_ofs: int
+
 
 class NameLUT(Mapping):
     """

--- a/elftools/dwarf/ranges.py
+++ b/elftools/dwarf/ranges.py
@@ -7,15 +7,25 @@
 # This code is in the public domain
 #-------------------------------------------------------------------------------
 import os
-from collections import namedtuple
+from typing import NamedTuple
 
 from ..common.utils import struct_parse
 from ..common.exceptions import DWARFError
 from .dwarf_util import _iter_CUs_in_section
 
 
-RangeEntry = namedtuple('RangeEntry', 'entry_offset entry_length begin_offset end_offset is_absolute')
-BaseAddressEntry = namedtuple('BaseAddressEntry', 'entry_offset base_address')
+class RangeEntry(NamedTuple):
+    entry_offset: int
+    entry_length: int
+    begin_offset: int
+    end_offset: int
+    is_absolute: bool
+
+
+class BaseAddressEntry(NamedTuple):
+    entry_offset: int
+    base_address: int
+
 # If we ever see a list with a base entry at the end, there will be an error that entry_length is not a field.
 
 def _translate_startx_length(e, cu):

--- a/elftools/ehabi/decoder.py
+++ b/elftools/ehabi/decoder.py
@@ -6,7 +6,9 @@
 # LeadroyaL (leadroyal@qq.com)
 # This code is in the public domain
 # -------------------------------------------------------------------------------
-from collections import namedtuple
+from __future__ import annotations
+
+from typing import Callable, NamedTuple
 
 
 class EHABIBytecodeDecoder:
@@ -244,7 +246,10 @@ class EHABIBytecodeDecoder:
         self._index += 1
         return 'spare'
 
-    _DECODE_RECIPE_TYPE = namedtuple('_DECODE_RECIPE_TYPE', 'mask value handler')
+    class _DECODE_RECIPE_TYPE(NamedTuple):
+        mask: int
+        value: int
+        handler: Callable[[EHABIBytecodeDecoder], str]
 
     ring = (
         _DECODE_RECIPE_TYPE(mask=0xc0, value=0x00, handler=_decode_00xxxxxx),

--- a/elftools/elf/relocation.py
+++ b/elftools/elf/relocation.py
@@ -6,7 +6,7 @@
 # Eli Bendersky (eliben@gmail.com)
 # This code is in the public domain
 #-------------------------------------------------------------------------------
-from collections import namedtuple
+from typing import Callable, NamedTuple
 
 from ..common.exceptions import ELFRelocationError
 from ..common.utils import elf_assert, struct_parse
@@ -368,8 +368,10 @@ class RelocationHandler:
     #  calc_func: A function that performs the relocation on an extracted
     #             value, and returns the updated value.
     #
-    _RELOCATION_RECIPE_TYPE = namedtuple('_RELOCATION_RECIPE_TYPE',
-        'bytesize has_addend calc_func')
+    class _RELOCATION_RECIPE_TYPE(NamedTuple):
+        bytesize: int
+        has_addend: bool
+        calc_func: Callable[..., int]
 
     _RELOCATION_RECIPES_ARM = {
         ENUM_RELOC_TYPE_ARM['R_ARM_ABS32']: _RELOCATION_RECIPE_TYPE(


### PR DESCRIPTION
Convert from legacy `collections.namedtuple` to `typing.NamedTuple` to allow adding type hints. Part of #611 