### PR TITLE
Typing elftools.dwarf

### DIFF
--- a/elftools/dwarf/abbrevtable.py
+++ b/elftools/dwarf/abbrevtable.py
@@ -6,14 +6,24 @@
 # Eli Bendersky (eliben@gmail.com)
 # This code is in the public domain
 #-------------------------------------------------------------------------------
+from __future__ import annotations
+
+from typing import IO, TYPE_CHECKING, Any
+
 from ..common.utils import struct_parse
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from ..construct.lib.container import Container
+    from .structs import DWARFStructs
 
 
 class AbbrevTable:
     """ Represents a DWARF abbreviation table.
     """
     __slots__ = ('structs', 'stream', 'offset', '_abbrev_map')
-    def __init__(self, structs, stream, offset):
+    def __init__(self, structs: DWARFStructs, stream: IO[bytes], offset: int) -> None:
         """ Create new abbreviation table. Parses the actual table from the
             stream and stores it internally.
 
@@ -30,16 +40,16 @@ class AbbrevTable:
 
         self._abbrev_map = self._parse_abbrev_table()
 
-    def get_abbrev(self, code):
+    def get_abbrev(self, code: int) -> AbbrevDecl:
         """ Get the AbbrevDecl for a given code. Raise KeyError if no
             declaration for this code exists.
         """
         return self._abbrev_map[code]
 
-    def _parse_abbrev_table(self):
+    def _parse_abbrev_table(self) -> dict[int, AbbrevDecl]:
         """ Parse the abbrev table from the stream
         """
-        map = {}
+        map: dict[int, AbbrevDecl] = {}
         self.stream.seek(self.offset)
         while True:
             decl_code: int = struct_parse(
@@ -61,7 +71,7 @@ class AbbrevDecl:
         The abbreviation declaration represents an "entry" that points to it.
     """
     __slots__ = ('code', 'decl', '_has_children')
-    def __init__(self, code, decl):
+    def __init__(self, code: int, decl: Container) -> None:
         self.code = code
         self.decl = decl
         self._has_children = decl['children_flag'] == 'DW_CHILDREN_yes'
@@ -69,12 +79,12 @@ class AbbrevDecl:
     def has_children(self) -> bool:
         return self._has_children
 
-    def iter_attr_specs(self):
+    def iter_attr_specs(self) -> Iterator[tuple[str, str]]:
         """ Iterate over the attribute specifications for the entry. Yield
             (name, form) pairs.
         """
         for attr_spec in self['attr_spec']:
             yield attr_spec.name, attr_spec.form
 
-    def __getitem__(self, entry):
+    def __getitem__(self, entry: str) -> Any:
         return self.decl[entry]

--- a/elftools/dwarf/aranges.py
+++ b/elftools/dwarf/aranges.py
@@ -6,11 +6,20 @@
 # Dorothy Chen (dorothchen@gmail.com)
 # This code is in the public domain
 #-------------------------------------------------------------------------------
-from typing import NamedTuple
+from __future__ import annotations
+
+from typing import IO, TYPE_CHECKING, NamedTuple
 
 from ..common.utils import struct_parse
 from bisect import bisect_right
 import math
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from ..construct.core import Construct
+    from .structs import DWARFStructs
+
 
 # An entry in the aranges table;
 # begin_addr: The beginning address in the CU
@@ -36,7 +45,7 @@ class ARanges:
         structs:
             A DWARFStructs instance for parsing the data
     """
-    def __init__(self, stream, size, structs):
+    def __init__(self, stream: IO[bytes], size: int, structs: DWARFStructs) -> None:
         self.stream = stream
         self.size = size
         self.structs = structs
@@ -63,7 +72,7 @@ class ARanges:
 
 
     #------ PRIVATE ------#
-    def _get_entries(self, need_empty=False):
+    def _get_entries(self, need_empty: bool = False) -> list[ARangeEntry]:
         """ Populate self.entries with ARangeEntry tuples for each range of addresses
 
             Terminating null entries of CU blocks are not returned, unless
