### PR TITLE
Add Boring type annotations

### DIFF
--- a/elftools/dwarf/abbrevtable.py
+++ b/elftools/dwarf/abbrevtable.py
@@ -42,7 +42,7 @@ class AbbrevTable:
         map = {}
         self.stream.seek(self.offset)
         while True:
-            decl_code = struct_parse(
+            decl_code: int = struct_parse(
                 struct=self.structs.the_Dwarf_uleb128,
                 stream=self.stream)
             if decl_code == 0:

--- a/elftools/dwarf/abbrevtable.py
+++ b/elftools/dwarf/abbrevtable.py
@@ -66,7 +66,7 @@ class AbbrevDecl:
         self.decl = decl
         self._has_children = decl['children_flag'] == 'DW_CHILDREN_yes'
 
-    def has_children(self):
+    def has_children(self) -> bool:
         return self._has_children
 
     def iter_attr_specs(self):

--- a/elftools/dwarf/aranges.py
+++ b/elftools/dwarf/aranges.py
@@ -51,7 +51,7 @@ class ARanges:
         self.keys = [entry.begin_addr for entry in self.entries]
 
 
-    def cu_offset_at_addr(self, addr):
+    def cu_offset_at_addr(self, addr: int) -> int | None:
         """ Given an address, get the offset of the CU it belongs to, where
             'offset' refers to the offset in the .debug_info section.
         """

--- a/elftools/dwarf/aranges.py
+++ b/elftools/dwarf/aranges.py
@@ -84,7 +84,7 @@ class ARanges:
             # No segmentation
             if aranges_header["segment_size"] == 0:
                 # pad to nearest multiple of tuple size
-                tuple_size = aranges_header["address_size"] * 2
+                tuple_size: int = aranges_header["address_size"] * 2
                 fp = self.stream.tell()
                 seek_to = int(math.ceil(fp/float(tuple_size)) * tuple_size)
                 self.stream.seek(seek_to)
@@ -95,8 +95,8 @@ class ARanges:
                 got_entries = False
 
                 # entries in this set/CU
-                addr = struct_parse(addr_size('addr'), self.stream)
-                length = struct_parse(addr_size('length'), self.stream)
+                addr: int = struct_parse(addr_size('addr'), self.stream)
+                length: int = struct_parse(addr_size('length'), self.stream)
                 while addr != 0 or length != 0 or (not got_entries and need_empty):
                     # 'begin_addr length info_offset version address_size segment_size'
                     entries.append(

--- a/elftools/dwarf/callframe.py
+++ b/elftools/dwarf/callframe.py
@@ -642,7 +642,7 @@ class ZERO:
     in pure DWARF. `readelf` displays these as "ZERO terminator", hence the
     class name.
     """
-    def __init__(self, offset):
+    def __init__(self, offset: int) -> None:
         self.offset = offset
 
 

--- a/elftools/dwarf/callframe.py
+++ b/elftools/dwarf/callframe.py
@@ -95,7 +95,7 @@ class CallFrameInfo:
                 entry.structs.initial_length_field_size(), os.SEEK_CUR)
             return entry
 
-        entry_length = struct_parse(
+        entry_length: int = struct_parse(
             self.base_structs.the_Dwarf_uint32, self.stream, offset)
 
         if self.for_eh_frame and entry_length == 0:
@@ -112,7 +112,7 @@ class CallFrameInfo:
             address_size=self.base_structs.address_size)
 
         # Read the next field to see whether this is a CIE or FDE
-        CIE_id = struct_parse(
+        CIE_id: int = struct_parse(
             entry_structs.the_Dwarf_offset, self.stream)
 
         if self.for_eh_frame:
@@ -135,7 +135,7 @@ class CallFrameInfo:
 
         # If the augmentation string is not empty, hope to find a length field
         # in order to skip the data specified augmentation.
-        lsda_pointer = None
+        lsda_pointer: int | None = None
         aug_dict = None
         if is_CIE:
             aug_bytes, aug_dict = self._parse_cie_augmentation(
@@ -151,7 +151,7 @@ class CallFrameInfo:
                                                         lsda_encoding)
 
         # For convenience, compute the end offset for this entry
-        end_offset = (
+        end_offset: int = (
             offset + header.length +
             entry_structs.initial_length_field_size())
 
@@ -185,7 +185,7 @@ class CallFrameInfo:
         """
         instructions = []
         while offset < end_offset:
-            raw_opcode = struct_parse(structs.the_Dwarf_uint8, self.stream, offset)
+            raw_opcode: int = struct_parse(structs.the_Dwarf_uint8, self.stream, offset)
 
             opcode, *args = DW_CFA.parse_raw_opcode(raw_opcode)
             match opcode:
@@ -240,8 +240,8 @@ class CallFrameInfo:
             # CIE_pointer contains the offset for a reverse displacement from
             # the section offset of the CIE_pointer field itself (not from the
             # FDE header offset).
-            cie_displacement = fde_header['CIE_pointer']
-            cie_offset = (fde_offset + entry_structs.dwarf_format // 8
+            cie_displacement: int = fde_header['CIE_pointer']
+            cie_offset: int = (fde_offset + entry_structs.dwarf_format // 8
                           - cie_displacement)
         else:
             cie_offset = fde_header['CIE_pointer']
@@ -256,7 +256,7 @@ class CallFrameInfo:
         Return a tuple that contains 1) the augmentation data as a string
         (without the length field) and 2) the augmentation data as a dict.
         """
-        augmentation = header.get('augmentation')
+        augmentation: bytes | None = header.get('augmentation')
         if not augmentation:
             return (b'', {})
 
@@ -320,7 +320,7 @@ class CallFrameInfo:
         if not self.for_eh_frame:
             return b''
 
-        augmentation_data_length = struct_parse(
+        augmentation_data_length: int = struct_parse(
             Struct('Dummy_Augmentation_Data',
                    entry_structs.Dwarf_uleb128('length')),
             self.stream)['length']
@@ -341,7 +341,7 @@ class CallFrameInfo:
 
         formats = self._eh_encoding_to_field(structs)
 
-        ptr = struct_parse(
+        ptr: int = struct_parse(
             Struct('Augmentation_Data',
                    formats[basic_encoding]('LSDA_pointer')),
             self.stream, stream_pos=stream_offset)['LSDA_pointer']

--- a/elftools/dwarf/callframe.py
+++ b/elftools/dwarf/callframe.py
@@ -486,7 +486,7 @@ class CFIEntry:
             self._decoded_table = self._decode_CFI_table()
         return self._decoded_table
 
-    def __getitem__(self, name):
+    def __getitem__(self, name: str) -> Any:
         """ Implement dict-like access to header entries
         """
         return self.header[name]

--- a/elftools/dwarf/callframe.py
+++ b/elftools/dwarf/callframe.py
@@ -521,7 +521,7 @@ class CFIEntry:
         # instructions.
         line_stack = []
 
-        def _add_to_order(regnum):
+        def _add_to_order(regnum: int) -> None:
             # DW_CFA.restore and others remove registers from cur_line,
             #  but they stay in reg_order. Avoid duplicates.
             if regnum not in reg_order:

--- a/elftools/dwarf/callframe.py
+++ b/elftools/dwarf/callframe.py
@@ -450,7 +450,7 @@ class CallFrameInstruction:
         self.opcode = opcode
         self.args = args
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"{self.opcode.FQN} ({self.opcode.value:#02x}): {self.args}"
 
 
@@ -664,7 +664,7 @@ class RegisterRule:
         self.type = type
         self.arg = arg
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return 'RegisterRule(%s, %s)' % (self.type, self.arg)
 
 
@@ -677,7 +677,7 @@ class CFARule:
         self.offset = offset
         self.expr = expr
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return 'CFARule(reg=%s, offset=%s, expr=%s)' % (
             self.reg, self.offset, self.expr)
 

--- a/elftools/dwarf/compileunit.py
+++ b/elftools/dwarf/compileunit.py
@@ -66,7 +66,7 @@ class CompileUnit:
         # as DIEs are iterated over.
         self._diemap = []
 
-    def dwarf_format(self):
+    def dwarf_format(self) -> int:
         """ Get the DWARF format (32 or 64) for this CU
         """
         return self.structs.dwarf_format
@@ -101,14 +101,14 @@ class CompileUnit:
 
         return top
 
-    def has_top_DIE(self):
+    def has_top_DIE(self) -> bool:
         """ Returns whether the top DIE in this CU has already been parsed and cached.
             No parsing on demand!
         """
         return bool(self._diemap)
 
     @property
-    def size(self):
+    def size(self) -> int:
         return self['unit_length'] + self.structs.initial_length_field_size()
 
     def get_DIE_from_refaddr(self, refaddr):

--- a/elftools/dwarf/compileunit.py
+++ b/elftools/dwarf/compileunit.py
@@ -64,7 +64,7 @@ class CompileUnit:
         # DIE population strategy used in `iter_DIE_children`.
         # Like `self._dielist`, this list is lazily constructed
         # as DIEs are iterated over.
-        self._diemap = []
+        self._diemap: list[int] = []
 
     def dwarf_format(self) -> int:
         """ Get the DWARF format (32 or 64) for this CU

--- a/elftools/dwarf/datatype_cpp.py
+++ b/elftools/dwarf/datatype_cpp.py
@@ -35,7 +35,7 @@ def parse_cpp_datatype(var_die):
 
     type_die = var_die.get_DIE_from_attribute('DW_AT_type')
 
-    mods = []
+    mods: list[str] = []
     # Unlike readelf, dwarfdump doesn't chase typedefs
     while type_die.tag in ('DW_TAG_const_type', 'DW_TAG_volatile_type', 'DW_TAG_pointer_type', 'DW_TAG_reference_type'):
         modifier = _strip_type_tag(type_die) # const/volatile/reference/pointer
@@ -101,7 +101,7 @@ def parse_cpp_datatype(var_die):
 
     # Check the nesting - important for parameters
     parent = type_die.get_parent()
-    scopes = []
+    scopes: list[str] = []
     while parent and parent.tag in ('DW_TAG_class_type', 'DW_TAG_structure_type', 'DW_TAG_union_type', 'DW_TAG_namespace'):
         scopes.insert(0, safe_DIE_name(parent, _strip_type_tag(parent) + " "))
         # If unnamed scope, fall back to scope type - like "structure "
@@ -135,10 +135,10 @@ class TypeDesc:
     """
     def __init__(self) -> None:
         self.name = None
-        self.modifiers = () # Reads left to right
-        self.scopes = () # Reads left to right
-        self.tag = None
-        self.dimensions = None
+        self.modifiers: tuple[str, ...] = () # Reads left to right
+        self.scopes: tuple[str, ...] = () # Reads left to right
+        self.tag: str | None = None
+        self.dimensions: tuple[int, ...] | None = None
 
     def __str__(self) -> str:
         # Some reference points from dwarfdump:
@@ -185,8 +185,8 @@ def DIE_type(die):
 
 class ClassDesc:
     def __init__(self) -> None:
-        self.scopes = ()
-        self.const_member = False
+        self.scopes: tuple[str, ...] = ()
+        self.const_member: bool = False
 
 def get_class_spec_if_member(func_spec, the_func):
     if 'DW_AT_object_pointer' in the_func.attributes:
@@ -201,7 +201,7 @@ def get_class_spec_if_member(func_spec, the_func):
     # Check the parent element chain - could be a class
     parent = func_spec.get_parent()
 
-    scopes = []
+    scopes: list[str] = []
     while parent and parent.tag in ("DW_TAG_class_type", "DW_TAG_structure_type", "DW_TAG_namespace"):
         scopes.insert(0, DIE_name(parent))
         parent = parent.get_parent()

--- a/elftools/dwarf/datatype_cpp.py
+++ b/elftools/dwarf/datatype_cpp.py
@@ -133,7 +133,7 @@ class TypeDesc:
             array. -1 means an array of unknown dimension.
 
     """
-    def __init__(self):
+    def __init__(self) -> None:
         self.name = None
         self.modifiers = () # Reads left to right
         self.scopes = () # Reads left to right
@@ -184,7 +184,7 @@ def DIE_type(die):
     return die.get_DIE_from_attribute("DW_AT_type")
 
 class ClassDesc:
-    def __init__(self):
+    def __init__(self) -> None:
         self.scopes = ()
         self.const_member = False
 

--- a/elftools/dwarf/datatype_cpp.py
+++ b/elftools/dwarf/datatype_cpp.py
@@ -140,7 +140,7 @@ class TypeDesc:
         self.tag = None
         self.dimensions = None
 
-    def __str__(self):
+    def __str__(self) -> str:
         # Some reference points from dwarfdump:
         # const->pointer->const->char = const char *const
         # const->reference->const->int = const const int &

--- a/elftools/dwarf/descriptions.py
+++ b/elftools/dwarf/descriptions.py
@@ -182,7 +182,7 @@ def describe_form_class(form: str) -> str | None:
 
 # The machine architecture. Set globally via set_global_machine_arch
 #
-_MACHINE_ARCH = None
+_MACHINE_ARCH: str | None = None
 
 # Implements the alternative format of readelf: lowercase hex, prefixed with 0x unless 0
 def _format_hex(n: int) -> str:

--- a/elftools/dwarf/descriptions.py
+++ b/elftools/dwarf/descriptions.py
@@ -17,7 +17,7 @@ from ..common.utils import preserve_stream_pos, dwarf_assert, bytes2str
 from .callframe import CIE, FDE
 
 
-def set_global_machine_arch(machine_arch):
+def set_global_machine_arch(machine_arch: str) -> None:
     global _MACHINE_ARCH
     _MACHINE_ARCH = machine_arch
 
@@ -608,7 +608,7 @@ class ExprDumper:
             for deo in parsed
         )
 
