### PR TITLE
typing: Add type hints to structs

### DIFF
--- a/elftools/dwarf/structs.py
+++ b/elftools/dwarf/structs.py
@@ -7,6 +7,10 @@
 # Eli Bendersky (eliben@gmail.com)
 # This code is in the public domain
 #-------------------------------------------------------------------------------
+from __future__ import annotations
+
+from typing import IO, TYPE_CHECKING, Any, ClassVar
+
 import elftools.dwarf.enums as e
 from ..construct import (
     UBInt8, UBInt16, UBInt32, UBInt64, ULInt8, ULInt16, ULInt32, ULInt64,
@@ -16,6 +20,14 @@ from ..construct import (
     )
 from ..common.construct_utils import (RepeatUntilExcluding, ULEB128, SLEB128,
     StreamOffset, ULInt24, UBInt24)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from typing_extensions import Self  # 3.11+
+
+    from ..construct.adapters import LengthValueAdapter
+    from ..construct.lib.container import Container
 
 
 class DWARFStructs:
@@ -78,12 +90,25 @@ class DWARFStructs:
         See also the documentation of public methods.
     """
 
+    if TYPE_CHECKING:
+        # type hints for dynamically defined class variables
+        little_endian: bool
+        dwarf_format: int
+        address_size: int
+        dwarf_version: int
+
     # Cache for structs instances based on creation parameters. Structs
     # initialization is expensive and we don't won't to repeat it
     # unnecessarily.
-    _structs_cache = {}
+    _structs_cache: ClassVar[dict[tuple[bool, int, int, int], Self]] = {}
 
-    def __new__(cls, little_endian, dwarf_format, address_size, dwarf_version=2):
+    def __new__(
+        cls,
+        little_endian: bool,
+        dwarf_format: int,
+        address_size: int,
+        dwarf_version: int = 2,
+    ) -> Self:
         """ dwarf_version:
                 Numeric DWARF version
 
@@ -122,7 +147,7 @@ class DWARFStructs:
         if self.little_endian:
             self.Dwarf_uint8 = ULInt8
             self.Dwarf_uint16 = ULInt16
-            self.Dwarf_uint24 = ULInt24
+            self.Dwarf_uint24: type[ULInt24 | UBInt24] = ULInt24
             self.Dwarf_uint32 = ULInt32
             self.Dwarf_uint64 = ULInt64
             self.Dwarf_offset = ULInt32 if self.dwarf_format == 32 else ULInt64
@@ -177,7 +202,7 @@ class DWARFStructs:
         self._create_gnu_debugaltlink()
 
     def _create_initial_length(self) -> None:
-        def _InitialLength(name):
+        def _InitialLength(name: str) -> _InitialLengthAdapter:
             # Adapts a Struct that parses forward a full initial length field.
             # Only if the first word is the continuation value, the second
             # word is parsed from the stream.
@@ -385,18 +410,18 @@ class DWARFStructs:
             # similar to deprecared Dynamic.
             # Strings are resolved later, since it potentially requires
             # looking at another section.
-            def __init__(self, name, structs, format_field):
+            def __init__(self, name: str, structs: DWARFStructs, format_field: str) -> None:
                 Construct.__init__(self, name)
                 self.structs = structs
                 self.format_field = format_field
 
-            def _parse(self, stream, context):
+            def _parse(self, stream: IO[bytes], context: Container) -> Any:
                 # Somewhat tricky technique here, explicitly writing back to the context
                 if self.format_field + "_parser" in context:
                     parser = context[self.format_field + "_parser"]
                 else:
                     fields = tuple(
-                        Rename(f.content_type, self.structs.Dwarf_dw_form[f.form])
+                        Rename(f.content_type, self.structs.Dwarf_dw_form[f.form])  # type: ignore[arg-type] # ty: ignore[invalid-argument-type]
                         for f in context[self.format_field])
                     parser = Struct('formatted_entry', *fields)
                     context[self.format_field + "_parser"] = parser
@@ -481,7 +506,7 @@ class DWARFStructs:
             self.Dwarf_target_addr('initial_location'),
             self.Dwarf_target_addr('address_range'))
 