@@ -72,7 +81,7 @@ class ARanges:
             set to 0.
         """
         self.stream.seek(0)
-        entries = []
+        entries: list[ARangeEntry] = []
         offset = 0
 
         # one loop == one "set" == one CU
@@ -122,7 +131,7 @@ class ARanges:
 
         return entries
 
-    def _get_addr_size_struct(self, addr_header_value):
+    def _get_addr_size_struct(self, addr_header_value: int) -> Callable[[str], Construct]:
         """ Given this set's header value (int) for the address size,
             get the Construct representation of that size
         """

--- a/elftools/dwarf/callframe.py
+++ b/elftools/dwarf/callframe.py
@@ -176,6 +176,7 @@ class CallFrameInfo:
                     header, entry_structs)
         else:
             cie = self._parse_cie_for_fde(offset, header, entry_structs)
+            assert isinstance(cie, CFIEntry)
             aug_bytes = self._read_augmentation_data(entry_structs)
             lsda_encoding = cast(int, cie.augmentation_dict.get('LSDA_encoding', DW_EH_encoding_flags['DW_EH_PE_omit']))
             if lsda_encoding != DW_EH_encoding_flags['DW_EH_PE_omit']:
@@ -203,6 +204,7 @@ class CallFrameInfo:
 
         else: # FDE
             cie = self._parse_cie_for_fde(offset, header, entry_structs)
+            assert isinstance(cie, CIE)
             entry = FDE(
                 header=header, instructions=instructions, offset=offset,
                 structs=entry_structs, cie=cie,
@@ -420,6 +422,7 @@ class CallFrameInfo:
         minimal_header = struct_parse(Struct('eh_frame_minimal_header',
                                              *fields), self.stream, offset)
         cie = self._parse_cie_for_fde(offset, minimal_header, entry_structs)
+        assert isinstance(cie, CFIEntry)
         initial_location_offset = self.stream.tell()
 
         # Try to parse the initial location. We need the initial location in

--- a/elftools/dwarf/callframe.py
+++ b/elftools/dwarf/callframe.py
@@ -6,10 +6,12 @@
 # Eli Bendersky (eliben@gmail.com)
 # This code is in the public domain
 #-------------------------------------------------------------------------------
+from __future__ import annotations
+
 import copy
 import os
 from collections.abc import Iterator
-from typing import Any, Literal, NamedTuple
+from typing import IO, TYPE_CHECKING, Any, Literal, NamedTuple, cast
 from warnings import warn
 
 from ..common.utils import (
@@ -19,6 +21,12 @@ from ..construct.lib.container import Container
 from .enums import DW_EH_encoding_flags
 from .structs import DWARFStructs
 from .constants import DW_CFA
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from ..construct.core import Construct
+    from ..construct.lib.container import ListContainer
 
 
 Line = dict[Any, Any]
@@ -67,25 +75,31 @@ class CallFrameInfo:
             such as guessing which CU contains which FDEs (based on their
             address ranges) and taking the address_size from those CUs.
     """
-    def __init__(self, stream, size, address, base_structs,
-                 for_eh_frame=False):
+    def __init__(
+        self,
+        stream: IO[bytes],
+        size: int,
+        address: int,
+        base_structs: DWARFStructs,
+        for_eh_frame: bool = False,
+    ) -> None:
         self.stream = stream
         self.size = size
         self.address = address
         self.base_structs = base_structs
-        self.entries = None
+        self.entries: list[CFIEntry | ZERO] | None = None
 
         # Map between an offset in the stream and the entry object found at this
         # offset. Useful for assigning CIE to FDEs according to the CIE_pointer
         # header field which contains a stream offset.
-        self._entry_cache = {}
+        self._entry_cache: dict[int, CFIEntry] = {}
 
         # The .eh_frame and .debug_frame section use almost the same CFI
         # encoding, but there are tiny variations we need to handle during
         # parsing.
         self.for_eh_frame = for_eh_frame
 
-    def get_entries(self):
+    def get_entries(self) -> list[CFIEntry | ZERO]:
         """ Get a list of entries that constitute this CFI. The list consists
             of CIE or FDE objects, in the order of their appearance in the
             section.
@@ -96,7 +110,7 @@ class CallFrameInfo:
 
     #-------------------------
 
-    def _parse_entries(self):
+    def _parse_entries(self) -> list[CFIEntry | ZERO]:
         entries = []
         offset = 0
         while offset < self.size:
@@ -104,7 +118,7 @@ class CallFrameInfo:
             offset = self.stream.tell()
         return entries
 
-    def _parse_entry_at(self, offset):
+    def _parse_entry_at(self, offset: int) -> CFIEntry | ZERO:
         """ Parse an entry from self.stream starting with the given offset.
             Return the entry object. self.stream will point right after the
             entry (even if pulled from the cache).
@@ -156,14 +170,14 @@ class CallFrameInfo:
         # If the augmentation string is not empty, hope to find a length field
         # in order to skip the data specified augmentation.
         lsda_pointer: int | None = None
-        aug_dict = None
+        aug_dict: Augmentation | None = None
         if is_CIE:
             aug_bytes, aug_dict = self._parse_cie_augmentation(
                     header, entry_structs)
         else:
             cie = self._parse_cie_for_fde(offset, header, entry_structs)
             aug_bytes = self._read_augmentation_data(entry_structs)