-    def _init_lookups(self):
+    def _init_lookups(self) -> None:
         self._ops_with_decimal_arg = {
             'DW_OP_const1u', 'DW_OP_const1s', 'DW_OP_const2u', 'DW_OP_const2s',
             'DW_OP_const4u', 'DW_OP_const4s', 'DW_OP_const8u', 'DW_OP_const8s',

--- a/elftools/dwarf/descriptions.py
+++ b/elftools/dwarf/descriptions.py
@@ -49,7 +49,7 @@ def describe_CFI_instructions(entry):
             isinstance(entry, FDE),
             'Unexpected instruction "%s" for a CIE' % instr)
 
-    def _full_reg_name(regnum):
+    def _full_reg_name(regnum: int) -> str:
         regname = describe_reg_name(regnum, _MACHINE_ARCH, False)
         if regname:
             return 'r%s (%s)' % (regnum, regname)
@@ -148,7 +148,7 @@ def describe_DWARF_expr(expr, structs, cu_offset=None):
     return '(' + dwarf_expr_dumper.dump_expr(expr, cu_offset) + ')'
 
 
-def describe_reg_name(regnum, machine_arch=None, default=True):
+def describe_reg_name(regnum: int, machine_arch: str | None = None, default: bool = True) -> str | None:
     """ Provide a textual description for a register name, given its serial
         number. The number is expected to be valid.
     """
@@ -166,7 +166,7 @@ def describe_reg_name(regnum, machine_arch=None, default=True):
     else:
         return None
 
-def describe_form_class(form):
+def describe_form_class(form: str) -> str | None:
     """For a given form name, determine its value class.
 
     For example, given 'DW_FORM.data1' returns 'constant'.
@@ -185,7 +185,7 @@ def describe_form_class(form):
 _MACHINE_ARCH = None
 
 # Implements the alternative format of readelf: lowercase hex, prefixed with 0x unless 0
-def _format_hex(n):
+def _format_hex(n: int) -> str:
     return '0x%x' % n if n != 0 else '0'
 
 def _describe_attr_ref(attr, die, section_offset):

--- a/elftools/dwarf/die.py
+++ b/elftools/dwarf/die.py
@@ -91,10 +91,10 @@ class DIE:
         self.stream = stream
         self.offset = offset
 
-        self.attributes = {}
-        self.tag = None
-        self.has_children = None
-        self.abbrev_code = None
+        self.attributes: dict[str, Any] = {}
+        self.tag: str | int | None = None
+        self.has_children: bool | None = None
+        self.abbrev_code: int | None = None
         self.size = 0
         # Null DIE terminator. It can be used to obtain offset range occupied
         # by this DIE including its whole subtree.
@@ -288,7 +288,7 @@ class DIE:
         # Returns (form, raw_value, length).
         structs = self.cu.structs
         length = 1
-        real_form_code = struct_parse(structs.the_Dwarf_uleb128, self.stream) # Numeric form code
+        real_form_code: int = struct_parse(structs.the_Dwarf_uleb128, self.stream) # Numeric form code
         while True:
             try:
                 real_form = DW_FORM_raw2name[real_form_code] # Form name or exception if bogus code

--- a/elftools/dwarf/die.py
+++ b/elftools/dwarf/die.py
@@ -179,7 +179,7 @@ class DIE:
 
     #------ PRIVATE ------#
 
-    def _search_ancestor_offspring(self):
+    def _search_ancestor_offspring(self) -> None:
         """ Search our ancestors identifying their offspring to find our parent.
 
             DIEs are stored as a flattened tree.  The top DIE is the ancestor
@@ -225,7 +225,7 @@ class DIE:
     def __str__(self) -> str:
         return self.__repr__()
 
-    def _parse_DIE(self):
+    def _parse_DIE(self) -> None:
         """ Parses the DIE info from the section, based on the abbreviation
             table of the CU
         """
@@ -340,7 +340,7 @@ class DIE:
             return _resolve_via_offset_table(self.dwarfinfo.debug_rnglists_sec.stream, self.cu, raw_value, 'DW_AT_rnglists_base')
         return raw_value
 
-    def _translate_indirect_attributes(self):
+    def _translate_indirect_attributes(self) -> None:
         """ This is a hook to translate the DW_FORM_...x values in the top DIE
             once the top DIE is parsed to the end. They can't be translated
             while the top DIE is being parsed, because they implicitly make a

--- a/elftools/dwarf/die.py
+++ b/elftools/dwarf/die.py
@@ -215,14 +215,14 @@ class DIE:
 
             search = prev
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         s = 'DIE %s, size=%s, has_children=%s\n' % (
             self.tag, self.size, self.has_children)
         for attrname, attrval in self.attributes.items():
             s += '    |%-18s:  %s\n' % (attrname, attrval)
         return s
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.__repr__()
 
     def _parse_DIE(self):

--- a/elftools/dwarf/die.py
+++ b/elftools/dwarf/die.py
@@ -103,7 +103,7 @@ class DIE:
 
         self._parse_DIE()
 
-    def is_null(self):
+    def is_null(self) -> bool:
         """ Is this a null entry?
         """
         return self.tag is None
@@ -140,7 +140,7 @@ class DIE:
             self._search_ancestor_offspring()
         return self._parent
 
-    def get_full_path(self):
+    def get_full_path(self) -> str:
         """ Return the full path filename for the DIE.
 
             The filename is the join of 'DW_AT_comp_dir' and 'DW_AT_name',
@@ -282,7 +282,7 @@ class DIE:
         except ConstructError as e:
             raise ELFParseError(str(e))
 
-    def _resolve_indirect(self):
+    def _resolve_indirect(self) -> tuple[str, int, int]:
         # Supports arbitrary indirection nesting (the standard doesn't prohibit that).
         # Expects the stream to be at the real form.
         # Returns (form, raw_value, length).
@@ -307,7 +307,7 @@ class DIE:
                 # And continue parsing
             # No explicit infinite loop guard because the stream will end eventually
 
-    def _translate_attr_value(self, form, raw_value):
+    def _translate_attr_value(self, form: str, raw_value: Any) -> Any:
         """ Translate a raw attr value according to the form
         """
         # Indirect forms can only be parsed if the top DIE of this CU has already been parsed

--- a/elftools/dwarf/dwarf_expr.py
+++ b/elftools/dwarf/dwarf_expr.py
@@ -100,7 +100,7 @@ DW_OP_name2opcode = dict(
     DW_OP_hi_user=0xff,
 )
 
-def _generate_dynamic_values(map, prefix, index_start, index_end, value_start):
+def _generate_dynamic_values(map: dict[str, int], prefix: str, index_start: int, index_end: int, value_start: int) -> None:
     """ Generate values in a map (dict) dynamically. Each key starts with
         a (string) prefix, followed by an index in the inclusive range
         [index_start, index_end]. The values start at value_start.

--- a/elftools/dwarf/dwarf_expr.py
+++ b/elftools/dwarf/dwarf_expr.py
@@ -194,7 +194,7 @@ def _init_dispatch_table(structs):
     # ULEB128, then an expression of that length
     def parse_nestedexpr():
         def parse(stream):
-            size = struct_parse(structs.the_Dwarf_uleb128, stream)
+            size: int = struct_parse(structs.the_Dwarf_uleb128, stream)
             nested_expr_blob = stream.read(size)
             return [DWARFExprParser(structs).parse_expr(nested_expr_blob)]
         return parse
@@ -211,7 +211,7 @@ def _init_dispatch_table(structs):
     # Byte, then variant: 0, 1, 2 => uleb128, 3 => uint32
     def parse_wasmloc():
         def parse(stream):
-            op = struct_parse(structs.the_Dwarf_uint8, stream)
+            op: int = struct_parse(structs.the_Dwarf_uint8, stream)
             if 0 <= op <= 2:
                 return [op, struct_parse(structs.the_Dwarf_uleb128, stream)]
             elif op == 3:

--- a/elftools/dwarf/dwarfinfo.py
+++ b/elftools/dwarf/dwarfinfo.py
@@ -146,7 +146,7 @@ class DWARFInfo:
         self._type_units_by_sig = None
 
     @property
-    def has_debug_info(self):
+    def has_debug_info(self) -> bool:
         """ Return whether this contains debug information.
 
         It can be not the case when the ELF only contains .eh_frame, which is
@@ -154,7 +154,7 @@ class DWARFInfo:
         """
         return bool(self.debug_info_sec)
 
-    def has_debug_types(self):
+    def has_debug_types(self) -> bool:
         """ Return whether this contains debug types information.
         """
         return bool(self.debug_types_sec)
@@ -311,13 +311,13 @@ class DWARFInfo:
                 offset=offset)
         return self._abbrevtable_cache[offset]
 
-    def get_string_from_table(self, offset):
+    def get_string_from_table(self, offset: int) -> bytes | None:
         """ Obtain a string from the string table section, given an offset
             relative to the section.
         """
         return parse_cstring_from_stream(self.debug_str_sec.stream, offset)
 
-    def get_string_from_linetable(self, offset):
+    def get_string_from_linetable(self, offset: int) -> bytes | None:
         """ Obtain a string from the string table section, given an offset
             relative to the section.
         """
@@ -345,7 +345,7 @@ class DWARFInfo:
         else:
             return None
 
-    def has_CFI(self):
+    def has_CFI(self) -> bool:
         """ Does this dwarf info have a dwarf_frame CFI section?
         """
         return self.debug_frame_sec is not None
@@ -360,7 +360,7 @@ class DWARFInfo:
             base_structs=self.structs)
         return cfi.get_entries()
 
-    def has_EH_CFI(self):
+    def has_EH_CFI(self) -> bool:
         """ Does this dwarf info have a eh_frame CFI section?
         """
         return self.eh_frame_sec is not None
@@ -648,7 +648,7 @@ class DWARFInfo:
             tu_offset=offset,
             tu_die_offset=tu_die_offset)
 
-    def _is_supported_version(self, version):
+    def _is_supported_version(self, version: int) -> bool:
         """ DWARF version supported by this parser
         """
         return 2 <= version <= 5
@@ -717,7 +717,7 @@ class DWARFInfo:
         self._linetable_cache[offset] = lineprogram
         return lineprogram
 
-    def parse_debugsupinfo(self):
+    def parse_debugsupinfo(self) -> bytes | None:
         """
         Extract a filename from .debug_sup, .gnu_debualtlink sections.
         """

--- a/elftools/dwarf/dwarfinfo.py
+++ b/elftools/dwarf/dwarfinfo.py
@@ -140,7 +140,7 @@ class DWARFInfo:
         # Cache of compile units and map of their offsets for bisect lookup.
         # Access with .iter_CUs(), .get_CU_containing(), and/or .get_CU_at().
         self._cu_cache = []
-        self._cu_offsets_map = []
+        self._cu_offsets_map: list[int] = []
 
         # DWARF v4 type units by sig8 - ordered dict created when needed
         self._type_units_by_sig = None

--- a/elftools/dwarf/lineprogram.py
+++ b/elftools/dwarf/lineprogram.py
@@ -65,7 +65,7 @@ class LineState:
         self.isa = 0
         self.discriminator = 0
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return '\n'.join((
             '<LineState %x:' % id(self),
             '  address = 0x%x' % self.address,

--- a/elftools/dwarf/lineprogram.py
+++ b/elftools/dwarf/lineprogram.py
@@ -51,7 +51,7 @@ class LineState:
         The instance variables of this class are the "state machine registers"
         described in section 6.2.2 of DWARFv3
     """
-    def __init__(self, default_is_stmt):
+    def __init__(self, default_is_stmt: int) -> None:
         self.address = 0
         self.file = 1
         self.line = 1

--- a/elftools/dwarf/lineprogram.py
+++ b/elftools/dwarf/lineprogram.py
@@ -136,7 +136,7 @@ class LineProgram:
         entries = []
         state = LineState(self.header['default_is_stmt'])
 