-    def _make_block_struct(self, length_field):
+    def _make_block_struct(self, length_field: Callable[[str], Construct]) -> LengthValueAdapter:
         """ Create a struct for DW_FORM_block<size>
         """
         return PrefixedArray(
@@ -563,7 +588,7 @@ class _InitialLengthAdapter(Adapter):
     """ A standard Construct adapter that expects a sub-construct
         as a struct with one or two values (first, second).
     """
-    def _decode(self, obj, context):
+    def _decode(self, obj: Container, context: Container) -> int:
         if obj.first < 0xFFFFFF00:
             context['is64'] = False
             return obj.first

--- a/elftools/elf/structs.py
+++ b/elftools/elf/structs.py
@@ -7,6 +7,10 @@
 # Eli Bendersky (eliben@gmail.com)
 # This code is in the public domain
 #-------------------------------------------------------------------------------
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import elftools.elf .enums as e
 from ..construct import (
     UBInt8, UBInt16, UBInt32, UBInt64,
@@ -17,6 +21,12 @@ from ..construct import (
     )
 from ..common.construct_utils import ULEB128
 from ..common.utils import roundup
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from ..construct.core import FormatField
+    from ..construct.lib.container import Container
 
 
 class ELFStructs:
@@ -41,6 +51,24 @@ class ELFStructs:
             Elf_Rel, Elf_Rela:
                 Entries in relocation sections
     """
+    if TYPE_CHECKING:
+        # type hints for dynamically defined instance variables
+        Elf_byte: Callable[[str], FormatField[int]]
+        Elf_half: Callable[[str], FormatField[int]]
+        Elf_word: Callable[[str], FormatField[int]]
+        Elf_word64: Callable[[str], FormatField[int]]
+        Elf_addr: Callable[[str], FormatField[int]]
+        Elf_offset: Callable[[str], FormatField[int]]
+        Elf_sword: Callable[[str], FormatField[int]]
+        Elf_sxword: Callable[[str], FormatField[int]]
+        Elf_xsword: Callable[[str], FormatField[int]]
+        Elf_Ehdr: Struct
+        Elf_Phdr: Struct
+        Elf_Shdr: Struct
+        Elf_Sym: Struct
+        Elf_Rel: Struct
+        Elf_Rela: Struct
+
     def __init__(self, little_endian: bool = True, elfclass: int = 32) -> None:
         assert elfclass == 32 or elfclass == 64
         self.little_endian = little_endian
@@ -288,6 +316,7 @@ class ELFStructs:
     def _create_dyn(self) -> None:
         d_tag_dict = dict(e.ENUM_D_TAG_COMMON)
         if self.e_machine in e.ENUMMAP_EXTRA_D_TAG_MACHINE:
+            assert self.e_machine is not None
             d_tag_dict.update(e.ENUMMAP_EXTRA_D_TAG_MACHINE[self.e_machine])
         elif self.e_ident_osabi == 'ELFOSABI_SOLARIS':
             d_tag_dict.update(e.ENUM_D_TAG_SOLARIS)
@@ -397,12 +426,12 @@ class ELFStructs:
     def _create_gnu_property(self) -> None:
         # Structure of GNU property notes is documented in
         # https://github.com/hjl-tools/linux-abi/wiki/linux-abi-draft.pdf
-        def roundup_padding(ctx):
+        def roundup_padding(ctx: Container) -> int:
             if self.elfclass == 32:
                 return roundup(ctx.pr_datasz, 2) - ctx.pr_datasz
             return roundup(ctx.pr_datasz, 3) - ctx.pr_datasz
 
-        def classify_pr_data(ctx):
+        def classify_pr_data(ctx: Container) -> tuple[str, int, int] | None:
             if type(ctx.pr_type) is not str:
                 return None
             if ctx.pr_type.startswith('GNU_PROPERTY_X86_'):


### PR DESCRIPTION
The next small hunk from #611 
- `elftools.elf.structs` needs some additional type hints as many instance variables are only defined by methods called from `__init__()`. Static type checkers usually don't follow these call chains and thus need some manual hinting.
- `elfstools.dwarf.structs` uses `__new__()` to define several call variables, which also must be added manually.
- `ENUMMAP_EXTRA_D_TAG_MACHINE: dict[str, str]` does not allow looking up `None` ans thus requires a manual check for `is not None` :disappointed: 