-            lsda_encoding = cie.augmentation_dict.get('LSDA_encoding', DW_EH_encoding_flags['DW_EH_PE_omit'])
+            lsda_encoding = cast(int, cie.augmentation_dict.get('LSDA_encoding', DW_EH_encoding_flags['DW_EH_PE_omit']))
             if lsda_encoding != DW_EH_encoding_flags['DW_EH_PE_omit']:
                 # parse LSDA pointer
                 lsda_pointer = self._parse_lsda_pointer(entry_structs,
@@ -198,7 +212,12 @@ class CallFrameInfo:
         self._entry_cache[offset] = entry
         return entry
 
-    def _parse_instructions(self, structs, offset, end_offset):
+    def _parse_instructions(
+        self,
+        structs: DWARFStructs,
+        offset: int,
+        end_offset: int,
+    ) -> list[CallFrameInstruction]:
         """ Parse a list of CFI instructions from self.stream, starting with
             the offset and until (not including) end_offset.
             Return a list of CallFrameInstruction objects.
@@ -252,7 +271,12 @@ class CallFrameInfo:
             offset = self.stream.tell()
         return instructions
 
-    def _parse_cie_for_fde(self, fde_offset, fde_header, entry_structs):
+    def _parse_cie_for_fde(
+        self,
+        fde_offset: int,
+        fde_header: Container,
+        entry_structs: DWARFStructs,
+    ) -> CFIEntry | ZERO:
         """ Parse the CIE that corresponds to an FDE.
         """
         # Determine the offset of the CIE that corresponds to this FDE
@@ -270,7 +294,11 @@ class CallFrameInfo:
         with preserve_stream_pos(self.stream):
             return self._parse_entry_at(cie_offset)
 
-    def _parse_cie_augmentation(self, header, entry_structs):
+    def _parse_cie_augmentation(
+        self,
+        header: Container,
+        entry_structs: DWARFStructs,
+    ) -> tuple[bytes, Augmentation]:
         """ Parse CIE augmentation data from the annotation string in `header`.
 
         Return a tuple that contains 1) the augmentation data as a string
@@ -289,7 +317,7 @@ class CallFrameInfo:
         assert augmentation.startswith(b'z'), (
             'Unhandled augmentation string: {}'.format(repr(augmentation)))
 