-        def add_entry_new_state(cmd, args, is_extended=False):
+        def add_entry_new_state(cmd: int, args: list[int], is_extended: bool = False) -> None:
             # Add an entry that sets a new state.
             # After adding, clear some state registers.
             entries.append(LineProgramEntry(
@@ -146,7 +146,7 @@ class LineProgram:
             state.prologue_end = False
             state.epilogue_begin = False
 
-        def add_entry_old_state(cmd, args, is_extended=False):
+        def add_entry_old_state(cmd: int, args: list[int], is_extended: bool = False) -> None:
             # Add an entry that doesn't visibly set a new state
             entries.append(LineProgramEntry(cmd, is_extended, args, None))
 

--- a/elftools/dwarf/lineprogram.py
+++ b/elftools/dwarf/lineprogram.py
@@ -152,7 +152,7 @@ class LineProgram:
 
         offset = self.program_start_offset
         while offset < self.program_end_offset:
-            opcode = struct_parse(
+            opcode: int = struct_parse(
                 self.structs.the_Dwarf_uint8,
                 self.stream,
                 offset)
@@ -164,25 +164,25 @@ class LineProgram:
             # opcodes anyway.
             if opcode >= self.header['opcode_base']:
                 # Special opcode (follow the recipe in 6.2.5.1)
-                maximum_operations_per_instruction = self['maximum_operations_per_instruction']
-                adjusted_opcode = opcode - self['opcode_base']
-                operation_advance = adjusted_opcode // self['line_range']
-                address_addend = (
+                maximum_operations_per_instruction: int = self['maximum_operations_per_instruction']
+                adjusted_opcode: int = opcode - self['opcode_base']
+                operation_advance: int = adjusted_opcode // self['line_range']
+                address_addend: int = (
                     self['minimum_instruction_length'] *
                         ((state.op_index + operation_advance) //
                           maximum_operations_per_instruction))
                 state.address += address_addend
                 state.op_index = (state.op_index + operation_advance) % maximum_operations_per_instruction
-                line_addend = self['line_base'] + (adjusted_opcode % self['line_range'])
+                line_addend: int = self['line_base'] + (adjusted_opcode % self['line_range'])
                 state.line += line_addend
                 add_entry_new_state(
                     opcode, [line_addend, address_addend, state.op_index])
             elif opcode == 0:
                 # Extended opcode: start with a zero byte, followed by
                 # instruction size and the instruction itself.
-                inst_len = struct_parse(self.structs.the_Dwarf_uleb128,
+                inst_len: int = struct_parse(self.structs.the_Dwarf_uleb128,
                                         self.stream)
-                ex_opcode = struct_parse(self.structs.the_Dwarf_uint8,
+                ex_opcode: int = struct_parse(self.structs.the_Dwarf_uint8,
                                          self.stream)
 
                 if ex_opcode == DW_LNE.end_sequence:
@@ -192,7 +192,7 @@ class LineProgram:
                     # reset state
                     state = LineState(self.header['default_is_stmt'])
                 elif ex_opcode == DW_LNE.set_address:
-                    operand = struct_parse(self.structs.the_Dwarf_target_addr,
+                    operand: int = struct_parse(self.structs.the_Dwarf_target_addr,
                                            self.stream)
                     state.address = operand
                     add_entry_old_state(ex_opcode, [operand], is_extended=True)

--- a/elftools/dwarf/locationlists.py
+++ b/elftools/dwarf/locationlists.py
@@ -40,7 +40,7 @@ class LocationViewPair(NamedTuple):
 
 
 def _translate_startx_length(e, cu):
-    start_offset = cu.dwarfinfo.get_addr(cu, e.start_index)
+    start_offset: int = cu.dwarfinfo.get_addr(cu, e.start_index)
     return LocationEntry(e.entry_offset, e.entry_length, start_offset, start_offset + e.length, e.loc_expr, True)
 
 # Maps parsed entries to the tuples above; LocationViewPair is mapped elsewhere
@@ -107,7 +107,7 @@ class LocationLists:
         self.structs = structs
         self.dwarfinfo = dwarfinfo
         self.version = version
-        self._max_addr = 2 ** (self.structs.address_size * 8) - 1
+        self._max_addr: int = 2 ** (self.structs.address_size * 8) - 1
 
     def get_location_list_at_offset(self, offset, die=None):
         """ Get a location list at the given offset in the section.
@@ -152,7 +152,7 @@ class LocationLists:
         locviews = dict() # Map of locview offset to the respective loclist offset
         cu_map = dict() # Map of loclist offsets to CUs
         for cu in self.dwarfinfo.iter_CUs():
-            cu_ver = cu['version']
+            cu_ver: int = cu['version']
             if (cu_ver >= 5) == ver5:
                 for die in cu.iter_DIEs():
                     # A combination of location and locviews means there is a location list
@@ -160,8 +160,8 @@ class LocationLists:
                     if 'DW_AT_GNU_locviews' in die.attributes:
                         assert('DW_AT_location' in die.attributes and
                             LocationParser._attribute_has_loc_list(die.attributes['DW_AT_location'], cu_ver))
-                        views_offset = die.attributes['DW_AT_GNU_locviews'].value
-                        list_offset = die.attributes['DW_AT_location'].value
+                        views_offset: int = die.attributes['DW_AT_GNU_locviews'].value
+                        list_offset: int = die.attributes['DW_AT_location'].value
                         locviews[views_offset] = list_offset
                         cu_map[list_offset] = cu
                         all_offsets.add(views_offset)
@@ -190,7 +190,7 @@ class LocationLists:
                 # We don't have a binary for the former yet. On an off chance that we one day might,
                 # let's parse the header anyway.
 
-                cu_end_offset = cu_header.offset_after_length + cu_header.unit_length
+                cu_end_offset: int = cu_header.offset_after_length + cu_header.unit_length
                 # Unit_length includes the header but doesn't include the length
 
                 while stream.tell() < cu_end_offset:
@@ -229,9 +229,9 @@ class LocationLists:
         lst = []
         while True:
             entry_offset = self.stream.tell()
-            begin_offset = struct_parse(
+            begin_offset: int = struct_parse(
                 self.structs.the_Dwarf_target_addr, self.stream)
-            end_offset = struct_parse(
+            end_offset: int = struct_parse(
                 self.structs.the_Dwarf_target_addr, self.stream)
             if begin_offset == 0 and end_offset == 0:
                 # End of list - we're done.
@@ -242,9 +242,9 @@ class LocationLists:
                 lst.append(BaseAddressEntry(entry_offset=entry_offset, entry_length=entry_length, base_address=end_offset))
             else:
                 # Location list entry
-                expr_len = struct_parse(
+                expr_len: int = struct_parse(
                     self.structs.the_Dwarf_uint16, self.stream)
-                loc_expr = [struct_parse(self.structs.the_Dwarf_uint8,
+                loc_expr: list[int] = [struct_parse(self.structs.the_Dwarf_uint8,
                                          self.stream)
                                 for i in range(expr_len)]
                 entry_length = self.stream.tell() - entry_offset
@@ -271,9 +271,9 @@ class LocationLists:
 
     # From V5 style entries to a LocationEntry/BaseAddressEntry
     def _translate_entry_v5(self, entry, die):
-        off = entry.entry_offset
-        len = entry.entry_end_offset - off
-        type = entry.entry_type
+        off: int = entry.entry_offset
+        len: int = entry.entry_end_offset - off
+        type: str = entry.entry_type
         if type == 'DW_LLE_base_address':
             return BaseAddressEntry(off, len, entry.address)
         elif type == 'DW_LLE_offset_pair':
@@ -294,7 +294,7 @@ class LocationLists:
     # Locviews is the dict, mapping locview offsets to corresponding loclist offsets
     def _parse_locview_pairs(self, locviews):
         stream = self.stream
-        list_offset = locviews.get(stream.tell(), None)
+        list_offset: int | None = locviews.get(stream.tell(), None)
         pairs = []
         if list_offset is not None:
             while stream.tell() < list_offset:

--- a/elftools/dwarf/namelut.py
+++ b/elftools/dwarf/namelut.py
@@ -99,7 +99,7 @@ class NameLUT(Mapping):
         self._entries = entries
         self._cu_headers = cu_headers
 
-    def __len__(self):
+    def __len__(self) -> int:
         """
         Returns the number of entries in the NameLUT.
         """

--- a/elftools/dwarf/structs.py
+++ b/elftools/dwarf/structs.py
@@ -113,7 +113,7 @@ class DWARFStructs:
         cls._structs_cache[key] = self
         return self
 
-    def initial_length_field_size(self):
+    def initial_length_field_size(self) -> int:
         """ Size of an initial length field.
         """
         return 4 if self.dwarf_format == 32 else 12

--- a/elftools/dwarf/structs.py
+++ b/elftools/dwarf/structs.py
@@ -118,7 +118,7 @@ class DWARFStructs:
         """
         return 4 if self.dwarf_format == 32 else 12
 
-    def _create_structs(self):
+    def _create_structs(self) -> None:
         if self.little_endian:
             self.Dwarf_uint8 = ULInt8
             self.Dwarf_uint16 = ULInt16
@@ -176,7 +176,7 @@ class DWARFStructs:
         self._create_debugsup()
         self._create_gnu_debugaltlink()
 
-    def _create_initial_length(self):
+    def _create_initial_length(self) -> None:
         def _InitialLength(name):
             # Adapts a Struct that parses forward a full initial length field.
             # Only if the first word is the continuation value, the second
@@ -189,13 +189,13 @@ class DWARFStructs:
                         elsevalue=None)))
         self.Dwarf_initial_length = _InitialLength
 
-    def _create_leb128(self):
+    def _create_leb128(self) -> None:
         self.Dwarf_uleb128 = ULEB128
         self.Dwarf_sleb128 = SLEB128
         self.the_Dwarf_uleb128 = self.Dwarf_uleb128('')
         self.the_Dwarf_sleb128 = self.Dwarf_sleb128('')
 
-    def _create_cu_header(self):
+    def _create_cu_header(self) -> None:
         dwarfv4_CU_header = Struct('',
             self.Dwarf_offset('debug_abbrev_offset'),
             self.Dwarf_uint8('address_size')
@@ -238,7 +238,7 @@ class DWARFStructs:
                 Embed(dwarfv4_CU_header),
             ))
 
-    def _create_tu_header(self):
+    def _create_tu_header(self) -> None:
         self.Dwarf_TU_header = Struct('Dwarf_TU_header',
                                       self.Dwarf_initial_length('unit_length'),
                                       self.Dwarf_uint16('version'),
@@ -247,7 +247,7 @@ class DWARFStructs:
                                       self.Dwarf_uint64('signature'),
                                       self.Dwarf_offset('type_offset'))
 
-    def _create_abbrev_declaration(self):
+    def _create_abbrev_declaration(self) -> None:
         self.Dwarf_abbrev_declaration = Struct('Dwarf_abbrev_entry',
             Enum(self.Dwarf_uleb128('tag'), **e.ENUM_DW_TAG),
             Enum(self.Dwarf_uint8('children_flag'), **e.ENUM_DW_CHILDREN),
@@ -260,19 +260,19 @@ class DWARFStructs:
                     If(lambda ctx: ctx['form'] == 'DW_FORM_implicit_const',
                         self.Dwarf_sleb128('value')))))
 
-    def _create_debugsup(self):
+    def _create_debugsup(self) -> None:
         # We don't care about checksums, for now.
         self.Dwarf_debugsup = Struct('Elf_debugsup',
             self.Dwarf_int16('version'),
             self.Dwarf_uint8('is_supplementary'),
             CString('sup_filename'))
 
-    def _create_gnu_debugaltlink(self):
+    def _create_gnu_debugaltlink(self) -> None:
         self.Dwarf_debugaltlink = Struct('Elf_debugaltlink',
             CString("sup_filename"),
             String("sup_checksum", length=20))
 
-    def _create_dw_form(self):
+    def _create_dw_form(self) -> None:
         self.Dwarf_dw_form = dict(
             DW_FORM_addr=self.the_Dwarf_target_addr,
             DW_FORM_addrx=self.the_Dwarf_uleb128,
@@ -336,7 +336,7 @@ class DWARFStructs:
             DW_FORM_rnglistx=self.the_Dwarf_uleb128
         )
 
-    def _create_aranges_header(self):
+    def _create_aranges_header(self) -> None:
         self.Dwarf_aranges_header = Struct("Dwarf_aranges_header",
             self.Dwarf_initial_length('unit_length'),
             self.Dwarf_uint16('version'),
@@ -345,7 +345,7 @@ class DWARFStructs:
             self.Dwarf_uint8('segment_size')
             )
 
-    def _create_nameLUT_header(self):
+    def _create_nameLUT_header(self) -> None:
         self.Dwarf_nameLUT_header = Struct("Dwarf_nameLUT_header",
             self.Dwarf_initial_length('unit_length'),
             self.Dwarf_uint16('version'),
@@ -353,7 +353,7 @@ class DWARFStructs:
             self.Dwarf_length('debug_info_length')
             )
 
-    def _create_string_offsets_table_header(self):
+    def _create_string_offsets_table_header(self) -> None:
         self.Dwarf_string_offsets_table_header = Struct(
             "Dwarf_string_offets_table_header",
             self.Dwarf_initial_length('unit_length'),
@@ -361,7 +361,7 @@ class DWARFStructs:
             self.Dwarf_uint16('padding'),
             )
 
-    def _create_address_table_header(self):
+    def _create_address_table_header(self) -> None:
         self.Dwarf_address_table_header = Struct("Dwarf_address_table_header",
             self.Dwarf_initial_length('unit_length'),
             self.Dwarf_uint16('version'),
@@ -369,7 +369,7 @@ class DWARFStructs:
             self.Dwarf_uint8('segment_selector_size'),
             )
 
-    def _create_lineprog_header(self):
+    def _create_lineprog_header(self) -> None:
         # A file entry is terminated by a NULL byte, so we don't want to parse
         # past it. Therefore an If is used.
         self.Dwarf_lineprog_file_entry = Struct('file_entry',
@@ -455,7 +455,7 @@ class DWARFStructs:
                     self.Dwarf_lineprog_file_entry)) # array name is file_entry
         )
 
