### PR TITLE
Python typing: elftools.common

### DIFF
--- a/elftools/common/construct_utils.py
+++ b/elftools/common/construct_utils.py
@@ -6,10 +6,19 @@
 # Eli Bendersky (eliben@gmail.com)
 # This code is in the public domain
 #-------------------------------------------------------------------------------
+from __future__ import annotations
+
 from struct import Struct
+from typing import IO, TYPE_CHECKING, Any, NoReturn
+
 from ..construct import (
     Subconstruct, ConstructError, ArrayError, SizeofError, Construct, StaticField, FieldError
     )
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterable
+
+    from ..construct import Container
 
 
 class RepeatUntilExcluding(Subconstruct):
@@ -21,12 +30,12 @@ class RepeatUntilExcluding(Subconstruct):
         P.S. removed some code duplication
     """
     __slots__ = ("predicate",)
-    def __init__(self, predicate, subcon):
+    def __init__(self, predicate: Callable[[Any, Container], bool], subcon: Construct) -> None:
         Subconstruct.__init__(self, subcon)
         self.predicate = predicate
         self._clear_flag(self.FLAG_COPY_CONTEXT)
         self._set_flag(self.FLAG_DYNAMIC)
-    def _parse(self, stream, context):
+    def _parse(self, stream: IO[bytes], context: Container) -> list[Any]:
         obj = []
         try:
             context_for_subcon = context
@@ -41,15 +50,15 @@ class RepeatUntilExcluding(Subconstruct):
         except ConstructError as ex:
             raise ArrayError("missing terminator", ex)
         return obj
-    def _build(self, obj, stream, context):
+    def _build(self, obj: Iterable[Any], stream: IO[bytes], context: Container) -> NoReturn:
         raise NotImplementedError('no building')
-    def _sizeof(self, context):
+    def _sizeof(self, context: Container) -> int:
         raise SizeofError("can't calculate size")
 
 class ULEB128(Construct):
     """A construct based parser for ULEB128 encoding.
     """
-    def _parse(self, stream, context):
+    def _parse(self, stream: IO[bytes], context: Container) -> int:
         value = 0
         shift = 0
         while True:
@@ -65,7 +74,7 @@ class ULEB128(Construct):
 class SLEB128(Construct):
     """A construct based parser for SLEB128 encoding.
     """
-    def _parse(self, stream, context):
+    def _parse(self, stream: IO[bytes], context: Container) -> int:
         value = 0
         shift = 0
         while True:
@@ -89,14 +98,14 @@ class StreamOffset(Construct):
     StreamOffset("item_offset")
     """
     __slots__ = ()
-    def __init__(self, name):
+    def __init__(self, name: str) -> None:
         Construct.__init__(self, name)
         self._set_flag(self.FLAG_DYNAMIC)
-    def _parse(self, stream, context):
+    def _parse(self, stream: IO[bytes], context: Container) -> int:
         return stream.tell()
-    def _build(self, obj, stream, context):
+    def _build(self, obj: None, stream: IO[bytes], context: Container) -> None:
         context[self.name] = stream.tell()
-    def _sizeof(self, context):
+    def _sizeof(self, context: Container) -> int:
         return 0
 
 _UBInt24_packer = Struct(">BH")
@@ -104,24 +113,24 @@ _ULInt24_packer = Struct("<HB")
 
 class UBInt24(StaticField):
     """unsigned, big endian 24-bit integer"""
-    def __init__(self, name):
+    def __init__(self, name: str) -> None:
         StaticField.__init__(self, name, 3)
 
-    def _parse(self, stream, context):
+    def _parse(self, stream: IO[bytes], context: Container) -> int:
         (h, l) = _UBInt24_packer.unpack(StaticField._parse(self, stream, context))
         return l | (h << 16)
 
-    def _build(self, obj, stream, context):
+    def _build(self, obj: int, stream: IO[bytes], context: Container) -> None:
         StaticField._build(self, _UBInt24_packer.pack(obj >> 16, obj & 0xFFFF), stream, context)
 
 class ULInt24(StaticField):
     """unsigned, little endian 24-bit integer"""
-    def __init__(self, name):
+    def __init__(self, name: str) -> None:
         StaticField.__init__(self, name, 3)
 
-    def _parse(self, stream, context):
+    def _parse(self, stream: IO[bytes], context: Container) -> int:
         (l, h) = _ULInt24_packer.unpack(StaticField._parse(self, stream, context))
         return l | (h << 16)
 