-        available_fields = {
+        available_fields: dict[str, Construct | Literal[True]] = {
             'z': entry_structs.Dwarf_uleb128('length'),
             'L': entry_structs.Dwarf_uint8('LSDA_encoding'),
             'R': entry_structs.Dwarf_uint8('FDE_encoding'),
@@ -305,8 +333,8 @@ class CallFrameInfo:
 
         # Build the Struct we will be using to parse the augmentation data.
         # Stop as soon as we are not able to match the augmentation string.
-        fields = []
-        aug_dict = {}
+        fields: list[Construct] = []
+        aug_dict: Augmentation = {}
 
         for b in augmentation:
             try:
@@ -331,7 +359,7 @@ class CallFrameInfo:
         aug_bytes = self._read_augmentation_data(entry_structs)
         return (aug_bytes, aug_dict)
 
-    def _read_augmentation_data(self, entry_structs):
+    def _read_augmentation_data(self, entry_structs: DWARFStructs) -> bytes:
         """ Read augmentation data.
 
         This assumes that the augmentation string starts with 'z', i.e. that
@@ -346,7 +374,7 @@ class CallFrameInfo:
             self.stream)['length']
         return self.stream.read(augmentation_data_length)
 
-    def _parse_lsda_pointer(self, structs, stream_offset, encoding):
+    def _parse_lsda_pointer(self, structs: DWARFStructs, stream_offset: int, encoding: int) -> int:
         """ Parse bytes to get an LSDA pointer.
 
         The basic encoding (lower four bits of the encoding) describes how the values are encoded in a CIE or an FDE.
@@ -377,14 +405,14 @@ class CallFrameInfo:
 
         return ptr
 
-    def _parse_fde_header(self, entry_structs, offset):
+    def _parse_fde_header(self, entry_structs: DWARFStructs, offset: int) -> Container:
         """ Compute a struct to parse the header of the current FDE.
         """
         if not self.for_eh_frame:
             return struct_parse(entry_structs.Dwarf_FDE_header, self.stream,
                                 offset)
 
-        fields = [entry_structs.Dwarf_initial_length('length'),
+        fields: list[Construct] = [entry_structs.Dwarf_initial_length('length'),
                   entry_structs.Dwarf_offset('CIE_pointer')]
 
         # Parse the couple of header fields that are always here so we can
@@ -397,7 +425,7 @@ class CallFrameInfo:
         # Try to parse the initial location. We need the initial location in
         # order to create a meaningful FDE, so assume it's there. Omission does
         # not seem to happen in practice.
-        encoding = cie.augmentation_dict['FDE_encoding']
+        encoding = cast(int, cie.augmentation_dict['FDE_encoding'])
         assert encoding != DW_EH_encoding_flags['DW_EH_PE_omit']
         basic_encoding = encoding & 0x0f
         encoding_modifier = encoding & 0xf0
@@ -424,7 +452,9 @@ class CallFrameInfo:
         return result
 
     @staticmethod
-    def _eh_encoding_to_field(entry_structs):
+    def _eh_encoding_to_field(
+        entry_structs: DWARFStructs,
+    ) -> dict[int, Callable[[str], Construct]]:
         """
         Return a mapping from basic encodings (DW_EH_encoding_flags) the
         corresponding field constructors (for instance
@@ -453,7 +483,7 @@ class CallFrameInfo:
         }
 
 
-def instruction_name(opcode):
+def instruction_name(opcode: DW_CFA) -> str:
     """ Given an opcode, return the instruction name.
     """
     warn("Switch to DW_CFA.FQN", DeprecationWarning, stacklevel=2)
@@ -466,7 +496,7 @@ class CallFrameInstruction:
         arguments (including arguments embedded in the low bits of some
         instructions, when applicable), decoded from the stream.
     """
-    def __init__(self, opcode, args):
+    def __init__(self, opcode: DW_CFA, args: list[Any]) -> None:
         self.opcode = opcode
         self.args = args
 
@@ -486,18 +516,26 @@ class CFIEntry:
             CallFrameInfo._parse_cie_augmentation and
             http://www.airs.com/blog/archives/460.
     """
-    def __init__(self, header, structs, instructions, offset,
-            augmentation_dict=None, augmentation_bytes=b'', cie=None):
+    def __init__(
+        self,
+        header: Container,
+        structs: DWARFStructs,
+        instructions: list[CallFrameInstruction],
+        offset: int,
+        augmentation_dict: Augmentation | None = None,
+        augmentation_bytes: bytes | None = b'',
+        cie: CIE | None = None,
+    ) -> None:
         self.header = header
         self.structs = structs
         self.instructions = instructions
         self.offset = offset
         self.cie = cie
-        self._decoded_table = None
+        self._decoded_table: DecodedCallFrameTable | None = None
         self.augmentation_dict = augmentation_dict or {}
         self.augmentation_bytes = augmentation_bytes
 
-    def get_decoded(self):
+    def get_decoded(self) -> DecodedCallFrameTable:
         """ Decode the CFI contained in this entry and return a
             DecodedCallFrameTable object representing it. See the documentation
             of that class to understand how to interpret the decoded table.
@@ -511,15 +549,15 @@ class CFIEntry:
         """
         return self.header[name]
 
-    def _decode_CFI_table(self):
+    def _decode_CFI_table(self) -> DecodedCallFrameTable:
         """ Decode the instructions contained in the given CFI entry and return
             a DecodedCallFrameTable.
         """
-        last_line_in_CIE = None
+        last_line_in_CIE: Line | None = None
         if isinstance(self, CIE):
             # For a CIE, initialize cur_line to an "empty" line
             cie = self
-            cur_line = dict(pc=0, cfa=CFARule(reg=None, offset=0))
+            cur_line: Line = dict(pc=0, cfa=CFARule(reg=None, offset=0))
             reg_order = []
         else: # FDE
             # For a FDE, we need to decode the attached CIE first, because its
@@ -527,19 +565,19 @@ class CFIEntry:
             # line that serves as the base (first) line in the FDE's table.
             cie = self.cie
             cie_decoded_table = cie.get_decoded()
+            pc = self['initial_location']
             if cie_decoded_table.table:
                 last_line_in_CIE = copy.copy(cie_decoded_table.table[-1])
-                cur_line = copy.copy(last_line_in_CIE)
+                cur_line = dict(last_line_in_CIE, pc=pc)
             else:
-                cur_line = dict(cfa=CFARule(reg=None, offset=0))
-            cur_line['pc'] = self['initial_location']
+                cur_line = dict(cfa=CFARule(reg=None, offset=0), pc=pc)
             reg_order = copy.copy(cie_decoded_table.reg_order)
 
-        table = []
+        table: list[Line] = []
 
         # Keeps a stack for the use of DW_CFA.{remember|restore}_state
         # instructions.
-        line_stack = []
+        line_stack: list[Line] = []
 
         def _add_to_order(regnum: int) -> None:
             # DW_CFA.restore and others remove registers from cur_line,
@@ -624,7 +662,7 @@ class CFIEntry:
                 case DW_CFA.remember_state:
                     line_stack.append(copy.deepcopy(cur_line))
                 case DW_CFA.restore_state:
-                    pc: int = cur_line['pc']
+                    pc = cur_line['pc']
                     cur_line = line_stack.pop()
                     cur_line['pc'] = pc
                 case DW_CFA.nop | DW_CFA.AARCH64_negate_ra_state:
@@ -650,7 +688,16 @@ class CIE(CFIEntry):
 
 
 class FDE(CFIEntry):
-    def __init__(self, header, structs, instructions, offset, augmentation_bytes=None, cie=None, lsda_pointer=None):
+    def __init__(
+        self,
+        header: Container,
+        structs: DWARFStructs,
+        instructions: list[CallFrameInstruction],
+        offset: int,
+        augmentation_bytes: bytes | None = None,
+        cie: CIE | None = None,
+        lsda_pointer: int | None = None,
+    ) -> None:
         super().__init__(header, structs, instructions, offset, augmentation_bytes=augmentation_bytes, cie=cie)
         self.lsda_pointer = lsda_pointer
 
@@ -680,7 +727,7 @@ class RegisterRule:
     VAL_EXPRESSION = 'VAL_EXPRESSION'
     ARCHITECTURAL = 'ARCHITECTURAL'
 
-    def __init__(self, type, arg=None):
+    def __init__(self, type: str, arg: int | ListContainer | None = None) -> None:
         self.type = type
         self.arg = arg
 
@@ -692,7 +739,12 @@ class CFARule:
     """ A CFA rule is used to compute the CFA for each location. It either
         consists of a register+offset, or a DWARF expression.
     """
-    def __init__(self, reg=None, offset=None, expr=None):
+    def __init__(
+        self,
+        reg: int | None = None,
+        offset: int | None = None,
+        expr: ListContainer | None = None,
+    ) -> None:
         self.reg = reg
         self.offset = offset
         self.expr = expr
@@ -722,5 +774,5 @@ class CFARule:
 # their appearance.
 #
 class DecodedCallFrameTable(NamedTuple):
-    table: list[dict[str, Any]]
+    table: list[Line]
     reg_order: list[int]

--- a/elftools/dwarf/callframe.py
+++ b/elftools/dwarf/callframe.py
@@ -8,15 +8,35 @@
 #-------------------------------------------------------------------------------
 import copy
 import os
-from typing import Any, NamedTuple
+from collections.abc import Iterator
+from typing import Any, Literal, NamedTuple
 from warnings import warn
 
 from ..common.utils import (
     struct_parse, dwarf_assert, preserve_stream_pos)
 from ..construct import Struct, Switch
+from ..construct.lib.container import Container
 from .enums import DW_EH_encoding_flags
 from .structs import DWARFStructs
 from .constants import DW_CFA
+
+
+Line = dict[Any, Any]
+# TypedDict only supprts `str` as key, but "Line" mixes str|int.
+# class Line(TypedDict, total=False):
+#     pc: int
+#     cfa: CFARule
+#     "int": RegisterRule
+
+
+Augmentation = dict[str | bool, int | Container | Literal[True]]
+# TypedDict only supprts `str` as key, but "Stack Frame" is signaled as `True: True`.
+# class Augmentation(TypedDict, total=False):
+#     length: int
+#     LSDA_encoding: int
+#     FDE_encoding: int
+#     personality: Container
+#     "True": Literal[True]
 
 
 class CallFrameInfo:

--- a/elftools/dwarf/callframe.py
+++ b/elftools/dwarf/callframe.py
@@ -563,6 +563,7 @@ class CFIEntry:
             # For a FDE, we need to decode the attached CIE first, because its
             # decoded table is needed. Its "initial instructions" describe a
             # line that serves as the base (first) line in the FDE's table.
+            assert self.cie is not None
             cie = self.cie
             cie_decoded_table = cie.get_decoded()
             pc = self['initial_location']

--- a/elftools/dwarf/dwarf_expr.py
+++ b/elftools/dwarf/dwarf_expr.py
@@ -15,14 +15,14 @@ from ..common.utils import struct_parse
 from ..common.exceptions import DWARFError
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Iterable
+    from collections.abc import Callable, Iterable, Mapping
 
     from ..construct.core import Construct
     from .structs import DWARFStructs
 
 
 # DWARF expression opcodes. name -> opcode mapping
-DW_OP_name2opcode = dict(
+DW_OP_name2opcode: Mapping[str, int] = dict(
     DW_OP_addr=0x03,
     DW_OP_deref=0x06,
     DW_OP_const1u=0x08,
@@ -106,24 +106,13 @@ DW_OP_name2opcode = dict(
     DW_OP_GNU_const_index=0xfc,
     DW_OP_GNU_variable_value=0xfd,
     DW_OP_hi_user=0xff,
+    **{f"DW_OP_lit{val}": 0x30 + val for val in range(0, 32)},
+    **{f"DW_OP_reg{val}": 0x50 + val for val in range(0, 32)},
+    **{f"DW_OP_breg{val}": 0x70 + val for val in range(0, 32)},
 )
 
-def _generate_dynamic_values(map: dict[str, int], prefix: str, index_start: int, index_end: int, value_start: int) -> None:
-    """ Generate values in a map (dict) dynamically. Each key starts with
-        a (string) prefix, followed by an index in the inclusive range
-        [index_start, index_end]. The values start at value_start.
-    """
-    for index in range(index_start, index_end + 1):
-        name = '%s%s' % (prefix, index)
-        value = value_start + index - index_start
-        map[name] = value
-
-_generate_dynamic_values(DW_OP_name2opcode, 'DW_OP_lit', 0, 31, 0x30)
-_generate_dynamic_values(DW_OP_name2opcode, 'DW_OP_reg', 0, 31, 0x50)
-_generate_dynamic_values(DW_OP_name2opcode, 'DW_OP_breg', 0, 31, 0x70)
-
 # opcode -> name mapping
-DW_OP_opcode2name = {v: k for k, v in DW_OP_name2opcode.items()}
+DW_OP_opcode2name: Mapping[int, str] = {v: k for k, v in DW_OP_name2opcode.items()}
 
 
 # Each parsed DWARF expression is returned as this type with its numeric opcode,

--- a/elftools/dwarf/dwarf_expr.py
+++ b/elftools/dwarf/dwarf_expr.py
@@ -6,11 +6,19 @@
 # Eli Bendersky (eliben@gmail.com)
 # This code is in the public domain
 #-------------------------------------------------------------------------------
+from __future__ import annotations
+
 from io import BytesIO
-from typing import Any, NamedTuple
+from typing import IO, TYPE_CHECKING, Any, NamedTuple
 
 from ..common.utils import struct_parse
 from ..common.exceptions import DWARFError
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterable
+
+    from ..construct.core import Construct
+    from .structs import DWARFStructs
 
 
 # DWARF expression opcodes. name -> opcode mapping
@@ -134,16 +142,16 @@ class DWARFExprParser:
     parse_expr can be called repeatedly - it's stateless.
     """
 
-    def __init__(self, structs):
+    def __init__(self, structs: DWARFStructs) -> None:
         self._dispatch_table = _init_dispatch_table(structs)
 
-    def parse_expr(self, expr):
+    def parse_expr(self, expr: bytes | Iterable[int]) -> list[DWARFExprOp]:
         """ Parses expr (bytes or a list of integers) into a list of DWARFExprOp.
 
         The list can potentially be nested.
         """
         stream = BytesIO(bytes(expr))
-        parsed = []
+        parsed: list[DWARFExprOp] = []
 
         while True:
             # Get the next opcode from the stream. If nothing is left in the
@@ -166,51 +174,56 @@ class DWARFExprParser:
         return parsed
 
 
-def _init_dispatch_table(structs):
+def _init_dispatch_table(structs: DWARFStructs) -> dict[int, Callable[[IO[bytes]], list[Any]]]:
     """Creates a dispatch table for parsing args of an op.
 
     Returns a dict mapping opcode to a function. The function accepts a stream
     and return a list of parsed arguments for the opcode from the stream;
     the stream is advanced by the function as needed.
     """
-    table = {}
-    def add(opcode_name, func):
+    table: dict[int, Callable[[IO[bytes]], list[Any]]] = {}
+    def add(opcode_name: str, func: Callable[[IO[bytes]], list[Any]]) -> None:
         table[DW_OP_name2opcode[opcode_name]] = func
 
-    def parse_noargs():
+    def parse_noargs() -> Callable[[IO[bytes]], list[None]]:
         return lambda stream: []
 
-    def parse_op_addr():
+    def parse_op_addr() -> Callable[[IO[bytes]], list[int]]:
         return lambda stream: [struct_parse(structs.the_Dwarf_target_addr,
                                             stream)]
 
-    def parse_arg_struct(arg_struct):
+    def parse_arg_struct(arg_struct: Construct) -> Callable[[IO[bytes]], list[Any]]:
         return lambda stream: [struct_parse(arg_struct, stream)]
 
-    def parse_arg_struct2(arg1_struct, arg2_struct):
+    def parse_arg_struct2(
+        arg1_struct: Construct,
+        arg2_struct: Construct,
+    ) -> Callable[[IO[bytes]], list[Any]]:
         return lambda stream: [struct_parse(arg1_struct, stream),
                                struct_parse(arg2_struct, stream)]
 
     # ULEB128, then an expression of that length
-    def parse_nestedexpr():
-        def parse(stream):
+    def parse_nestedexpr() -> Callable[[IO[bytes]], list[list[DWARFExprOp]]]:
+
+        def parse(stream: IO[bytes]) -> list[list[DWARFExprOp]]:
             size: int = struct_parse(structs.the_Dwarf_uleb128, stream)
             nested_expr_blob = stream.read(size)
             return [DWARFExprParser(structs).parse_expr(nested_expr_blob)]
         return parse
 
     # ULEB128, then a blob of that size
-    def parse_blob():
+    def parse_blob() -> Callable[[IO[bytes]], list[list[int]]]:
         return lambda stream: [list(stream.read(struct_parse(structs.the_Dwarf_uleb128, stream)))]
 
     # ULEB128 with datatype DIE offset, then byte, then a blob of that size
-    def parse_typedblob():
+    def parse_typedblob() -> Callable[[IO[bytes]], list[int | list[int]]]:
         return lambda stream: [struct_parse(structs.the_Dwarf_uleb128, stream), list(stream.read(struct_parse(structs.the_Dwarf_uint8, stream)))]
 
     # https://yurydelendik.github.io/webassembly-dwarf/
     # Byte, then variant: 0, 1, 2 => uleb128, 3 => uint32
-    def parse_wasmloc():
-        def parse(stream):
+    def parse_wasmloc() -> Callable[[IO[bytes]], list[int]]:
+
+        def parse(stream: IO[bytes]) -> list[int]:
             op: int = struct_parse(structs.the_Dwarf_uint8, stream)
             if 0 <= op <= 2:
                 return [op, struct_parse(structs.the_Dwarf_uleb128, stream)]

--- a/elftools/dwarf/lineprogram.py
+++ b/elftools/dwarf/lineprogram.py
@@ -10,10 +10,14 @@ from __future__ import annotations
 
 import os
 import copy
-from typing import NamedTuple
+from typing import IO, TYPE_CHECKING, Any, NamedTuple
 
 from ..common.utils import struct_parse, dwarf_assert
 from .constants import DW_LNE, DW_LNS
+
+if TYPE_CHECKING:
+    from ..construct.lib.container import Container
+    from .structs import DWARFStructs
 
 
 # LineProgramEntry - an entry in the line program.
@@ -85,8 +89,14 @@ class LineProgram:
         sorted by increasing address, so it can be used to obtain the
         state information for each address.
     """
-    def __init__(self, header, stream, structs,
-                 program_start_offset, program_end_offset):
+    def __init__(
+        self,
+        header: Container,
+        stream: IO[bytes],
+        structs: DWARFStructs,
+        program_start_offset: int,
+            program_end_offset: int,
+    ) -> None:
         """
             header:
                 The header of this line program. Note: LineProgram may modify
@@ -110,9 +120,9 @@ class LineProgram:
         self.structs = structs
         self.program_start_offset = program_start_offset
         self.program_end_offset = program_end_offset
-        self._decoded_entries = None
+        self._decoded_entries: list[LineProgramEntry] | None = None
 
-    def get_entries(self):
+    def get_entries(self) -> list[LineProgramEntry]:
         """ Get the decoded entries for this line program. Return a list of
             LineProgramEntry objects.
             Note that this contains more information than absolutely required
@@ -127,12 +137,12 @@ class LineProgram:
 
     #------ PRIVATE ------#
 
-    def __getitem__(self, name):
+    def __getitem__(self, name: str) -> Any:
         """ Implement dict-like access to header entries
         """
         return self.header[name]
 
-    def _decode_line_program(self):
+    def _decode_line_program(self) -> list[LineProgramEntry]:
         entries = []
         state = LineState(self.header['default_is_stmt'])
 

--- a/elftools/dwarf/namelut.py
+++ b/elftools/dwarf/namelut.py
@@ -6,11 +6,21 @@
 # Vijay Ramasami (rvijayc@gmail.com)
 # This code is in the public domain
 #-------------------------------------------------------------------------------
+from __future__ import annotations
+
 from collections.abc import Mapping
-from typing import NamedTuple
+from typing import IO, TYPE_CHECKING, NamedTuple, TypeVar, overload
 
 from ..common.utils import struct_parse
 from ..construct import CString, Struct, If
+
+if TYPE_CHECKING:
+    from collections.abc import ItemsView, Iterator
+
+    from ..construct.lib.container import Container
+    from .structs import DWARFStructs
+
+    _T = TypeVar("_T")
 
 
 class NameLUTEntry(NamedTuple):
@@ -18,7 +28,7 @@ class NameLUTEntry(NamedTuple):
     die_ofs: int
 
 
-class NameLUT(Mapping):
+class NameLUT(Mapping[str, NameLUTEntry]):
     """
     A "Name LUT" holds any of the tables specified by .debug_pubtypes or
     .debug_pubnames sections. This is basically a dictionary where the key is
@@ -62,17 +72,17 @@ class NameLUT(Mapping):
 
     """
 
-    def __init__(self, stream, size, structs):
+    def __init__(self, stream: IO[bytes], size: int, structs: DWARFStructs) -> None:
 
         self._stream = stream
         self._size = size
         self._structs = structs
         # entries are lazily loaded on demand.
-        self._entries = None
+        self._entries: dict[str, NameLUTEntry] | None = None
         # CU headers (for readelf).
-        self._cu_headers = None
+        self._cu_headers: list[Container] | None = None
 
-    def get_entries(self):
+    def get_entries(self) -> dict[str, NameLUTEntry]:
         """
         Returns the parsed NameLUT entries. The returned object is a dictionary
         with the symbol name as the key and NameLUTEntry(cu_ofs, die_ofs) as
@@ -86,7 +96,7 @@ class NameLUT(Mapping):
             self._entries, self._cu_headers = self._get_entries()
         return self._entries
 
-    def set_entries(self, entries, cu_headers):
+    def set_entries(self, entries: dict[str, NameLUTEntry], cu_headers: list[Container]) -> None:
         """
         Set the NameLUT entries from an external source. The input is a
         dictionary with the symbol name as the key and NameLUTEntry(cu_ofs,
@@ -107,7 +117,7 @@ class NameLUT(Mapping):
             self._entries, self._cu_headers = self._get_entries()
         return len(self._entries)
 
-    def __getitem__(self, name):
+    def __getitem__(self, name: str) -> NameLUTEntry:
         """
         Returns a namedtuple - NameLUTEntry(cu_ofs, die_ofs) - that corresponds
         to the given symbol name.
@@ -116,7 +126,7 @@ class NameLUT(Mapping):
             self._entries, self._cu_headers = self._get_entries()
         return self._entries[name]
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[str]:
         """
         Returns an iterator to the NameLUT dictionary.
         """
@@ -124,7 +134,7 @@ class NameLUT(Mapping):
             self._entries, self._cu_headers = self._get_entries()
         return iter(self._entries)
 
-    def items(self):
+    def items(self) -> ItemsView[str, NameLUTEntry]:
         """
         Returns the NameLUT dictionary items.
         """
@@ -132,7 +142,11 @@ class NameLUT(Mapping):
             self._entries, self._cu_headers = self._get_entries()
         return self._entries.items()
 
-    def get(self, name, default=None):
+    @overload
+    def get(self, name: str) -> NameLUTEntry | None: ...
+    @overload
+    def get(self, name: str, default: NameLUTEntry | _T = ...) -> NameLUTEntry | _T: ...
+    def get(self, name: str, default: NameLUTEntry | _T | None = None) -> NameLUTEntry | _T | None:
         """
         Returns NameLUTEntry(cu_ofs, die_ofs) for the provided symbol name or
         None if the symbol does not exist in the corresponding section.
@@ -141,7 +155,7 @@ class NameLUT(Mapping):
             self._entries, self._cu_headers = self._get_entries()
         return self._entries.get(name, default)
 
-    def get_cu_headers(self):
+    def get_cu_headers(self) -> list[Container]:
         """
         Returns all CU headers. Mainly required for readelf.
         """
@@ -150,15 +164,15 @@ class NameLUT(Mapping):
 
         return self._cu_headers
 
-    def _get_entries(self):
+    def _get_entries(self) -> tuple[dict[str, NameLUTEntry], list[Container]]:
         """
         Parse the (name, cu_ofs, die_ofs) information from this section and
         store as a dictionary.
         """
 
         self._stream.seek(0)
-        entries = {}
-        cu_headers = []
+        entries: dict[str, NameLUTEntry] = {}
+        cu_headers: list[Container] = []
         offset = 0
         # According to 6.1.1. of DWARFv4, each set of names is terminated by
         # an offset field containing zero (and no following string). Because

--- a/elftools/dwarf/structs.py
+++ b/elftools/dwarf/structs.py
@@ -202,6 +202,7 @@ class DWARFStructs:
         self._create_gnu_debugaltlink()
 
     def _create_initial_length(self) -> None:
+
         def _InitialLength(name: str) -> _InitialLengthAdapter:
             # Adapts a Struct that parses forward a full initial length field.
             # Only if the first word is the continuation value, the second
@@ -212,6 +213,7 @@ class DWARFStructs:
                     If(lambda ctx: ctx.first == 0xFFFFFFFF,
                         self.Dwarf_uint64('second'),
                         elsevalue=None)))
+
         self.Dwarf_initial_length = _InitialLength
 
     def _create_leb128(self) -> None:


### PR DESCRIPTION
Next batch from #611 related to `elftools.dwarf.{abbrevtable,aranges,callframe,dwarf_expr,lineprogram,namelut,structs}`. Most is really straight forward except:
- `callframe` is using a mixed `dict[str | int, int | CFARule | RegisterRule]` for `Line`. I define a `Protocol` to get the correct type for `"pc", "cfa", int` as `TypedDict` does not work for `int`, but that requires some ugly `cast()s` from/to `Line`. An alternative would be to use just `dict[Any, Any]`.
- For `Augmentation` see https://github.com/eliben/pyelftools/pull/611#issuecomment-4363868618; Because of that some `cast()`s a are needed.
- `Line` and `Augmentation` must **not** be declared under a `if TYPE_CHECKING` as those types are used to type local variables: `from __future__ import annotations` does not work there and the types must be referencable at runtime.
- In `dwarf_expr` I changed how `DW_OP_name2opcode` gets build to make it "`const`".