### PR TITLE
typing[enum,const]: Add / fix PEP-484 type hints

### DIFF
--- a/elftools/dwarf/constants.py
+++ b/elftools/dwarf/constants.py
@@ -6,15 +6,21 @@
 # Eli Bendersky (eliben@gmail.com)
 # This code is in the public domain
 #-------------------------------------------------------------------------------
+from __future__ import annotations
+
 from enum import Enum
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from typing_extensions import Self  # 3.11+
 
 
 class _IntEnum(int, Enum):  # Py3.11: enum.ReprEnum
-    def __repr__(self):
+    def __repr__(self) -> str:
         return int.__str__(self.value)
 
     @property  # Py3.11+: enum.property
-    def FQN(self):
+    def FQN(self) -> str:
         return f"{self.__class__.__name__}_{self.name}"
 
 
@@ -235,7 +241,7 @@ class DW_CFA(_IntEnum):
     GNU_args_size = 0x2e
 
     @classmethod
-    def parse_raw_opcode(cls, /, opcode, *, __MASK = 0b11_00_0000):
+    def parse_raw_opcode(cls, /, opcode: int, *, __MASK: int = 0b11_00_0000) -> tuple[Self, int] | tuple[Self]:
         """Extract primary or extended opcode from raw byte."""
         if primary := opcode & __MASK:
             return (cls(primary), opcode & ~__MASK)

--- a/elftools/elf/enums.py
+++ b/elftools/elf/enums.py
@@ -6,33 +6,40 @@
 # Eli Bendersky (eliben@gmail.com)
 # This code is in the public domain
 #-------------------------------------------------------------------------------
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from ..common.utils import merge_dicts
 from ..construct import Pass
 
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
 
 # e_ident[EI_CLASS] in the ELF header