-    def _build(self, obj, stream, context):
+    def _build(self, obj: int, stream: IO[bytes], context: Container) -> None:
         StaticField._build(self, _ULInt24_packer.pack(obj & 0xFFFF, obj >> 16), stream, context)

--- a/elftools/common/construct_utils.py
+++ b/elftools/common/construct_utils.py
@@ -55,7 +55,13 @@ class RepeatUntilExcluding(Subconstruct):
     def _sizeof(self, context: Container) -> int:
         raise SizeofError("can't calculate size")
 
-class ULEB128(Construct):
+
+class _NamedConstruct(Construct):
+    if TYPE_CHECKING:
+        name: str  # instead of `str|None` from Construct to save us from `is None` checks everywhere
+
+
+class ULEB128(_NamedConstruct):
     """A construct based parser for ULEB128 encoding.
     """
     def _parse(self, stream: IO[bytes], context: Container) -> int:
@@ -71,7 +77,8 @@ class ULEB128(Construct):
             if b & 0x80 == 0:
                 return value
 
-class SLEB128(Construct):
+
+class SLEB128(_NamedConstruct):
     """A construct based parser for SLEB128 encoding.
     """
     def _parse(self, stream: IO[bytes], context: Container) -> int:
@@ -87,7 +94,8 @@ class SLEB128(Construct):
             if b & 0x80 == 0:
                 return value | (~0 << shift) if b & 0x40 else value
 
-class StreamOffset(Construct):
+
+class StreamOffset(_NamedConstruct):
     """
     Captures the current stream offset
 

--- a/elftools/common/utils.py
+++ b/elftools/common/utils.py
@@ -6,24 +6,45 @@
 # Eli Bendersky (eliben@gmail.com)
 # This code is in the public domain
 #-------------------------------------------------------------------------------
+from __future__ import annotations
+
 from contextlib import contextmanager
+from typing import IO, TYPE_CHECKING, Any, TypeVar, overload
+
 from .exceptions import ELFParseError, ELFError, DWARFError
 from ..construct import ConstructError, ULInt8
 import os
 
+if TYPE_CHECKING:
+    from collections.abc import Iterator, Mapping
 
-def merge_dicts(*dicts):
+    from ..construct import Construct, FormatField
+    from ..dwarf.dwarfinfo import DebugSectionDescriptor
+    from .construct_utils import SLEB128, ULEB128, UBInt24, ULInt24
+
+    _T = TypeVar("_T")
+    _K = TypeVar("_K")
+    _V = TypeVar("_V")
+
+
+def merge_dicts(*dicts: Mapping[_K, _V]) -> dict[_K, _V]:
     "Given any number of dicts, merges them into a new one."""
-    result = {}
+    result: dict[_K, _V] = {}
     for d in dicts:
         result.update(d)
     return result
 
-def bytes2str(b):
+def bytes2str(b: bytes) -> str:
     """Decode a bytes object into a string."""
     return b.decode('latin-1')
 
-def struct_parse(struct, stream, stream_pos=None):
+
+# Use @overload to get more specific type, e.g. [SU][BLN]{EB,Int}{8,16,24,32,64,128} -> int
+@overload
+def struct_parse(struct: FormatField[_T] | ULEB128 | SLEB128 | UBInt24 | ULInt24, stream: IO[bytes], stream_pos: int | None = ...) -> _T: ...
+@overload
+def struct_parse(struct: Construct, stream: IO[bytes], stream_pos: int | None = ...) -> Any: ...
+def struct_parse(struct: Construct, stream: IO[bytes], stream_pos: int | None = None) -> Any:
     """ Convenience function for using the given struct to parse a stream.
         If stream_pos is provided, the stream is seeked to this position before
         the parsing is done. Otherwise, the current position of the stream is
@@ -38,7 +59,7 @@ def struct_parse(struct, stream, stream_pos=None):
         raise ELFParseError(str(e))
 
 
-def parse_cstring_from_stream(stream, stream_pos=None):
+def parse_cstring_from_stream(stream: IO[bytes], stream_pos: int | None = None) -> bytes | None:
     """ Parse a C-string from the given stream. The string is returned without
         the terminating \x00 byte. If the terminating byte wasn't found, None
         is returned (the stream is exhausted).
@@ -67,20 +88,20 @@ def parse_cstring_from_stream(stream, stream_pos=None):
     return b''.join(chunks) if found else None
 
 
-def elf_assert(cond, msg=''):
+def elf_assert(cond: object, msg: str = '') -> None:
     """ Assert that cond is True, otherwise raise ELFError(msg)
     """
     _assert_with_exception(cond, msg, ELFError)
 
 