-    def _create_callframe_entry_headers(self):
+    def _create_callframe_entry_headers(self) -> None:
         self.Dwarf_CIE_header = Struct('Dwarf_CIE_header',
             self.Dwarf_initial_length('length'),
             self.Dwarf_offset('CIE_id'),
@@ -488,7 +488,7 @@ class DWARFStructs:
                     subcon=self.Dwarf_uint8('elem'),
                     length_field=length_field(''))
 
-    def _create_loclists_parsers(self):
+    def _create_loclists_parsers(self) -> None:
         """ Create a struct for debug_loclists CU header, DWARFv5, 7,29
         """
         self.Dwarf_loclists_CU_header = Struct('Dwarf_loclists_CU_header',
@@ -527,7 +527,7 @@ class DWARFStructs:
         self.Dwarf_locview_pair = Struct('locview_pair',
             StreamOffset('entry_offset'), self.Dwarf_uleb128('begin'), self.Dwarf_uleb128('end'))
 
-    def _create_rnglists_parsers(self):
+    def _create_rnglists_parsers(self) -> None:
         self.Dwarf_rnglists_CU_header = Struct('Dwarf_rnglists_CU_header',
             StreamOffset('cu_offset'),
             self.Dwarf_initial_length('unit_length'),

--- a/elftools/dwarf/typeunit.py
+++ b/elftools/dwarf/typeunit.py
@@ -69,7 +69,7 @@ class TypeUnit:
         # DIE population strategy used in `iter_DIE_children`.
         # Like `self._dielist`, this list is lazily constructed
         # as DIEs are iterated over.
-        self._diemap = []
+        self._diemap: list[int] = []
 
     @property
     def cu_offset(self) -> int:

--- a/elftools/dwarf/typeunit.py
+++ b/elftools/dwarf/typeunit.py
@@ -72,18 +72,18 @@ class TypeUnit:
         self._diemap = []
 
     @property
-    def cu_offset(self):
+    def cu_offset(self) -> int:
         """Simulates the cu_offset attribute required by the DIE by returning the tu_offset instead
         """
         return self.tu_offset
 
     @property
-    def cu_die_offset(self):
+    def cu_die_offset(self) -> int:
         """Simulates the cu_die_offset attribute required by the DIE by returning the tu_offset instead
         """
         return self.tu_die_offset
 
-    def dwarf_format(self):
+    def dwarf_format(self) -> int:
         """ Get the DWARF format (32 or 64) for this TU
         """
         return self.structs.dwarf_format
@@ -117,14 +117,14 @@ class TypeUnit:
 
         return top
 
-    def has_top_DIE(self):
+    def has_top_DIE(self) -> bool:
         """ Returns whether the top DIE in this TU has already been parsed and cached.
             No parsing on demand!
         """
         return bool(self._diemap)
 
     @property
-    def size(self):
+    def size(self) -> int:
         return self['unit_length'] + self.structs.initial_length_field_size()
 
     def iter_DIEs(self):

--- a/elftools/elf/descriptions.py
+++ b/elftools/elf/descriptions.py
@@ -339,7 +339,7 @@ def describe_note_gnu_properties(properties, machine):
     return '\n        '.join(descriptions)
 
 #-------------------------------------------------------------------------------
-_unknown = '<unknown>'
+_unknown: str = '<unknown>'
 
 
 _DESCR_EI_CLASS = dict(

--- a/elftools/elf/descriptions.py
+++ b/elftools/elf/descriptions.py
@@ -17,22 +17,22 @@ from .constants import (
     P_FLAGS, RH_FLAGS, SH_FLAGS, SUNW_SYMINFO_FLAGS, VER_FLAGS)
 
 
-def describe_ei_class(x):
+def describe_ei_class(x: str) -> str:
     return _DESCR_EI_CLASS.get(x, _unknown)
 
 
-def describe_ei_data(x):
+def describe_ei_data(x: str) -> str:
     return _DESCR_EI_DATA.get(x, _unknown)
 
 
-def describe_ei_version(x):
+def describe_ei_version(x: str) -> str:
     s = str(ENUM_E_VERSION.get(x, f"{x} <unknown>"))
     if x == 'EV_CURRENT':
         s += ' (current)'
     return s
 
 
-def describe_ei_osabi(x):
+def describe_ei_osabi(x: str) -> str:
     return _DESCR_EI_OSABI.get(x, _unknown)
 
 
@@ -47,15 +47,15 @@ def describe_e_type(x, elffile=None):
     return _DESCR_E_TYPE.get(x, _unknown)
 
 
-def describe_e_machine(x):
+def describe_e_machine(x: str) -> str:
     return _DESCR_E_MACHINE.get(x, _unknown)
 
 
-def describe_e_version_numeric(x):
+def describe_e_version_numeric(x: str) -> str:
     return f"{ENUM_E_VERSION.get(x, x):#x}"
 
 
-def describe_p_type(x):
+def describe_p_type(x: int | str) -> str:
     if x in _DESCR_P_TYPE:
         return _DESCR_P_TYPE[x]
     elif x >= ENUM_P_TYPE_BASE['PT_LOOS'] and x <= ENUM_P_TYPE_BASE['PT_HIOS']:
@@ -64,14 +64,14 @@ def describe_p_type(x):
         return _unknown
 
 
-def describe_p_flags(x):
+def describe_p_flags(x: int) -> str:
     s = ''
     for flag in (P_FLAGS.PF_R, P_FLAGS.PF_W, P_FLAGS.PF_X):
         s += _DESCR_P_FLAGS[flag] if (x & flag) else ' '
     return s
 
 
-def describe_rh_flags(x):
+def describe_rh_flags(x: int) -> str:
     return ' '.join(
         _DESCR_RH_FLAGS[flag]
         for flag in (RH_FLAGS.RHF_NONE, RH_FLAGS.RHF_QUICKSTART,
@@ -87,7 +87,7 @@ def describe_rh_flags(x):
         if x & flag)
 
 
-def describe_sh_type(x):
+def describe_sh_type(x: int | str) -> str:
     if x in _DESCR_SH_TYPE:
         return _DESCR_SH_TYPE[x]
     elif (x >= ENUM_SH_TYPE_BASE['SHT_LOOS'] and
@@ -97,7 +97,7 @@ def describe_sh_type(x):
         return _unknown
 
 
-def describe_sh_flags(x):
+def describe_sh_flags(x: int) -> str:
     s = ''
     for flag in (
             SH_FLAGS.SHF_WRITE, SH_FLAGS.SHF_ALLOC, SH_FLAGS.SHF_EXECINSTR,
@@ -112,19 +112,19 @@ def describe_sh_flags(x):
     return s
 
 
-def describe_symbol_type(x):
+def describe_symbol_type(x: str) -> str:
     return _DESCR_ST_INFO_TYPE.get(x, _unknown)
 
 
-def describe_symbol_bind(x):
+def describe_symbol_bind(x: str) -> str:
     return _DESCR_ST_INFO_BIND.get(x, _unknown)
 
 
-def describe_symbol_visibility(x):
+def describe_symbol_visibility(x: str) -> str:
     return _DESCR_ST_VISIBILITY.get(x, _unknown)
 
 
-def describe_symbol_local(x):
+def describe_symbol_local(x: int) -> str:
     return '[<localentry>: ' + str(1 << x) + ']'
 
 
@@ -135,7 +135,7 @@ def describe_symbol_other(x):
     return vis
 
 
-def describe_symbol_shndx(x):
+def describe_symbol_shndx(x: int | str) -> str:
     return _DESCR_ST_SHNDX.get(x, '%3s' % x)
 
 
@@ -163,21 +163,21 @@ def describe_reloc_type(x, elffile):
         return 'unrecognized: %-7x' % (x & 0xFFFFFFFF)
 
 
-def describe_dyn_tag(x):
+def describe_dyn_tag(x: int) -> str:
     return _DESCR_D_TAG.get(x, _unknown)
 
 
-def describe_dt_flags(x):
+def describe_dt_flags(x: int) -> str:
     return ' '.join(key[3:] for key, val in
         sorted(ENUM_DT_FLAGS.items(), key=lambda t: t[1]) if x & val)
 
 
-def describe_dt_flags_1(x):
+def describe_dt_flags_1(x: int) -> str:
     return ' '.join(key[5:] for key, val in
         sorted(ENUM_DT_FLAGS_1.items(), key=lambda t: t[1]) if x & val)
 
 
-def describe_syminfo_flags(x):
+def describe_syminfo_flags(x: int) -> str:
     return ''.join(_DESCR_SYMINFO_FLAGS[flag] for flag in (
         SUNW_SYMINFO_FLAGS.SYMINFO_FLG_CAP,
         SUNW_SYMINFO_FLAGS.SYMINFO_FLG_DIRECT,
@@ -191,11 +191,11 @@ def describe_syminfo_flags(x):
         SUNW_SYMINFO_FLAGS.SYMINFO_FLG_DEFERRED) if x & flag)
 
 
-def describe_symbol_boundto(x):
+def describe_symbol_boundto(x: str) -> str:
     return _DESCR_SYMINFO_BOUNDTO.get(x, '%3s' % x)
 
 
-def describe_ver_flags(x):
+def describe_ver_flags(x: int) -> str:
     return ' | '.join(_DESCR_VER_FLAGS[flag] for flag in (
         VER_FLAGS.VER_FLG_WEAK,
         VER_FLAGS.VER_FLG_BASE,

--- a/elftools/elf/dynamic.py
+++ b/elftools/elf/dynamic.py
@@ -26,7 +26,7 @@ class _DynamicStringTable:
         self._stream = stream
         self._table_offset = table_offset
 
-    def get_string(self, offset):
+    def get_string(self, offset: int) -> str:
         """ Get the string stored at the given offset in this string table.
         """
         s = parse_cstring_from_stream(self._stream, self._table_offset + offset)
@@ -103,7 +103,7 @@ class Dynamic:
         # Do not access this directly yourself; use _get_stringtable() instead.
         self._stringtable = stringtable
 
-    def get_table_offset(self, tag_name):
+    def get_table_offset(self, tag_name: str) -> tuple[int | None, int | None]:
         """ Return the virtual address and file offset of a dynamic table.
         """
         ptr = None
@@ -175,7 +175,7 @@ class Dynamic:
         """
         return DynamicTag(self._get_tag(n), self._get_stringtable())
 
-    def num_tags(self):
+    def num_tags(self) -> int | None:
         """ Number of dynamic tags in the file, including the DT_NULL tag
         """
         if self._num_tags != -1:
@@ -264,7 +264,7 @@ class DynamicSegment(Segment, Dynamic):
         self._num_symbols = None
         self._symbol_name_map = None
 
-    def num_symbols(self):
+    def num_symbols(self) -> int:
         """ Number of symbols in the table recovered from DT_SYMTAB
         """
         if self._num_symbols is not None:

--- a/elftools/elf/dynamic.py
+++ b/elftools/elf/dynamic.py
@@ -59,10 +59,10 @@ class DynamicTag:
         """
         return self.entry[name]
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return '<DynamicTag (%s): %r>' % (self.entry.d_tag, self.entry)
 
-    def __str__(self):
+    def __str__(self) -> str:
         if self.entry.d_tag in self._HANDLED_TAGS:
             s = '"%s"' % getattr(self, self.entry.d_tag[3:].lower())
         else:

--- a/elftools/elf/dynamic.py
+++ b/elftools/elf/dynamic.py
@@ -106,14 +106,14 @@ class Dynamic:
     def get_table_offset(self, tag_name: str) -> tuple[int | None, int | None]:
         """ Return the virtual address and file offset of a dynamic table.
         """
-        ptr = None
+        ptr: int | None = None
         for tag in self._iter_tags(type=tag_name):
             ptr = tag['d_ptr']
             break
 
         # If we found a virtual address, locate the offset in the file
         # by using the program headers.
-        offset = None
+        offset: int | None = None
         if ptr:
             offset = next(self.elffile.address_offsets(ptr), None)
 
@@ -261,8 +261,8 @@ class DynamicSegment(Segment, Dynamic):
         Dynamic.__init__(self, stream, elffile, stringtable, self['p_offset'],
              self['p_filesz'] == 0)
         self._symbol_size = self.elfstructs.Elf_Sym.sizeof()
-        self._num_symbols = None
-        self._symbol_name_map = None
+        self._num_symbols: int | None = None
+        self._symbol_name_map: dict[str, list[int]] | None = None
 
     def num_symbols(self) -> int:
         """ Number of symbols in the table recovered from DT_SYMTAB
@@ -291,7 +291,7 @@ class DynamicSegment(Segment, Dynamic):
             tab_ptr, tab_offset = self.get_table_offset('DT_SYMTAB')
             if tab_ptr is None or tab_offset is None:
                 raise ELFError('Segment does not contain DT_SYMTAB.')
-            nearest_ptr = None
+            nearest_ptr: int | None = None
             for tag in self.iter_tags():
                 tag_ptr = tag['d_ptr']
                 if tag['d_tag'] == 'DT_SYMENT':

--- a/elftools/elf/elffile.py
+++ b/elftools/elf/elffile.py
@@ -125,7 +125,7 @@ class ELFFile:
             return open(rel_path, 'rb')
         return loader
 
-    def num_sections(self):
+    def num_sections(self) -> int:
         """ Number of sections in the file
         """
         if self['e_shoff'] == 0:
@@ -189,7 +189,7 @@ class ELFFile:
         secnum = self._section_name_map.get(name, None)
         return None if secnum is None else self.get_section(secnum)
 
-    def get_section_index(self, section_name):
+    def get_section_index(self, section_name: str) -> int | None:
         """ Gets the index of the section by name. Return None if no such
             section name exists.
         """
@@ -200,7 +200,7 @@ class ELFFile:
             self._make_section_name_map()
         return self._section_name_map.get(section_name, None)
 
-    def has_section(self, section_name):
+    def has_section(self, section_name: str) -> bool:
         """ Section existence check by name, without the overhead of parsing if found.
         """
         if self._section_name_map is None:
@@ -219,7 +219,7 @@ class ELFFile:
             if type is None or section['sh_type'] == type:
                 yield section
 
-    def num_segments(self):
+    def num_segments(self) -> int:
         """ Number of segments in the file
         """
         # From: https://github.com/hjl-tools/x86-psABI/wiki/X86-psABI
@@ -265,7 +265,7 @@ class ELFFile:
                 end <= seg['p_vaddr'] + seg['p_filesz']):
                 yield start - seg['p_vaddr'] + seg['p_offset']
 
-    def has_dwarf_info(self, strict=False):
+    def has_dwarf_info(self, strict: bool = False) -> bool:
         """ Check whether this file appears to have debugging information.
             We assume that if it has the .debug_info or .zdebug_info section, it
             has all the other required sections as well.
@@ -379,7 +379,7 @@ class ELFFile:
             dwarfinfo.supplementary_dwarfinfo = self.get_supplementary_dwarfinfo(dwarfinfo)
         return dwarfinfo
 
-    def has_dwarf_link(self):
+    def has_dwarf_link(self) -> bool:
         """ Whether the binary's debug info is in an
             external file. Use get_dwarf_link to retrieve the path to it.
         """
@@ -406,7 +406,7 @@ class ELFFile:
         return None
 
 
-    def has_ehabi_info(self):
+    def has_ehabi_info(self) -> bool:
         """ Check whether this file appears to have arm exception handler index table.
         """
         return any(self.iter_sections(type='SHT_ARM_EXIDX'))
@@ -425,7 +425,7 @@ class ELFFile:
         ]
         return _ret if _ret else None
 
-    def get_machine_arch(self):
+    def get_machine_arch(self) -> str:
         """ Return the machine architecture, as detected from the ELF header.
         """
         architectures = {
@@ -619,7 +619,7 @@ class ELFFile:
 
         return architectures.get(self['e_machine'], '<unknown>')
 
-    def get_shstrndx(self):
+    def get_shstrndx(self) -> int:
         """ Find the string table section index for the section header table
         """
         # From https://refspecs.linuxfoundation.org/elf/gabi4+/ch4.eheader.html:
@@ -667,7 +667,7 @@ class ELFFile:
         else:
             raise ELFError('Invalid EI_DATA %s' % repr(ei_data))
 
-    def _section_offset(self, n):
+    def _section_offset(self, n: int) -> int:
         """ Compute the offset of section #n in the file
         """
         shentsize = self['e_shentsize']
@@ -675,7 +675,7 @@ class ELFFile:
             raise ELFError('Too small e_shentsize: %s' % shentsize)
         return self['e_shoff'] + n * shentsize
 
-    def _segment_offset(self, n):
+    def _segment_offset(self, n: int) -> int:
         """ Compute the offset of segment #n in the file
         """
         phentsize = self['e_phentsize']
@@ -942,7 +942,7 @@ class ELFFile:
     def __exit__(self, type, value, traceback):
         self.close()
 
-    def has_phantom_bytes(self):
+    def has_phantom_bytes(self) -> bool:
         """The XC16 compiler for the PIC microcontrollers emits DWARF where all odd bytes in all DWARF sections
            are to be discarded ("phantom").
 

--- a/elftools/elf/elffile.py
+++ b/elftools/elf/elffile.py
@@ -85,7 +85,7 @@ class ELFFile:
         self.e_ident_raw = self.stream.read(16)
 
         self._section_header_stringtable = None # Lazy load
-        self._section_name_map = None
+        self._section_name_map: dict[str, int] | None = None
         self.stream_loader = stream_loader
 
     @classmethod

--- a/elftools/elf/elffile.py
+++ b/elftools/elf/elffile.py
@@ -641,7 +641,7 @@ class ELFFile:
         """
         return self.header[name]
 
-    def _identify_file(self):
+    def _identify_file(self) -> None:
         """ Verify the ELF file and identify its class and endianness.
         """
         # Note: this code reads the stream directly, without using ELFStructs,
@@ -764,7 +764,7 @@ class ELFFile:
         else:
             return Section(section_header, name, self)
 
-    def _make_section_name_map(self):
+    def _make_section_name_map(self) -> None:
         self._section_name_map = {}
         for i, sec in enumerate(self.iter_sections()):
             self._section_name_map[sec.name] = i
@@ -933,7 +933,7 @@ class ELFFile:
 
         return section._replace(stream=uncompressed_stream, size=size)
 
-    def close(self):
+    def close(self) -> None:
         self.stream.close()
 
     def __enter__(self):

--- a/elftools/elf/gnuversions.py
+++ b/elftools/elf/gnuversions.py
@@ -63,7 +63,7 @@ class GNUVersionSection(Section):
         self.version_struct = version_struct
         self.version_auxiliaries_struct = version_auxiliaries_struct
 
-    def num_versions(self):
+    def num_versions(self) -> int:
         """ Number of version entries in the section
         """
         return self['sh_info']
@@ -134,7 +134,7 @@ class GNUVerNeedSection(GNUVersionSection):
                 elffile.structs.Elf_Verneed, elffile.structs.Elf_Vernaux)
         self._has_indexes = None
 
-    def has_indexes(self):
+    def has_indexes(self) -> bool:
         """ Return True if at least one version definition entry has an index
             that is stored in the vna_other field.
             This information is used for symbol versioning
@@ -197,7 +197,7 @@ class GNUVerSymSection(Section):
         super().__init__(header, name, elffile)
         self.symboltable = symboltable
 
-    def num_symbols(self):
+    def num_symbols(self) -> int:
         """ Number of symbols in the table
         """
         return self['sh_size'] // self['sh_entsize']

--- a/elftools/elf/gnuversions.py
+++ b/elftools/elf/gnuversions.py
@@ -132,7 +132,7 @@ class GNUVerNeedSection(GNUVersionSection):
         super().__init__(
                 header, name, elffile, stringtable, 'vn',
                 elffile.structs.Elf_Verneed, elffile.structs.Elf_Vernaux)
-        self._has_indexes = None
+        self._has_indexes: bool | None = None
 
     def has_indexes(self) -> bool:
         """ Return True if at least one version definition entry has an index

--- a/elftools/elf/hash.py
+++ b/elftools/elf/hash.py
@@ -49,7 +49,7 @@ class ELFHashTable:
                                        self.elffile.stream,
                                        start_offset)
 
-    def get_number_of_symbols(self):
+    def get_number_of_symbols(self) -> int:
         """ Get the number of symbols from the hash table parameters.
         """
         return self.params['nchains']
@@ -69,7 +69,7 @@ class ELFHashTable:
         return None
 
     @staticmethod
-    def elf_hash(name):
+    def elf_hash(name: bytes | str) -> int:
         """ Compute the hash value for a given symbol name.
         """
         if not isinstance(name, bytes):
@@ -121,7 +121,7 @@ class GNUHashTable:
             self.params['bloom_size'] * self._xwordsize + \
             self.params['nbuckets'] * self._wordsize
 
-    def get_number_of_symbols(self):
+    def get_number_of_symbols(self) -> int:
         """ Get the number of symbols in the hash table by finding the bucket
             with the highest symbol index and walking to the end of its chain.
         """
@@ -144,7 +144,7 @@ class GNUHashTable:
 
             max_idx += 1
 
-    def _matches_bloom(self, H1):
+    def _matches_bloom(self, H1: int) -> bool:
         """ Helper function to check if the given hash could be in the hash
             table by testing it against the bloom filter.
         """
@@ -180,7 +180,7 @@ class GNUHashTable:
         return None
 
     @staticmethod
-    def gnu_hash(key):
+    def gnu_hash(key: bytes | str) -> int:
         """ Compute the GNU-style hash value for a given symbol name.
         """
         if not isinstance(key, bytes):

--- a/elftools/elf/hash.py
+++ b/elftools/elf/hash.py
@@ -115,9 +115,9 @@ class GNUHashTable:
                                    self.elffile.stream,
                                    start_offset)
         # Element sizes in the hash table
-        self._wordsize = self.elffile.structs.Elf_word('').sizeof()
-        self._xwordsize = self.elffile.structs.Elf_xword('').sizeof()
-        self._chain_pos = start_offset + 4 * self._wordsize + \
+        self._wordsize: int = self.elffile.structs.Elf_word('').sizeof()
+        self._xwordsize: int = self.elffile.structs.Elf_xword('').sizeof()
+        self._chain_pos: int = start_offset + 4 * self._wordsize + \
             self.params['bloom_size'] * self._xwordsize + \
             self.params['nbuckets'] * self._wordsize
 

--- a/elftools/elf/notes.py
+++ b/elftools/elf/notes.py
@@ -27,14 +27,14 @@ def iter_notes(elffile, offset, size):
         elffile.stream.seek(offset)
         if note['n_namesz']:
             # n_namesz is 4-byte aligned.
-            disk_namesz = roundup(note['n_namesz'], 2)
+            disk_namesz: int = roundup(note['n_namesz'], 2)
             note['n_name'] = bytes2str(
                 CString('').parse(elffile.stream.read(disk_namesz)))
             offset += disk_namesz
         else:
             note['n_name'] = None
 
-        desc_data = elffile.stream.read(note['n_descsz'])
+        desc_data: bytes = elffile.stream.read(note['n_descsz'])
         note['n_descdata'] = desc_data
         if note['n_type'] == 'NT_GNU_ABI_TAG' and note['n_name'] == 'GNU':
             note['n_desc'] = struct_parse(elffile.structs.Elf_abi,
@@ -57,7 +57,7 @@ def iter_notes(elffile, offset, size):
             props = []
             # n_descsz contains the size of the note "descriptor" (the data payload),
             # excluding padding. See "Note Section" in https://refspecs.linuxfoundation.org/elf/elf.pdf
-            current_note_end = offset + note['n_descsz']
+            current_note_end: int = offset + note['n_descsz']
             while off < current_note_end:
                 p = struct_parse(elffile.structs.Elf_Prop, elffile.stream, off)
                 off += roundup(p.pr_datasz + 8, 2 if elffile.elfclass == 32 else 3)

--- a/elftools/elf/relocation.py
+++ b/elftools/elf/relocation.py
@@ -28,7 +28,7 @@ class Relocation:
         self.entry = entry
         self.elffile = elffile
 
-    def is_RELA(self):
+    def is_RELA(self) -> bool:
         """ Is this a RELA relocation? If not, it's REL.
         """
         return 'r_addend' in self.entry
@@ -66,12 +66,12 @@ class RelocationTable:
 
         self.entry_size = self.entry_struct.sizeof()
 
-    def is_RELA(self):
+    def is_RELA(self) -> bool:
         """ Is this a RELA relocation section? If not, it's REL.
         """
         return self._is_rela
 
-    def num_relocations(self):
+    def num_relocations(self) -> int:
         """ Number of relocations in the section
         """
         return self._size // self.entry_size
@@ -179,7 +179,7 @@ class RelrRelocationTable:
             # Advance to the next entry
             relr += self._entrysize
 
-    def num_relocations(self):
+    def num_relocations(self) -> int:
         """ Number of relocations in the section
         """
         if self._cached_relocations is None:
@@ -203,35 +203,35 @@ class RelrRelocationSection(Section, RelrRelocationTable):
             self['sh_offset'], self['sh_size'], self['sh_entsize'])
 
 
-def _reloc_calc_identity(value, sym_value, offset, addend=0):
+def _reloc_calc_identity(value: int, sym_value: int, offset: int, addend: int = 0) -> int:
     return value
 
 
-def _reloc_calc_sym_plus_value(value, sym_value, offset, addend=0):
+def _reloc_calc_sym_plus_value(value: int, sym_value: int, offset: int, addend: int = 0) -> int:
     return sym_value + value + addend
 
 
-def _reloc_calc_sym_plus_value_pcrel(value, sym_value, offset, addend=0):
+def _reloc_calc_sym_plus_value_pcrel(value: int, sym_value: int, offset: int, addend: int = 0) -> int:
     return sym_value + value - offset
 
 
-def _reloc_calc_sym_plus_addend(value, sym_value, offset, addend=0):
+def _reloc_calc_sym_plus_addend(value: int, sym_value: int, offset: int, addend: int = 0) -> int:
     return sym_value + addend
 
 
-def _reloc_calc_sym_plus_addend_pcrel(value, sym_value, offset, addend=0):
+def _reloc_calc_sym_plus_addend_pcrel(value: int, sym_value: int, offset: int, addend: int = 0) -> int:
     return sym_value + addend - offset
 
 
-def _reloc_calc_value_minus_sym_addend(value, sym_value, offset, addend=0):
+def _reloc_calc_value_minus_sym_addend(value: int, sym_value: int, offset: int, addend: int = 0) -> int:
     return value - sym_value - addend
 
 
-def _arm_reloc_calc_sym_plus_value_pcrel(value, sym_value, offset, addend=0):
+def _arm_reloc_calc_sym_plus_value_pcrel(value: int, sym_value: int, offset: int, addend: int = 0) -> int:
     return sym_value // 4 + value - offset // 4
 
 
-def _bpf_64_32_reloc_calc_sym_plus_addend(value, sym_value, offset, addend=0):
+def _bpf_64_32_reloc_calc_sym_plus_addend(value: int, sym_value: int, offset: int, addend: int = 0) -> int:
     return (sym_value + addend) // 8 - 1
 
 

--- a/elftools/elf/relocation.py
+++ b/elftools/elf/relocation.py
@@ -142,12 +142,12 @@ class RelrRelocationTable:
         relr = self._offset
         # The addresses of relocations in a bitmap are calculated from a base
         # value provided in an initial 'anchor' relocation.
-        base = None
+        base: int | None = None
         while relr < limit:
             entry = struct_parse(self._relr_struct,
                                  self._elffile.stream,
                                  stream_pos=relr)
-            entry_offset = entry['r_offset']
+            entry_offset: int = entry['r_offset']
             if (entry_offset & 1) == 0:
                 # We found an anchor, take the current value as the base address
                 # for the following bitmaps and move the 'where' pointer to the

--- a/elftools/elf/relocation.py
+++ b/elftools/elf/relocation.py
@@ -38,12 +38,12 @@ class Relocation:
         """
         return self.entry[name]
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return '<Relocation (%s): %s>' % (
                 'RELA' if self.is_RELA() else 'REL',
                 self.entry)
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.__repr__()
 
 

--- a/elftools/elf/sections.py
+++ b/elftools/elf/sections.py
@@ -120,10 +120,10 @@ class Section:
         """
         return self.header[name]
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         return isinstance(other, Section) and self.header == other.header
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         return hash(self.header)
 
 
@@ -315,7 +315,7 @@ class Attribute:
     def tag(self):
         return self._tag['tag']
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         s = '<%s (%s): %r>' % \
             (self.__class__.__name__, self.tag, self.value)
         s += ' %s' % self.extra if self.extra is not None else ''
@@ -364,7 +364,7 @@ class AttributesSubsubsection(Section):
         while self.stream.tell() != end:
             yield self.attribute(self.structs, self.stream)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         s = "<%s (%s): %d bytes>"
         return s % (self.__class__.__name__,
                     self.header.tag[4:], self.header.value)
@@ -422,7 +422,7 @@ class AttributesSubsection(Section):
         """
         return self.header[name]
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         s = "<%s (%s): %d bytes>"
         return s  % (self.__class__.__name__,
                      self.header['vendor_name'], self.header['length'])

--- a/elftools/elf/sections.py
+++ b/elftools/elf/sections.py
@@ -45,13 +45,13 @@ class Section:
             self._decompressed_align = header['sh_addralign']
 
     @property
-    def compressed(self):
+    def compressed(self) -> int:
         """ Is this section compressed?
         """
         return self._compressed
 
     @property
-    def data_size(self):
+    def data_size(self) -> int:
         """ Return the logical size for this section's data.
 
         This can be different from the .sh_size header field when the section
@@ -60,7 +60,7 @@ class Section:
         return self._decompressed_size
 
     @property
-    def data_alignment(self):
+    def data_alignment(self) -> int:
         """ Return the logical alignment for this section's data.
 
         This can be different from the .sh_addralign header field when the
@@ -68,7 +68,7 @@ class Section:
         """
         return self._decompressed_align
 
-    def data(self):
+    def data(self) -> bytes:
         """ The section data from the file.
 
         Note that data is decompressed if the stored section data is
@@ -110,7 +110,7 @@ class Section:
 
         return result
 
-    def is_null(self):
+    def is_null(self) -> bool:
         """ Is this a null section?
         """
         return False
@@ -130,14 +130,14 @@ class Section:
 class NullSection(Section):
     """ ELF NULL section
     """
-    def is_null(self):
+    def is_null(self) -> bool:
         return True
 
 
 class StringTableSection(Section):
     """ ELF string table section.
     """
-    def get_string(self, offset):
+    def get_string(self, offset: int) -> str:
         """ Get the string stored at the given offset in this string table.
         """
         table_offset = self['sh_offset']
@@ -156,7 +156,7 @@ class SymbolTableIndexSection(Section):
         super().__init__(header, name, elffile)
         self.symboltable = symboltable
 
-    def get_section_index(self, n):
+    def get_section_index(self, n: int) -> int:
         """ Get the section header table index for the symbol with index #n.
             The section contains an array of Elf32_word values with one entry
             for every symbol in the associated symbol table.
@@ -178,7 +178,7 @@ class SymbolTableSection(Section):
                 'Expected section size to be a multiple of entry size in section %r' % name)
         self._symbol_name_map = None
 
-    def num_symbols(self):
+    def num_symbols(self) -> int:
         """ Number of symbols in the table
         """
         return self['sh_size'] // self['sh_entsize']
@@ -242,7 +242,7 @@ class SUNWSyminfoTableSection(Section):
         super().__init__(header, name, elffile)
         self.symboltable = symboltable
 
-    def num_symbols(self):
+    def num_symbols(self) -> int:
         """ Number of symbols in the table
         """
         return self['sh_size'] // self['sh_entsize'] - 1
@@ -312,7 +312,7 @@ class Attribute:
         raise NotImplementedError
 
     @property
-    def tag(self):
+    def tag(self) -> str:
         return self._tag['tag']
 
     def __repr__(self) -> str:
@@ -342,7 +342,7 @@ class AttributesSubsubsection(Section):
                 yield attribute
 
     @property
-    def num_attributes(self):
+    def num_attributes(self) -> int:
         """ Number of attributes in the subsubsection.
         """
         return sum(1 for _ in self.iter_attributes()) + 1
@@ -392,7 +392,7 @@ class AttributesSubsection(Section):
                 yield subsubsec
 
     @property
-    def num_subsubsections(self):
+    def num_subsubsections(self) -> int:
         """ Number of subsubsections in the subsection.
         """
         return sum(1 for _ in self.iter_subsubsections())
@@ -453,7 +453,7 @@ class AttributesSection(Section):
                 yield subsec
 
     @property
-    def num_subsections(self):
+    def num_subsections(self) -> int:
         """ Number of subsections in the section.
         """
         return sum(1 for _ in self.iter_subsections())

--- a/elftools/elf/sections.py
+++ b/elftools/elf/sections.py
@@ -29,7 +29,7 @@ class Section:
         self.elffile = elffile
         self.stream = self.elffile.stream
         self.structs = self.elffile.structs
-        self._compressed = header['sh_flags'] & SH_FLAGS.SHF_COMPRESSED
+        self._compressed: int = header['sh_flags'] & SH_FLAGS.SHF_COMPRESSED
 
         if self.compressed:
             # Read the compression header now to know about the size/alignment
@@ -37,9 +37,9 @@ class Section:
             header = struct_parse(self.structs.Elf_Chdr,
                                   self.stream,
                                   stream_pos=self['sh_offset'])
-            self._compression_type = header['ch_type']
-            self._decompressed_size = header['ch_size']
-            self._decompressed_align = header['ch_addralign']
+            self._compression_type: str = header['ch_type']
+            self._decompressed_size: int = header['ch_size']
+            self._decompressed_align: int = header['ch_addralign']
         else:
             self._decompressed_size = header['sh_size']
             self._decompressed_align = header['sh_addralign']
@@ -84,9 +84,9 @@ class Section:
             if c_type == 'ELFCOMPRESS_ZLIB':
                 # Read the data to decompress starting right after the
                 # compression header until the end of the section.
-                hdr_size = self.structs.Elf_Chdr.sizeof()
+                hdr_size: int = self.structs.Elf_Chdr.sizeof()
                 self.stream.seek(self['sh_offset'] + hdr_size)
-                compressed = self.stream.read(self['sh_size'] - hdr_size)
+                compressed: bytes = self.stream.read(self['sh_size'] - hdr_size)
 
                 decomp = zlib.decompressobj()
                 result = decomp.decompress(compressed, self.data_size)
@@ -176,7 +176,7 @@ class SymbolTableSection(Section):
                 'Expected entry size of section %r to be > 0' % name)
         elf_assert(self['sh_size'] % self['sh_entsize'] == 0,
                 'Expected section size to be a multiple of entry size in section %r' % name)
-        self._symbol_name_map = None
+        self._symbol_name_map: dict[str, list[int]] | None = None
 
     def num_symbols(self) -> int:
         """ Number of symbols in the table
@@ -286,8 +286,8 @@ class StabSection(Section):
     def iter_stabs(self):
         """ Yield all stab entries.  Result type is ELFStructs.Elf_Stabs.
         """
-        offset = self['sh_offset']
-        size = self['sh_size']
+        offset: int = self['sh_offset']
+        size: int = self['sh_size']
         end = offset + size
         while offset < end:
             stabs = struct_parse(
@@ -436,7 +436,7 @@ class AttributesSection(Section):
     def __init__(self, header, name, elffile):
         super().__init__(header, name, elffile)
 
-        fv = struct_parse(self.structs.Elf_byte('format_version'),
+        fv: int = struct_parse(self.structs.Elf_byte('format_version'),
                           self.stream,
                           self['sh_offset'])
 
@@ -494,8 +494,8 @@ class ARMAttribute(Attribute):
             self.value = struct_parse(structs.Elf_word('value'), stream)
 
             if self.tag != 'TAG_FILE':
-                self.extra = []
-                s_number = struct_parse(structs.Elf_uleb128('s_number'), stream)
+                self.extra: list[int] = []
+                s_number: int = struct_parse(structs.Elf_uleb128('s_number'), stream)
 
                 while s_number != 0:
                     self.extra.append(s_number)
@@ -517,7 +517,7 @@ class ARMAttribute(Attribute):
             self.value = ARMAttribute(structs, stream)
 
             if type(self.value.value) is not str:
-                nul = struct_parse(structs.Elf_byte('nul'), stream)
+                nul: int = struct_parse(structs.Elf_byte('nul'), stream)
                 elf_assert(nul == 0,
                            "Invalid terminating byte %r, expecting NUL." % nul)
 
@@ -558,8 +558,8 @@ class RISCVAttribute(Attribute):
             self.value = struct_parse(structs.Elf_word('value'), stream)
 
             if self.tag != 'TAG_FILE':
-                self.extra = []
-                s_number = struct_parse(structs.Elf_uleb128('s_number'), stream)
+                self.extra: list[int] = []
+                s_number: int = struct_parse(structs.Elf_uleb128('s_number'), stream)
 
                 while s_number != 0:
                     self.extra.append(s_number)

--- a/elftools/elf/segments.py
+++ b/elftools/elf/segments.py
@@ -17,7 +17,7 @@ class Segment:
         self.header = header
         self.stream = stream
 
-    def data(self):
+    def data(self) -> bytes:
         """ The segment data from the file.
         """
         self.stream.seek(self['p_offset'])
@@ -101,7 +101,7 @@ class InterpSegment(Segment):
     def __init__(self, header, stream):
         super().__init__(header, stream)
 
-    def get_interp_name(self):
+    def get_interp_name(self) -> str:
         """ Obtain the interpreter path used for this ELF file.
         """
         path_offset = self['p_offset']

--- a/elftools/elf/segments.py
+++ b/elftools/elf/segments.py
@@ -36,9 +36,9 @@ class Segment:
             elf/include/internal.h in the source of binutils.
         """
         # Only the 'strict' checks from ELF_SECTION_IN_SEGMENT_1 are included
-        segtype = self['p_type']
-        sectype = section['sh_type']
-        secflags = section['sh_flags']
+        segtype: str = self['p_type']
+        sectype: str = section['sh_type']
+        secflags: int = section['sh_flags']
 
         # Only PT_LOAD, PT_GNU_RELRO and PT_TLS segments can contain SHF_TLS
         # sections
@@ -62,8 +62,8 @@ class Segment:
         # In ELF_SECTION_IN_SEGMENT_STRICT the flag check_vma is on, so if
         # this is an alloc section, check whether its VMA is in bounds.
         if secflags & SH_FLAGS.SHF_ALLOC:
-            secaddr = section['sh_addr']
-            vaddr = self['p_vaddr']
+            secaddr: int = section['sh_addr']
+            vaddr: int = self['p_vaddr']
 
             # This checks that the section is wholly contained in the segment.
             # The third condition is the 'strict' one - an empty section will
@@ -83,8 +83,8 @@ class Segment:
         if sectype == 'SHT_NOBITS':
             return True
 
-        secoffset = section['sh_offset']
-        poffset = self['p_offset']
+        secoffset: int = section['sh_offset']
+        poffset: int = self['p_offset']
 
         # Same logic as with secaddr vs. vaddr checks above, just on offsets in
         # the file
@@ -104,7 +104,7 @@ class InterpSegment(Segment):
     def get_interp_name(self) -> str:
         """ Obtain the interpreter path used for this ELF file.
         """
-        path_offset = self['p_offset']
+        path_offset: int = self['p_offset']
         return struct_parse(
             CString('', encoding='utf-8'),
             self.stream,

--- a/elftools/elf/structs.py
+++ b/elftools/elf/structs.py
@@ -49,10 +49,10 @@ class ELFStructs:
         self.e_machine = None
         self.e_ident_osabi = None
 
-    def __getstate__(self):
+    def __getstate__(self) -> tuple[bool, int, str | None, str | None, str | None]:
         return self.little_endian, self.elfclass, self.e_type, self.e_machine, self.e_ident_osabi
 
-    def __setstate__(self, state):
+    def __setstate__(self, state: tuple[bool, int, str | None, str | None, str | None]) -> None:
         self.little_endian, self.elfclass, e_type, e_machine, e_osabi = state
         self.create_basic_structs()
         self.create_advanced_structs(e_type, e_machine, e_osabi)

--- a/elftools/elf/structs.py
+++ b/elftools/elf/structs.py
@@ -45,9 +45,9 @@ class ELFStructs:
         assert elfclass == 32 or elfclass == 64
         self.little_endian = little_endian
         self.elfclass = elfclass
-        self.e_type = None
-        self.e_machine = None
-        self.e_ident_osabi = None
+        self.e_type: str | None = None  # e.ENUM_E_TYPE
+        self.e_machine: str | None = None  # e.ENUM_E_MACHINE
+        self.e_ident_osabi: str | None = None  # e.ENUM_E_VERSION
 
     def __getstate__(self) -> tuple[bool, int, str | None, str | None, str | None]:
         return self.little_endian, self.elfclass, self.e_type, self.e_machine, self.e_ident_osabi

--- a/elftools/elf/structs.py
+++ b/elftools/elf/structs.py
@@ -57,7 +57,7 @@ class ELFStructs:
         self.create_basic_structs()
         self.create_advanced_structs(e_type, e_machine, e_osabi)
 
-    def create_basic_structs(self):
+    def create_basic_structs(self) -> None:
         """ Create word-size related structs and ehdr struct needed for
             initial determining of ELF type.
         """
@@ -85,7 +85,7 @@ class ELFStructs:
         self._create_leb128()
         self._create_ntbs()
 
-    def create_advanced_structs(self, e_type=None, e_machine=None, e_ident_osabi=None):
+    def create_advanced_structs(self, e_type: str | None = None, e_machine: str | None = None, e_ident_osabi: str | None = None) -> None:
         """ Create all ELF structs except the ehdr. They may possibly depend
             on provided e_type and/or e_machine parsed from ehdr.
         """
@@ -116,7 +116,7 @@ class ELFStructs:
 
     #-------------------------------- PRIVATE --------------------------------#
 
-    def _create_ehdr(self):
+    def _create_ehdr(self) -> None:
         self.Elf_Ehdr = Struct('Elf_Ehdr',
             Struct('e_ident',
                 Array(4, self.Elf_byte('EI_MAG')),
@@ -142,13 +142,13 @@ class ELFStructs:
             self.Elf_half('e_shstrndx'),
         )
 
-    def _create_leb128(self):
+    def _create_leb128(self) -> None:
         self.Elf_uleb128 = ULEB128
 
-    def _create_ntbs(self):
+    def _create_ntbs(self) -> None:
         self.Elf_ntbs = CString
 
-    def _create_phdr(self):
+    def _create_phdr(self) -> None:
         p_type_dict = e.ENUM_P_TYPE_BASE
         if self.e_machine == 'EM_ARM':
             p_type_dict = e.ENUM_P_TYPE_ARM
@@ -182,7 +182,7 @@ class ELFStructs:
                 self.Elf_xword('p_align'),
             )
 
-    def _create_shdr(self):
+    def _create_shdr(self) -> None:
         """Section header parsing.
 
         Depends on e_machine because of machine-specific values in sh_type.
@@ -212,7 +212,7 @@ class ELFStructs:
             self.Elf_xword('sh_entsize'),
         )
 
-    def _create_chdr(self):
+    def _create_chdr(self) -> None:
         # Structure of compressed sections header. It is documented in Oracle
         # "Linker and Libraries Guide", Part IV ELF Application Binary
         # Interface, Chapter 13 Object File Format, Section Compression:
@@ -226,7 +226,7 @@ class ELFStructs:
             fields.insert(1, self.Elf_word('ch_reserved'))
         self.Elf_Chdr = Struct('Elf_Chdr', *fields)
 
-    def _create_rel(self):
+    def _create_rel(self) -> None:
         # r_info is also taken apart into r_info_sym and r_info_type. This is
         # done in Value to avoid endianity issues while parsing.
         if self.elfclass == 32:
@@ -285,7 +285,7 @@ class ELFStructs:
         # For us, this is the same as self.Elf_addr (or self.Elf_xword).
         self.Elf_Relr = Struct('Elf_Relr', self.Elf_addr('r_offset'))
 
-    def _create_dyn(self):
+    def _create_dyn(self) -> None:
         d_tag_dict = dict(e.ENUM_D_TAG_COMMON)
         if self.e_machine in e.ENUMMAP_EXTRA_D_TAG_MACHINE:
             d_tag_dict.update(e.ENUMMAP_EXTRA_D_TAG_MACHINE[self.e_machine])
@@ -298,7 +298,7 @@ class ELFStructs:
             Value('d_ptr', lambda ctx: ctx['d_val']),
         )
 
-    def _create_sym(self):
+    def _create_sym(self) -> None:
         # st_info is hierarchical. To access the type, use
         # container['st_info']['type']
         st_info_struct = BitStruct('st_info',
@@ -331,13 +331,13 @@ class ELFStructs:
                 self.Elf_xword('st_size'),
             )
 
-    def _create_sunw_syminfo(self):
+    def _create_sunw_syminfo(self) -> None:
         self.Elf_Sunw_Syminfo = Struct('Elf_Sunw_Syminfo',
             Enum(self.Elf_half('si_boundto'), **e.ENUM_SUNW_SYMINFO_BOUNDTO),
             self.Elf_half('si_flags'),
         )
 
-    def _create_gnu_verneed(self):
+    def _create_gnu_verneed(self) -> None:
         # Structure of "version needed" entries is documented in
         # Oracle "Linker and Libraries Guide", Chapter 13 Object File Format
         self.Elf_Verneed = Struct('Elf_Verneed',
@@ -355,7 +355,7 @@ class ELFStructs:
             self.Elf_word('vna_next'),
         )
 
-    def _create_gnu_verdef(self):
+    def _create_gnu_verdef(self) -> None:
         # Structure of "version definition" entries are documented in
         # Oracle "Linker and Libraries Guide", Chapter 13 Object File Format
         self.Elf_Verdef = Struct('Elf_Verdef',
@@ -372,14 +372,14 @@ class ELFStructs:
             self.Elf_word('vda_next'),
         )
 
-    def _create_gnu_versym(self):
+    def _create_gnu_versym(self) -> None:
         # Structure of "version symbol" entries are documented in
         # Oracle "Linker and Libraries Guide", Chapter 13 Object File Format
         self.Elf_Versym = Struct('Elf_Versym',
             Enum(self.Elf_half('ndx'), **e.ENUM_VERSYM),
         )
 
-    def _create_gnu_abi(self):
+    def _create_gnu_abi(self) -> None:
         # Structure of GNU ABI notes is documented in
         # https://code.woboq.org/userspace/glibc/csu/abi-note.S.html
         self.Elf_abi = Struct('Elf_abi',
@@ -389,12 +389,12 @@ class ELFStructs:
             self.Elf_word('abi_tiny'),
         )
 
-    def _create_gnu_debugaltlink(self):
+    def _create_gnu_debugaltlink(self) -> None:
         self.Elf_debugaltlink = Struct('Elf_debugaltlink',
             CString("sup_filename"),
             String("sup_checksum", length=20))
 
-    def _create_gnu_property(self):
+    def _create_gnu_property(self) -> None:
         # Structure of GNU property notes is documented in
         # https://github.com/hjl-tools/linux-abi/wiki/linux-abi-draft.pdf
         def roundup_padding(ctx):
@@ -428,7 +428,7 @@ class ELFStructs:
             Padding(roundup_padding)
         )
 
-    def _create_note(self, e_type=None):
+    def _create_note(self, e_type: str | None = None) -> None:
         # Structure of "PT_NOTE" section
 
         self.Elf_ugid = self.Elf_half if self.elfclass == 32 and self.e_machine in {
@@ -503,7 +503,7 @@ class ELFStructs:
                                   Array(lambda ctx: ctx.num_map_entries,
                                         CString('filename')))
 
-    def _create_stabs(self):
+    def _create_stabs(self) -> None:
         # Structure of one stabs entry, see binutils/bfd/stabs.c
         # Names taken from https://sourceware.org/gdb/current/onlinedocs/stabs.html#Overview
         self.Elf_Stabs = Struct('Elf_Stabs',
@@ -514,7 +514,7 @@ class ELFStructs:
             self.Elf_word('n_value'),
         )
 
-    def _create_attributes_subsection(self):
+    def _create_attributes_subsection(self) -> None:
         # Structure of a build attributes subsection header. A subsection is
         # either public to all tools that process the ELF file or private to
         # the vendor's tools.
@@ -524,21 +524,21 @@ class ELFStructs:
                                                                encoding='utf-8')
         )
 
-    def _create_arm_attributes(self):
+    def _create_arm_attributes(self) -> None:
         # Structure of an ARM build attribute tag.
         self.Elf_Arm_Attribute_Tag = Struct('Elf_Arm_Attribute_Tag',
                                              Enum(self.Elf_uleb128('tag'),
                                                   **e.ENUM_ATTR_TAG_ARM)
         )
 
-    def _create_riscv_attributes(self):
+    def _create_riscv_attributes(self) -> None:
         # Structure of a RISC-V build attribute tag.
         self.Elf_RiscV_Attribute_Tag = Struct('Elf_RiscV_Attribute_Tag',
                                         Enum(self.Elf_uleb128('tag'),
                                              **e.ENUM_ATTR_TAG_RISCV)
         )
 
-    def _create_elf_hash(self):
+    def _create_elf_hash(self) -> None:
         # Structure of the old SYSV-style hash table header. It is documented
         # in the Oracle "Linker and Libraries Guide", Part IV ELF Application
         # Binary Interface, Chapter 14 Object File Format, Section Hash Table
@@ -551,7 +551,7 @@ class ELFStructs:
                                Array(lambda ctx: ctx['nbuckets'], self.Elf_word('buckets')),
                                Array(lambda ctx: ctx['nchains'], self.Elf_word('chains')))
 
-    def _create_gnu_hash(self):
+    def _create_gnu_hash(self) -> None:
         # Structure of the GNU-style hash table header. Documentation for this
         # table is mostly in the GLIBC source code, a good explanation of the
         # format can be found in this blog post:
@@ -564,7 +564,7 @@ class ELFStructs:
                                Array(lambda ctx: ctx['bloom_size'], self.Elf_xword('bloom')),
                                Array(lambda ctx: ctx['nbuckets'], self.Elf_word('buckets')))
 
-    def _create_gnu_debuglink(self):
+    def _create_gnu_debuglink(self) -> None:
         self.Gnu_debuglink = Struct('Gnu_debuglink',
             CString("filename"),
             Padding(lambda ctx: 3 - len(ctx.filename) % 4, strict=True),

--- a/elftools/elf/structs.py
+++ b/elftools/elf/structs.py
@@ -41,7 +41,7 @@ class ELFStructs:
             Elf_Rel, Elf_Rela:
                 Entries in relocation sections
     """
-    def __init__(self, little_endian=True, elfclass=32):
+    def __init__(self, little_endian: bool = True, elfclass: int = 32) -> None:
         assert elfclass == 32 or elfclass == 64
         self.little_endian = little_endian
         self.elfclass = elfclass

--- a/scripts/dwarfdump.py
+++ b/scripts/dwarfdump.py
@@ -131,7 +131,7 @@ FORM_DESCRIPTIONS = dict(
     DW_FORM_exprloc=lambda attr, die: _desc_expression(attr.value, die)
 )
 
-def _desc_enum(attr, enum):
+def _desc_enum(attr, enum: dict[str, int]) -> str:
     """For attributes like DW_AT_language, physically
     int, logically an enum
     """

--- a/scripts/dwarfdump.py
+++ b/scripts/dwarfdump.py
@@ -357,17 +357,17 @@ class ReadElf:
         bits = self.elffile.elfclass
         self._emitline("%s:	file format elf%d-%s" % (filename, bits, arch))
 
-    def _emit(self, s=''):
+    def _emit(self, s: str = '') -> None:
         """ Emit an object to output
         """
         self.output.write(str(s))
 
-    def _emitline(self, s=''):
+    def _emitline(self, s: str = '') -> None:
         """ Emit an object to output, followed by a newline
         """
         self.output.write(str(s).rstrip() + '\n')
 
-    def dump_info(self):
+    def dump_info(self) -> None:
         # TODO: DWARF64 will cause discrepancies in hex offset sizes
         self._emitline(".debug_info contents:")
         for cu in self._dwarfinfo.iter_CUs():
@@ -419,13 +419,13 @@ class ReadElf:
         else:
             return str(attr.value)
 
-    def dump_loc(self):
+    def dump_loc(self) -> None:
         pass
 
-    def dump_loclists(self):
+    def dump_loclists(self) -> None:
         pass
 
-    def dump_ranges(self):
+    def dump_ranges(self) -> None:
         pass
 
     def dump_v4_rangelist(self, rangelist, cu_map):
@@ -444,7 +444,7 @@ class ReadElf:
             else:
                 raise NotImplementedError("Unknown object in a range list")
 
-    def dump_rnglists(self):
+    def dump_rnglists(self) -> None:
         self._emitline(".debug_rnglists contents:")
         ranges_sec = self._dwarfinfo.range_lists()
         if ranges_sec.version < 5:

--- a/scripts/readelf.py
+++ b/scripts/readelf.py
@@ -115,7 +115,7 @@ class ReadElf:
 
         self._shndx_sections = None
 
-    def display_file_header(self):
+    def display_file_header(self) -> None:
         """ Display the ELF file header
         """
         self._emitline('ELF Header:')
@@ -273,7 +273,7 @@ class ReadElf:
 
         return description
 
-    def display_program_headers(self, show_heading=True):
+    def display_program_headers(self, show_heading: bool = True) -> None:
         """ Display the ELF program headers.
             If show_heading is True, displays the heading for this information
             (Elf file type is...)
@@ -362,7 +362,7 @@ class ReadElf:
 
             self._emitline('')
 
-    def display_section_headers(self, show_heading=True):
+    def display_section_headers(self, show_heading: bool = True) -> None:
         """ Display the ELF section headers
         """
         elfheader = self.elffile.header
@@ -425,7 +425,7 @@ class ReadElf:
             self._emit('y (purecode), ')
         self._emitline('p (processor specific)')
 
-    def display_symbol_tables(self):
+    def display_symbol_tables(self) -> None:
         """ Display the symbol tables contained in the file
         """
         self._init_versioninfo()
@@ -499,7 +499,7 @@ class ReadElf:
                     _format_symbol_name(symbol_name),
                     version_info))
 
-    def display_dynamic_tags(self):
+    def display_dynamic_tags(self) -> None:
         """ Display the dynamic tags contained in the file
         """
         has_dynamic_sections = False
@@ -556,7 +556,7 @@ class ReadElf:
         if not has_dynamic_sections:
             self._emitline("\nThere is no dynamic section in this file.")
 
-    def display_notes(self):
+    def display_notes(self) -> None:
         """ Display the notes contained in the file
         """
         for section in self.elffile.iter_sections():
@@ -570,7 +570,7 @@ class ReadElf:
                           self._format_hex(note['n_descsz'], fieldsize=8),
                           describe_note(note, self.elffile.header.e_machine)))
 
-    def display_relocations(self):
+    def display_relocations(self) -> None:
         """ Display the relocations contained in the file
         """
         has_relocation_sections = False
@@ -656,7 +656,7 @@ class ReadElf:
         if not has_relocation_sections:
             self._emitline('\nThere are no relocations in this file.')
 
-    def display_arm_unwind(self):
+    def display_arm_unwind(self) -> None:
         if not self.elffile.has_ehabi_info():
             self._emitline('There are no .ARM.idx sections in this file.')
             return
@@ -691,7 +691,7 @@ class ReadElf:
                         self._emit('    ')
                         self._emitline(mnemonic_item)
 
-    def display_version_info(self):
+    def display_version_info(self) -> None:
         """ Display the version info contained in the file
         """
         self._init_versioninfo()
@@ -794,7 +794,7 @@ class ReadElf:
 
                     offset += verneed['vn_next']
 
-    def display_arch_specific(self):
+    def display_arch_specific(self) -> None:
         """ Display the architecture-specific info contained in the file.
         """
         if self.elffile['e_machine'] == 'EM_ARM':
@@ -802,7 +802,7 @@ class ReadElf:
         elif self.elffile['e_machine'] == 'EM_RISCV':
             self._display_arch_specific_riscv()
 
-    def display_hex_dump(self, section_spec):
+    def display_hex_dump(self, section_spec) -> None:
         """ Display a hex dump of a section. section_spec is either a section
             number or a name.
         """
@@ -850,7 +850,7 @@ class ReadElf:
 
         self._emitline()
 
-    def display_string_dump(self, section_spec):
+    def display_string_dump(self, section_spec) -> None:
         """ Display a strings dump of a section. section_spec is either a
             section number or a name.
         """
@@ -895,7 +895,7 @@ class ReadElf:
         else:
             self._emitline()
 
-    def display_debug_dump(self, dump_what):
+    def display_debug_dump(self, dump_what: str) -> None:
         """ Dump a DWARF section
         """
         self._init_dwarfinfo()
@@ -990,7 +990,7 @@ class ReadElf:
             )
         )
 
-    def _init_versioninfo(self):
+    def _init_versioninfo(self) -> None:
         """ Search and initialize informations about version related sections
             and the kind of versioning used (GNU or Solaris).
         """
@@ -1096,7 +1096,7 @@ class ReadElf:
                     self._emitline('  Note: This section has relocations against it, but these have NOT been applied to this dump.')
                     return
 
-    def _init_dwarfinfo(self):
+    def _init_dwarfinfo(self) -> None:
         """ Initialize the DWARF info contained in the file and assign it to
             self._dwarfinfo.
             Leave self._dwarfinfo at None if no DWARF info was found in the file
@@ -1109,7 +1109,7 @@ class ReadElf:
         else:
             self._dwarfinfo = None
 
-    def _dump_debug_info(self):
+    def _dump_debug_info(self) -> None:
         """ Dump the debugging info section.
         """
         if not self._dwarfinfo.has_debug_info:
@@ -1188,7 +1188,7 @@ class ReadElf:
 
         self._emitline()
 
-    def _dump_debug_types(self):
+    def _dump_debug_types(self) -> None:
         """Dump the debug types section
         """
         if not self._dwarfinfo.has_debug_info:
@@ -1240,7 +1240,7 @@ class ReadElf:
 
         self._emitline()
 
-    def _dump_debug_line_programs(self):
+    def _dump_debug_line_programs(self) -> None:
         """ Dump the (decoded) line programs from .debug_line
             The programs are dumped in the order of the CUs they belong to.
         """
@@ -1308,7 +1308,7 @@ class ReadElf:
                     # Another readelf oddity...
                     self._emitline()
 
-    def _dump_frames_info(self, section, cfi_entries):
+    def _dump_frames_info(self, section, cfi_entries) -> None:
         """ Dump the raw call frame info in a section.
 
             `section` is the Section instance that contains the call frame info
@@ -1358,7 +1358,7 @@ class ReadElf:
             self._emit(describe_CFI_instructions(entry))
         self._emitline()
 
-    def _dump_debug_frames(self):
+    def _dump_debug_frames(self) -> None:
         """ Dump the raw frame info from .debug_frame and .eh_frame sections.
         """
         if self._dwarfinfo.has_EH_CFI():
@@ -1372,7 +1372,7 @@ class ReadElf:
                     self._dwarfinfo.debug_frame_sec,
                     self._dwarfinfo.CFI_entries())
 
-    def _dump_debug_namelut(self, what):
+    def _dump_debug_namelut(self, what: str) -> None:
         """
         Dump the debug pubnames section.
         """
@@ -1406,7 +1406,7 @@ class ReadElf:
                 self._emitline('    %x          %s' % (item[1].die_ofs - cu_ofs, item[0]))
         self._emitline()
 
-    def _dump_debug_aranges(self):
+    def _dump_debug_aranges(self) -> None:
         """ Dump the aranges table
         """
         aranges_table = self._dwarfinfo.get_aranges()
@@ -1539,7 +1539,7 @@ class ReadElf:
                 self._emitline()
         self._emitline()
 
-    def _dump_debug_frames_interp(self):
+    def _dump_debug_frames_interp(self) -> None:
         """ Dump the interpreted (decoded) frame information from .debug_frame
             and .eh_frame sections.
         """
@@ -1554,7 +1554,7 @@ class ReadElf:
                     self._dwarfinfo.debug_frame_sec,
                     self._dwarfinfo.CFI_entries())
 
-    def _dump_debug_locations(self):
+    def _dump_debug_locations(self) -> None:
         """ Dump the location lists from .debug_loc/.debug_loclists section
         """
         di = self._dwarfinfo
@@ -1698,7 +1698,7 @@ class ReadElf:
             for i_offset in enumerate(cu.offsets):
                 self._emitline('    [%6d] 0x%x' % i_offset)
 
-    def _dump_debug_ranges(self):
+    def _dump_debug_ranges(self) -> None:
         # TODO: GNU readelf format doesn't need entry_length?
         di = self._dwarfinfo
         range_lists_sec = di.range_lists()
@@ -1817,26 +1817,26 @@ class ReadElf:
                     self._emit('  ')
                     self._emitline(descriptor(attr.tag, attr.value, attr.extra))
 
-    def _display_arch_specific_arm(self):
+    def _display_arch_specific_arm(self) -> None:
         """ Display the ARM architecture-specific info contained in the file.
         """
         attr_sec = self.elffile.get_section_by_name('.ARM.attributes')
         if attr_sec:
             self._display_attributes(attr_sec, describe_attr_tag_arm)
 
-    def _display_arch_specific_riscv(self):
+    def _display_arch_specific_riscv(self) -> None:
         """ Display the RISC-V architecture-specific info contained in the file.
         """
         attr_sec = self.elffile.get_section_by_name('.riscv.attributes')
         if attr_sec:
             self._display_attributes(attr_sec, describe_attr_tag_riscv)
 
-    def _emit(self, s=''):
+    def _emit(self, s: str = '') -> None:
         """ Emit an object to output
         """
         self.output.write(str(s))
 
-    def _emitline(self, s=''):
+    def _emitline(self, s: str = '') -> None:
         """ Emit an object to output, followed by a newline
         """
         self.output.write(str(s).rstrip() + '\n')
@@ -1971,7 +1971,7 @@ def main(stream=None):
             sys.exit(1)
 
 
-def profile_main():
+def profile_main() -> None:
     # Run 'main' redirecting its output to readelfout.txt
     # Saves profiling information in readelf.profile
     PROFFILE = 'readelf.profile'

--- a/scripts/readelf.py
+++ b/scripts/readelf.py
@@ -92,7 +92,7 @@ def _get_cu_base(cu):
 # formatting symbol names for display.
 _CONTROL_CHAR_RE = re.compile(r'[\x01-\x1f]')
 
-def _format_symbol_name(s):
+def _format_symbol_name(s: str) -> str:
     return _CONTROL_CHAR_RE.sub(lambda match: '^' + chr(0x40 + ord(match[0])), s)
 
 class ReadElf:
@@ -173,7 +173,7 @@ class ReadElf:
         else:
             self._emitline('')
 
-    def decode_flags(self, flags):
+    def decode_flags(self, flags: int) -> str:
         description = ""
         if self.elffile['e_machine'] == "EM_ARM":
             eabi = flags & E_FLAGS.EF_ARM_EABIMASK
@@ -924,8 +924,14 @@ class ReadElf:
         else:
             self._emitline('debug dump not yet supported for "%s"' % dump_what)
 
-    def _format_hex(self, addr, fieldsize=None, fullhex=False, lead0x=True,
-                    alternate=False):
+    def _format_hex(
+        self,
+        addr: int,
+        fieldsize: int | None = None,
+        fullhex: bool = False,
+        lead0x: bool = True,
+        alternate: bool = False,
+    ) -> str:
         """ Format an address into a hexadecimal string.
 
             fieldsize:


### PR DESCRIPTION
This is the "boring" part of #611:
- _dunder_-methods like `__str__()`, `__repr__()`, `__len__()`, `__hash__()`, `__eq__()`, `__getstate__()`, `__setstate__()`, `__init__()`
- functions / methods returning `None`
- functions / methods only receiving / returning _primitive types_ like `int`, `bool`, `str`, `dict`, `list`, `None`
- (local) variables with _primitive types_

Maybe it's easier to review the individual patches then the combined diff as they go by category.