-ENUM_EI_CLASS = dict(
+ENUM_EI_CLASS: Mapping[str, int] = dict(
     ELFCLASSNONE=0,
     ELFCLASS32=1,
     ELFCLASS64=2
 )
 
 # e_ident[EI_DATA] in the ELF header
-ENUM_EI_DATA = dict(
+ENUM_EI_DATA: Mapping[str, int] = dict(
     ELFDATANONE=0,
     ELFDATA2LSB=1,
     ELFDATA2MSB=2
 )
 
 # e_version in the ELF header
-ENUM_E_VERSION = dict(
+ENUM_E_VERSION: Mapping[str, int] = dict(
     EV_NONE=0,
     EV_CURRENT=1,
     _default_=Pass,
 )
 
 # e_ident[EI_OSABI] in the ELF header
-ENUM_EI_OSABI = dict(
+ENUM_EI_OSABI: Mapping[str, int] = dict(
     ELFOSABI_SYSV=0,
     ELFOSABI_HPUX=1,
     ELFOSABI_NETBSD=2,
@@ -59,7 +66,7 @@ ENUM_EI_OSABI = dict(
 )
 
 # e_type in the ELF header
-ENUM_E_TYPE = dict(
+ENUM_E_TYPE: Mapping[str, int] = dict(
     ET_NONE=0,
     ET_REL=1,
     ET_EXEC=2,
@@ -71,7 +78,7 @@ ENUM_E_TYPE = dict(
 )
 
 # e_machine in the ELF header
-ENUM_E_MACHINE = dict(
+ENUM_E_MACHINE: Mapping[str, int] = dict(
     EM_NONE          = 0,   # No machine
     EM_M32           = 1,   # AT&T WE 32100
     EM_SPARC         = 2,   # SPARC
@@ -278,7 +285,7 @@ ENUM_E_MACHINE = dict(
 # we later create per-processor dicts that use the LOPROC...HIPROC range to
 # define processor-specific values. The proper dict should be used based on the
 # machine the ELF header refers to.
-ENUM_SH_TYPE_BASE = dict(
+ENUM_SH_TYPE_BASE: Mapping[str, int] = dict(
     SHT_NULL=0,
     SHT_PROGBITS=1,
     SHT_SYMTAB=2,
@@ -318,11 +325,11 @@ ENUM_SH_TYPE_BASE = dict(
     _default_=Pass,
 )
 
-ENUM_SH_TYPE_AMD64 = merge_dicts(
+ENUM_SH_TYPE_AMD64: Mapping[str, int] = merge_dicts(
         ENUM_SH_TYPE_BASE,
         dict(SHT_AMD64_UNWIND=0x70000001))
 
-ENUM_SH_TYPE_ARM = merge_dicts(
+ENUM_SH_TYPE_ARM: Mapping[str, int] = merge_dicts(
         ENUM_SH_TYPE_BASE,
         dict(
             SHT_ARM_EXIDX=0x70000001,
@@ -330,15 +337,15 @@ ENUM_SH_TYPE_ARM = merge_dicts(
             SHT_ARM_ATTRIBUTES=0x70000003,
             SHT_ARM_DEBUGOVERLAY=0x70000004))
 
-ENUM_SH_TYPE_AARCH64 = merge_dicts(
+ENUM_SH_TYPE_AARCH64: Mapping[str, int] = merge_dicts(
         ENUM_SH_TYPE_BASE,
         dict(SHT_AARCH64_ATTRIBUTES=0x70000003))
 
-ENUM_SH_TYPE_RISCV = merge_dicts(
+ENUM_SH_TYPE_RISCV: Mapping[str, int] = merge_dicts(
         ENUM_SH_TYPE_BASE,
         dict(SHT_RISCV_ATTRIBUTES=0x70000003))
 
-ENUM_SH_TYPE_MIPS = merge_dicts(
+ENUM_SH_TYPE_MIPS: Mapping[str, int] = merge_dicts(
         ENUM_SH_TYPE_BASE,
         dict(
             SHT_MIPS_LIBLIST=0x70000000,
@@ -378,7 +385,7 @@ ENUM_SH_TYPE_MIPS = merge_dicts(
             SHT_MIPS_PDR_EXCEPTION=0x70000029,
             SHT_MIPS_ABIFLAGS=0x7000002a))
 
-ENUM_ELFCOMPRESS_TYPE = dict(
+ENUM_ELFCOMPRESS_TYPE: Mapping[str, int] = dict(
     ELFCOMPRESS_ZLIB=1,
     ELFCOMPRESS_LOOS=0x60000000,
     ELFCOMPRESS_HIOS=0x6fffffff,
@@ -391,7 +398,7 @@ ENUM_ELFCOMPRESS_TYPE = dict(
 # some values scavenged from the ELF headers in binutils-2.21
 #
 # Using the same base + per-processor augmentation technique as in sh_type.
-ENUM_P_TYPE_BASE = dict(
+ENUM_P_TYPE_BASE: Mapping[str, int] = dict(
     PT_NULL=0,
     PT_LOAD=1,
     PT_DYNAMIC=2,
@@ -415,28 +422,28 @@ ENUM_P_TYPE_BASE = dict(
     _default_=Pass,
 )
 
-ENUM_P_TYPE_ARM = merge_dicts(
+ENUM_P_TYPE_ARM: Mapping[str, int] = merge_dicts(
         ENUM_P_TYPE_BASE,
         dict(
             PT_ARM_ARCHEXT=0x70000000,
             PT_ARM_EXIDX=0x70000001))
 
-ENUM_P_TYPE_AARCH64 = merge_dicts(
+ENUM_P_TYPE_AARCH64: Mapping[str, int] = merge_dicts(
         ENUM_P_TYPE_BASE,
         dict(
             PT_AARCH64_ARCHEXT=0x70000000,
             PT_AARCH64_UNWIND=0x70000001))
 
-ENUM_P_TYPE_MIPS = merge_dicts(
+ENUM_P_TYPE_MIPS: Mapping[str, int] = merge_dicts(
         ENUM_P_TYPE_BASE,
         dict(PT_MIPS_ABIFLAGS=0x70000003))
 
-ENUM_P_TYPE_RISCV = merge_dicts(
+ENUM_P_TYPE_RISCV: Mapping[str, int] = merge_dicts(
         ENUM_P_TYPE_BASE,
         dict(PT_RISCV_ATTRIBUTES=0x70000003))
 
 # st_info bindings in the symbol header
-ENUM_ST_INFO_BIND = dict(
+ENUM_ST_INFO_BIND: Mapping[str, int] = dict(
     STB_LOCAL=0,
     STB_GLOBAL=1,
     STB_WEAK=2,
@@ -449,7 +456,7 @@ ENUM_ST_INFO_BIND = dict(
 )
 
 # st_info type in the symbol header
-ENUM_ST_INFO_TYPE = dict(
+ENUM_ST_INFO_TYPE: Mapping[str, int] = dict(
     STT_NOTYPE=0,
     STT_OBJECT=1,
     STT_FUNC=2,
@@ -468,7 +475,7 @@ ENUM_ST_INFO_TYPE = dict(
 )
 
 # visibility from st_other
-ENUM_ST_VISIBILITY = dict(
+ENUM_ST_VISIBILITY: Mapping[str, int] = dict(
     STV_DEFAULT=0,
     STV_INTERNAL=1,
     STV_HIDDEN=2,
@@ -479,12 +486,12 @@ ENUM_ST_VISIBILITY = dict(
     _default_=Pass,
 )
 
-ENUM_ST_LOCAL = dict(
+ENUM_ST_LOCAL: Mapping[str, int] = dict(
     _default_=Pass,
 )
 
 # st_shndx
-ENUM_ST_SHNDX = dict(
+ENUM_ST_SHNDX: Mapping[str, int] = dict(
     SHN_UNDEF=0,
     SHN_ABS=0xfff1,
     SHN_COMMON=0xfff2,
@@ -492,7 +499,7 @@ ENUM_ST_SHNDX = dict(
 )
 
 # d_tag
-ENUM_D_TAG_COMMON = dict(
+ENUM_D_TAG_COMMON: Mapping[str, int] = dict(
     DT_NULL=0,
     DT_NEEDED=1,
     DT_PLTRELSZ=2,
@@ -582,7 +589,7 @@ ENUM_D_TAG_COMMON = dict(
 # Above are the dynamic tags which are valid always.
 # Below are the dynamic tags which are only valid in certain contexts.
 
-ENUM_D_TAG_SOLARIS = dict(
+ENUM_D_TAG_SOLARIS: Mapping[str, int] = dict(
     DT_SUNW_AUXILIARY=0x6000000d,
     DT_SUNW_RTLDINF=0x6000000e,
     DT_SUNW_FILTER=0x6000000f,
@@ -603,7 +610,7 @@ ENUM_D_TAG_SOLARIS = dict(
     DT_SUNW_CAPCHAINSZ=0x6000001f,
 )
 
-ENUM_D_TAG_MIPS = dict(
+ENUM_D_TAG_MIPS: Mapping[str, int] = dict(
     DT_MIPS_RLD_VERSION=0x70000001,
     DT_MIPS_TIME_STAMP=0x70000002,
     DT_MIPS_ICHECKSUM=0x70000003,
@@ -624,7 +631,7 @@ ENUM_D_TAG_MIPS = dict(
     DT_MIPS_XHASH=0x70000036,
 )
 
-ENUM_D_TAG_AARCH64 = dict(
+ENUM_D_TAG_AARCH64: Mapping[str, int] = dict(
     DT_AARCH64_BTI_PLT=0x70000001,
 )
 
@@ -634,7 +641,7 @@ ENUM_D_TAG_AARCH64 = dict(
 # TODO: add the rest of the machine-specific dynamic tags, not just mips and
 # solaris
 
-ENUMMAP_EXTRA_D_TAG_MACHINE = dict(
+ENUMMAP_EXTRA_D_TAG_MACHINE: Mapping[str, Mapping[str, int]] = dict(
     EM_MIPS=ENUM_D_TAG_MIPS,
     EM_MIPS_RS3_LE=ENUM_D_TAG_MIPS,
     EM_AARCH64=ENUM_D_TAG_AARCH64
@@ -648,7 +655,7 @@ ENUM_D_TAG = merge_dicts(
     *ENUMMAP_EXTRA_D_TAG_MACHINE.values(),
 )
 
-ENUM_DT_FLAGS = dict(
+ENUM_DT_FLAGS: Mapping[str, int] = dict(
     DF_ORIGIN=0x1,
     DF_SYMBOLIC=0x2,
     DF_TEXTREL=0x4,
@@ -656,7 +663,7 @@ ENUM_DT_FLAGS = dict(
     DF_STATIC_TLS=0x10,
 )
 
-ENUM_DT_FLAGS_1 = dict(
+ENUM_DT_FLAGS_1: Mapping[str, int] = dict(
     DF_1_NOW=0x1,
     DF_1_GLOBAL=0x2,
     DF_1_GROUP=0x4,
@@ -687,7 +694,7 @@ ENUM_DT_FLAGS_1 = dict(
     DF_1_PIE=0x8000000,
 )
 
-ENUM_RELOC_TYPE_MIPS = dict(
+ENUM_RELOC_TYPE_MIPS: Mapping[str, int] = dict(
     R_MIPS_NONE=0,
     R_MIPS_16=1,
     R_MIPS_32=2,
@@ -742,7 +749,7 @@ ENUM_RELOC_TYPE_MIPS = dict(
     _default_=Pass,
 )
 
-ENUM_RELOC_TYPE_i386 = dict(
+ENUM_RELOC_TYPE_i386: Mapping[str, int] = dict(
     R_386_NONE=0,
     R_386_32=1,
     R_386_PC32=2,
@@ -789,7 +796,7 @@ ENUM_RELOC_TYPE_i386 = dict(
     _default_=Pass,
 )
 
-ENUM_RELOC_TYPE_x64 = dict(
+ENUM_RELOC_TYPE_x64: Mapping[str, int] = dict(
     R_X86_64_NONE=0,
     R_X86_64_64=1,
     R_X86_64_PC32=2,
@@ -832,7 +839,7 @@ ENUM_RELOC_TYPE_x64 = dict(
     _default_=Pass,
 )
 
-ENUM_RELOC_TYPE_BPF = dict(
+ENUM_RELOC_TYPE_BPF: Mapping[str, int] = dict(
     R_BPF_NONE=0,
     R_BPF_64_64=1,
     R_BPF_64_ABS64=2,
@@ -843,7 +850,7 @@ ENUM_RELOC_TYPE_BPF = dict(
 )
 
 # https://github.com/loongson/la-abi-specs/blob/release/laelf.adoc
-ENUM_RELOC_TYPE_LOONGARCH = dict(
+ENUM_RELOC_TYPE_LOONGARCH: Mapping[str, int] = dict(
     R_LARCH_NONE=0,
     R_LARCH_32=1,
     R_LARCH_64=2,
@@ -945,7 +952,7 @@ ENUM_RELOC_TYPE_LOONGARCH = dict(
     _default_=Pass,
 )
 
-ENUM_RELOC_TYPE_S390X = dict(
+ENUM_RELOC_TYPE_S390X: Mapping[str, int] = dict(
     R_390_NONE=0,
     R_390_8=1,
     R_390_12=2,
@@ -1009,7 +1016,7 @@ ENUM_RELOC_TYPE_S390X = dict(
 )
 
 # Sunw Syminfo Bound To special values
-ENUM_SUNW_SYMINFO_BOUNDTO = dict(
+ENUM_SUNW_SYMINFO_BOUNDTO: Mapping[str, int] = dict(
     SYMINFO_BT_SELF=0xffff,
     SYMINFO_BT_PARENT=0xfffe,
     SYMINFO_BT_NONE=0xfffd,
@@ -1027,7 +1034,7 @@ ENUM_VERSYM = dict(
 )
 
 # PT_NOTE section types for all ELF types except ET_CORE
-ENUM_NOTE_N_TYPE = dict(
+ENUM_NOTE_N_TYPE: Mapping[str, int] = dict(
     NT_GNU_ABI_TAG=1,
     NT_GNU_HWCAP=2,
     NT_GNU_BUILD_ID=3,
@@ -1037,7 +1044,7 @@ ENUM_NOTE_N_TYPE = dict(
 )
 
 # PT_NOTE section types for ET_CORE
-ENUM_CORE_NOTE_N_TYPE = dict(
+ENUM_CORE_NOTE_N_TYPE: Mapping[str, int] = dict(
     NT_PRSTATUS=1,
     NT_FPREGSET=2,
     NT_PRPSINFO=3,
@@ -1049,7 +1056,7 @@ ENUM_CORE_NOTE_N_TYPE = dict(
 )
 
 # Values in GNU .note.ABI-tag notes (n_type=='NT_GNU_ABI_TAG')
-ENUM_NOTE_ABI_TAG_OS = dict(
+ENUM_NOTE_ABI_TAG_OS: Mapping[str, int] = dict(
     ELF_NOTE_OS_LINUX=0,
     ELF_NOTE_OS_GNU=1,
     ELF_NOTE_OS_SOLARIS2=2,
@@ -1060,7 +1067,7 @@ ENUM_NOTE_ABI_TAG_OS = dict(
 )
 
 # Values in GNU .note.gnu.property notes (n_type=='NT_GNU_PROPERTY_TYPE_0')
-ENUM_NOTE_GNU_PROPERTY_TYPE = dict(
+ENUM_NOTE_GNU_PROPERTY_TYPE: Mapping[str, int] = dict(
     GNU_PROPERTY_STACK_SIZE=1,
     GNU_PROPERTY_NO_COPY_ON_PROTECTED=2,
     GNU_PROPERTY_X86_FEATURE_1_AND=0xc0000002,
@@ -1071,7 +1078,7 @@ ENUM_NOTE_GNU_PROPERTY_TYPE = dict(
     _default_=Pass,
 )
 
-ENUM_GNU_PROPERTY_X86_FEATURE_1_FLAGS = dict(
+ENUM_GNU_PROPERTY_X86_FEATURE_1_FLAGS: Mapping[str, int] = dict(
     GNU_PROPERTY_X86_FEATURE_1_IBT=1,
     GNU_PROPERTY_X86_FEATURE_1_SHSTK=2,
     GNU_PROPERTY_X86_FEATURE_1_LAM_U48=4,
@@ -1079,7 +1086,7 @@ ENUM_GNU_PROPERTY_X86_FEATURE_1_FLAGS = dict(
     _default_=Pass
 )
 
-ENUM_RELOC_TYPE_ARM = dict(
+ENUM_RELOC_TYPE_ARM: Mapping[str, int] = dict(
     R_ARM_NONE=0,
     R_ARM_PC24=1,
     R_ARM_ABS32=2,
@@ -1211,7 +1218,7 @@ ENUM_RELOC_TYPE_ARM = dict(
     R_ARM_IRELATIVE=140,
 )
 
-ENUM_RELOC_TYPE_AARCH64 = dict(
+ENUM_RELOC_TYPE_AARCH64: Mapping[str, int] = dict(
     R_AARCH64_NONE=256,
     R_AARCH64_ABS64=257,
     R_AARCH64_ABS32=258,
@@ -1322,7 +1329,7 @@ ENUM_RELOC_TYPE_AARCH64 = dict(
     R_AARCH64_TLS_TPREL32=1033,
 )
 
-ENUM_ATTR_TAG_ARM = dict(
+ENUM_ATTR_TAG_ARM: Mapping[str, int] = dict(
     TAG_FILE=1,
     TAG_SECTION=2,
     TAG_SYMBOL=3,
@@ -1375,7 +1382,7 @@ ENUM_ATTR_TAG_ARM = dict(
     TAG_PACRET_USE=76,
 )
 
-ENUM_ATTR_TAG_RISCV = dict(
+ENUM_ATTR_TAG_RISCV: Mapping[str, int] = dict(
     TAG_FILE=1,
     TAG_SECTION=2,
     TAG_SYMBOL=3,
@@ -1391,7 +1398,7 @@ ENUM_ATTR_TAG_RISCV = dict(
 
 # https://openpowerfoundation.org/wp-content/uploads/2016/03/ABI64BitOpenPOWERv1.1_16July2015_pub4.pdf
 # See 3.5.3 Relocation Types Table.
-ENUM_RELOC_TYPE_PPC64 = dict(
+ENUM_RELOC_TYPE_PPC64: Mapping[str, int] = dict(
     R_PPC64_NONE=0,
     R_PPC64_ADDR32=1,
     R_PPC64_ADDR24=2,
@@ -1518,7 +1525,7 @@ ENUM_RELOC_TYPE_PPC64 = dict(
 
 # https://example61560.files.wordpress.com/2016/11/powerpc_abi.pdf
 # See 4.13.5 Relocation Types Table.
-ENUM_RELOC_TYPE_PPC = dict(
+ENUM_RELOC_TYPE_PPC: Mapping[str, int] = dict(
     R_PPC_NONE=0,
     R_PPC_ADDR32=1,
     R_PPC_ADDR24=2,
@@ -1575,7 +1582,7 @@ ENUM_RELOC_TYPE_PPC = dict(
 )
 
 # https://gitlab.utu.fi/soft/binutils-gdb/-/blob/d18547d8b08615a58db18ad3e43f721dc92ae298/include/elf/v850.h
-ENUM_RELOC_TYPE_V850 = dict(
+ENUM_RELOC_TYPE_V850: Mapping[str, int] = dict(
     R_V800_NONE=0,
     R_V810_NONE=48,
     R_V810_BYTE=49,


### PR DESCRIPTION
Here are `eflfile.{elf,dwarf}.{const,enum}` from #611

I try to walk this ~~tree~~ graph: <img width="2600" height="2399" alt="elftools" src="https://github.com/user-attachments/assets/9cbd0b40-10de-4794-a129-21c30cbad5ab" />