-def dwarf_assert(cond, msg=''):
+def dwarf_assert(cond: object, msg: str = '') -> None:
     """ Assert that cond is True, otherwise raise DWARFError(msg)
     """
     _assert_with_exception(cond, msg, DWARFError)
 
 
 @contextmanager
-def preserve_stream_pos(stream):
+def preserve_stream_pos(stream: IO[bytes]) -> Iterator[None]:
     """ Usage:
         # stream has some position FOO (return value of stream.tell())
         with preserve_stream_pos(stream):
@@ -92,18 +113,18 @@ def preserve_stream_pos(stream):
     stream.seek(saved_pos)
 
 
-def roundup(num, bits):
+def roundup(num: int, bits: int) -> int:
     """ Round up a number to nearest multiple of 2^bits. The result is a number
         where the least significant bits passed in bits are 0.
     """
     return (num - 1 | (1 << bits) - 1) + 1
 
-def read_blob(stream, length):
+def read_blob(stream: IO[bytes], length: int) -> list[int]:
     """Read length bytes from stream, return a list of ints
     """
     return [struct_parse(ULInt8(''), stream) for i in range(length)]
 
-def save_dwarf_section(section, filename):
+def save_dwarf_section(section: DebugSectionDescriptor, filename: str) -> None:
     """Debug helper: dump section contents into a file
     Section is expected to be one of the debug_xxx_sec elements of DWARFInfo
     """
@@ -116,7 +137,7 @@ def save_dwarf_section(section, filename):
         file.write(data)
     stream.seek(pos, os.SEEK_SET)
 
-def iterbytes(b):
+def iterbytes(b: bytes) -> Iterator[bytes]:
     """Return an iterator over the elements of a bytes object.
 
     For example, for b'abc' yields b'a', b'b' and then b'c'.
@@ -124,13 +145,13 @@ def iterbytes(b):
     for i in range(len(b)):
         yield b[i:i+1]
 
-def bytes2hex(b, sep=''):
+def bytes2hex(b: bytes, sep: str = '') -> str:
     if not sep:
         return b.hex()
     return sep.join(f'{o:02x}' for o in b)
 
 #------------------------- PRIVATE -------------------------
 
-def _assert_with_exception(cond, msg, exception_type):
+def _assert_with_exception(cond: object, msg: str, exception_type: type[BaseException]) -> None:
     if not cond:
         raise exception_type(msg)

--- a/elftools/construct/adapters.py
+++ b/elftools/construct/adapters.py
@@ -191,7 +191,7 @@ class PaddedStringAdapter(Adapter):
     """
     __slots__ = ("padchar", "paddir", "trimdir")
     def __init__(self, subcon: Construct, padchar: bytes = b"\x00", paddir: Literal["right", "left", "center"] = "right",
-            trimdir: Literal["right", "left"] = "right"):
+            trimdir: Literal["right", "left"] = "right") -> None:
         if paddir not in ("right", "left", "center"):
             raise ValueError("paddir must be 'right', 'left' or 'center'",
                 paddir)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,26 @@ packages = "elftools"
 # junit_xml = "mypy.junit.xml"
 junit_format = "per_file"
 
+[[tool.mypy.overrides]]
+module = "elftools.construct.*"
+follow_imports = "skip"
+ignore_errors = true
+
 [tool.pyright]
 include = [
     "elftools",
+]
+
+[tool.pyrefly]
+project-includes = [
+	"elftools",
+]
+ignore-missing-imports = [
+	"elftools.construct.*",
+]
+errors.bad-override-mutable-attribute = "ignore"
+
+[tool.ty.src]
+include = [
+	"elftools",
 ]


### PR DESCRIPTION
Add type hints to `elftools.common` – part of #611 

The `from __future__ import annotations`' are needed for the following reasons:
- Some types are only defined when `TYPE_CHECKING` is enabled, which is an internal variable all type-checkers set to `True`. This is mostly used to break `import`-cycles, which only type-checkers must handle then, but not regular run-times during normal execution. Also some `TypeVar`s are only relevant for type-checking and thus are defined in an `if TYPE_CHECKING`-block. Referencing them would result in a `NameError`, which the _stringifying_ `__future__.annotations` mitigates.
- [typeguard](https://typeguard.readthedocs.io/en/stable/userguide.html#notes-on-forward-reference-handling) also needs it; otherwise it will fail to resolve those references during regular runtime when it is enabled.