### PR TITLE
typing: elftools.elf

### DIFF
--- a/elftools/dwarf/callframe.py
+++ b/elftools/dwarf/callframe.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 
 import copy
 import os
-from collections.abc import Iterator
 from functools import cached_property
 from typing import IO, TYPE_CHECKING, Any, Literal, NamedTuple, cast
 from warnings import warn

--- a/elftools/ehabi/ehabiinfo.py
+++ b/elftools/ehabi/ehabiinfo.py
@@ -142,13 +142,15 @@ class EHABIEntry:
 
     """
 
-    def __init__(self,
-                 function_offset: int | None,
-                 personality: int | None,
-                 bytecode_array: list[int] | None,
-                 eh_table_offset: int | None = None,
-                 unwindable: bool = True,
-                 corrupt: bool = False) -> None:
+    def __init__(
+        self,
+        function_offset: int | None,
+        personality: int | None,
+        bytecode_array: list[int] | None,
+        eh_table_offset: int | None = None,
+        unwindable: bool = True,
+        corrupt: bool = False,
+    ) -> None:
         self.function_offset = function_offset
         self.personality = personality
         self.bytecode_array = bytecode_array

--- a/elftools/elf/descriptions.py
+++ b/elftools/elf/descriptions.py
@@ -6,6 +6,10 @@
 # Eli Bendersky (eliben@gmail.com)
 # This code is in the public domain
 #-------------------------------------------------------------------------------
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Final
+
 from .enums import (
     ENUM_D_TAG, ENUM_E_VERSION, ENUM_P_TYPE_BASE, ENUM_SH_TYPE_BASE,
     ENUM_RELOC_TYPE_i386, ENUM_RELOC_TYPE_x64,
@@ -15,6 +19,12 @@ from .enums import (
     ENUM_DT_FLAGS_1, ENUM_RELOC_TYPE_PPC)
 from .constants import (
     P_FLAGS, RH_FLAGS, SH_FLAGS, SUNW_SYMINFO_FLAGS, VER_FLAGS)
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from ..construct.lib.container import Container
+    from .elffile import ELFFile
 
 
 def describe_ei_class(x: str) -> str:
@@ -36,7 +46,7 @@ def describe_ei_osabi(x: str) -> str:
     return _DESCR_EI_OSABI.get(x, _unknown)
 
 
-def describe_e_type(x, elffile=None):
+def describe_e_type(x: str, elffile: ELFFile | None = None) -> str:
     if elffile is not None and x == 'ET_DYN':
         # Detect whether this is a normal SO or a PIE executable
         dynamic = elffile.get_section_by_name('.dynamic')
@@ -56,9 +66,9 @@ def describe_e_version_numeric(x: str) -> str:
 
 
 def describe_p_type(x: int | str) -> str:
-    if x in _DESCR_P_TYPE:
+    if isinstance(x, str) and x in _DESCR_P_TYPE:
         return _DESCR_P_TYPE[x]
-    elif x >= ENUM_P_TYPE_BASE['PT_LOOS'] and x <= ENUM_P_TYPE_BASE['PT_HIOS']:
+    elif isinstance(x, int) and ENUM_P_TYPE_BASE['PT_LOOS'] <= x <= ENUM_P_TYPE_BASE['PT_HIOS']:
         return 'LOOS+%lx' % (x - ENUM_P_TYPE_BASE['PT_LOOS'])
     else:
         return _unknown
@@ -88,10 +98,9 @@ def describe_rh_flags(x: int) -> str:
 
 
 def describe_sh_type(x: int | str) -> str:
-    if x in _DESCR_SH_TYPE:
+    if isinstance(x, str) and x in _DESCR_SH_TYPE:
         return _DESCR_SH_TYPE[x]
-    elif (x >= ENUM_SH_TYPE_BASE['SHT_LOOS'] and
-          x < ENUM_SH_TYPE_BASE['SHT_GNU_versym']):
+    elif isinstance(x, int) and ENUM_SH_TYPE_BASE['SHT_LOOS'] <= x < ENUM_SH_TYPE_BASE['SHT_GNU_versym']:
         return 'loos+0x%lx' % (x - ENUM_SH_TYPE_BASE['SHT_LOOS'])
     else:
         return _unknown
@@ -128,7 +137,7 @@ def describe_symbol_local(x: int) -> str:
     return '[<localentry>: ' + str(1 << x) + ']'
 
 
-def describe_symbol_other(x):
+def describe_symbol_other(x: Container) -> str:
     vis = describe_symbol_visibility(x['visibility'])
     if 1 < x['local'] < 7:
         return vis + ' ' + describe_symbol_local(x['local'])
@@ -136,10 +145,10 @@ def describe_symbol_other(x):
 
 
 def describe_symbol_shndx(x: int | str) -> str:
-    return _DESCR_ST_SHNDX.get(x, '%3s' % x)
+    return _DESCR_ST_SHNDX.get(x, f'{x:3}')  # type: ignore[arg-type] # ty: ignore[no-matching-overload]
 
 
-def describe_reloc_type(x, elffile):
+def describe_reloc_type(x: int, elffile: ELFFile) -> str:
     arch = elffile.get_machine_arch()
     if arch == 'x86':
         return _DESCR_RELOC_TYPE_i386.get(x, _unknown)
@@ -202,7 +211,7 @@ def describe_ver_flags(x: int) -> str:
         VER_FLAGS.VER_FLG_INFO) if x & flag)
 
 
-def describe_note(x, machine):
+def describe_note(x: Container, machine: str) -> str:
     n_desc = x['n_desc']
     desc = ''
     if x['n_type'] == 'NT_GNU_ABI_TAG':
@@ -236,7 +245,7 @@ def describe_note(x, machine):
     return '%s (%s)%s' % (note_type, note_type_desc, desc)
 
 
-def describe_attr_tag_arm(tag, val, extra):
+def describe_attr_tag_arm(tag: str, val: Any, extra: str | None) -> str:
     s = _DESCR_ATTR_TAG_ARM.get(tag, '"%s"' % tag)
     idx = ENUM_ATTR_TAG_ARM[tag] - 1
     d_entry = _DESCR_ATTR_VAL_ARM[idx]
@@ -248,7 +257,7 @@ def describe_attr_tag_arm(tag, val, extra):
         elif tag == 'TAG_ALSO_COMPATIBLE_WITH':
             if val.tag == 'TAG_CPU_ARCH':
                 d_entry = _DESCR_ATTR_VAL_ARM[5]  # TAG_CPU_ARCH
-                return s + d_entry.get(val.value, '??? (%d)' % val.value)
+                return s + (d_entry.get(val.value) or f'??? ({val.value})')
 
             else:
                 return s + '??? (%d)' % val.tag
@@ -262,7 +271,7 @@ def describe_attr_tag_arm(tag, val, extra):
     else:
         return s + d_entry[val]
 
-def describe_attr_tag_riscv(tag, val, extra):
+def describe_attr_tag_riscv(tag: str, val: Any, extra: str) -> str:
     idx = ENUM_ATTR_TAG_RISCV[tag] - 1
     d_entry = _DESCR_ATTR_VAL_RISCV[idx]
 
@@ -274,19 +283,25 @@ def describe_attr_tag_riscv(tag, val, extra):
     else:
         return _DESCR_ATTR_TAG_RISCV[tag] + d_entry[val]
 
-def describe_note_gnu_property_bitmap_and(values, prefix, value):
+def describe_note_gnu_property_bitmap_and(
+    values: Iterable[tuple[int, str]],
+    prefix: str,
+    value: int,
+) -> str:
     descs = []
     for mask, desc in values:
         if value & mask:
             descs.append(desc)
     return '%s: %s' % (prefix, ', '.join(descs))
 
-def describe_note_gnu_properties(properties, machine):
+def describe_note_gnu_properties(properties: list[Container], machine: str) -> str:
     descriptions = []
     for prop in properties:
-        t, d, sz = prop.pr_type, prop.pr_data, prop.pr_datasz
+        t: str | int = prop.pr_type
+        d = prop.pr_data
+        sz: int = prop.pr_datasz
         if t == 'GNU_PROPERTY_STACK_SIZE':
-            if type(d) is int:
+            if isinstance(d, int):
                 prop_desc = 'stack size: 0x%x' % d
             else:
                 prop_desc = 'stack size: <corrupt length: 0x%x>' % sz
@@ -773,7 +788,7 @@ _DESCR_ATTR_TAG_ARM = dict(
     TAG_MPEXTENSION_USE_OLD='Tag_MPextension_use_old: ',
 )
 
-_DESCR_ATTR_VAL_ARM = [
+_DESCR_ATTR_VAL_ARM: Final = (
     None, #1
     None, #2
     None, #3
@@ -1021,7 +1036,7 @@ _DESCR_ATTR_VAL_ARM = [
         0: 'Not Allowed',
         1: 'Allowed',
     },
-]
+)
 
 _DESCR_ATTR_TAG_RISCV = dict(
     TAG_FILE='File Attributes',
@@ -1037,7 +1052,7 @@ _DESCR_ATTR_TAG_RISCV = dict(
     TAG_X3_REG_USAGE='Tag_RISCV_x3_reg_usage: ',
 )
 
-_DESCR_ATTR_VAL_RISCV = [
+_DESCR_ATTR_VAL_RISCV: Final = (
     None, #1
     None, #2
     None, #3
@@ -1065,4 +1080,4 @@ _DESCR_ATTR_VAL_RISCV = [
         2: 'This object uses x3 as the shadow stack pointer.',
         3: 'This object uses X3 as a temporary register.',
     },
-]
+)

--- a/elftools/elf/dynamic.py
+++ b/elftools/elf/dynamic.py
@@ -6,24 +6,33 @@
 # Mike Frysinger (vapier@gentoo.org)
 # This code is in the public domain
 #-------------------------------------------------------------------------------
-import itertools
-from functools import cached_property
+from __future__ import annotations
 
+import itertools
 from collections import defaultdict
-from .hash import ELFHashTable, GNUHashTable
-from .sections import Section, Symbol
-from .enums import ENUM_D_TAG
-from .segments import Segment
-from .relocation import RelocationTable, RelrRelocationTable
+from functools import cached_property
+from typing import IO, TYPE_CHECKING, Any
+
 from ..common.exceptions import ELFError
 from ..common.utils import elf_assert, struct_parse, parse_cstring_from_stream
+from .enums import ENUM_D_TAG
+from .hash import ELFHashTable, GNUHashTable
+from .relocation import RelocationTable, RelrRelocationTable
+from .sections import Section, Symbol
+from .segments import Segment
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from ..construct.lib.container import Container
+    from .elffile import ELFFile
 
 
 class _DynamicStringTable:
     """ Bare string table based on values found via ELF dynamic tags and
         loadable segments only.  Good enough for get_string() only.
     """
-    def __init__(self, stream, table_offset):
+    def __init__(self, stream: IO[bytes], table_offset: int) -> None:
         self._stream = stream
         self._table_offset = table_offset
 
@@ -47,7 +56,11 @@ class DynamicTag:
         ['DT_NEEDED', 'DT_RPATH', 'DT_RUNPATH', 'DT_SONAME',
          'DT_SUNW_FILTER'])
 
-    def __init__(self, entry, stringtable):
+    def __init__(
+        self,
+        entry: Container,
+        stringtable,
+    ) -> None:
         if stringtable is None:
             raise ELFError('Creating DynamicTag without string table')
         self.entry = entry
@@ -55,7 +68,7 @@ class DynamicTag:
             setattr(self, entry.d_tag[3:].lower(),
                     stringtable.get_string(self.entry.d_val))
 
-    def __getitem__(self, name):
+    def __getitem__(self, name: str) -> Any:
         """ Implement dict-like access to entries
         """
         return self.entry[name]
@@ -74,7 +87,14 @@ class DynamicTag:
 class Dynamic:
     """ Shared functionality between dynamic sections and segments.
     """
-    def __init__(self, stream, elffile, stringtable, position, empty):
+    def __init__(
+        self,
+        stream: IO[bytes],
+        elffile: ELFFile,
+        stringtable,
+        position: int,
+        empty: bool,
+    ) -> None:
         """
         stream:
             The file-like object from which to load data
@@ -142,7 +162,7 @@ class Dynamic:
         self._stringtable = self.elffile.get_section_by_name('.dynstr')
         return self._stringtable
 
-    def _iter_tags(self, type=None):
+    def _iter_tags(self, type: str | None = None) -> Iterator[Container]:
         """ Yield all raw tags (limit to |type| if specified)
         """
         if self._empty:
@@ -154,13 +174,13 @@ class Dynamic:
             if tag['d_tag'] == 'DT_NULL':
                 break
 
-    def iter_tags(self, type=None):
+    def iter_tags(self, type: str | None = None) -> Iterator[DynamicTag]:
         """ Yield all tags (limit to |type| if specified)
         """
         for tag in self._iter_tags(type=type):
             yield DynamicTag(tag, self._get_stringtable())
 
-    def _get_tag(self, n):
+    def _get_tag(self, n: int) -> Container:
         """ Get the raw tag at index #n from the file
         """
         if self._num_tags != -1 and n >= self._num_tags:
@@ -171,7 +191,7 @@ class Dynamic:
             self._stream,
             stream_pos=offset)
 
-    def get_tag(self, n):
+    def get_tag(self, n: int) -> DynamicTag:
         """ Get the tag at index #n from the file (DynamicTag object)
         """
         return DynamicTag(self._get_tag(n), self._get_stringtable())
@@ -201,7 +221,7 @@ class Dynamic:
 
         if list(self.iter_tags('DT_REL')):
             result['REL'] = RelocationTable(self.elffile,
-                self.get_table_offset('DT_REL')[1],
+                self.get_table_offset('DT_REL')[1],  # type: ignore[arg-type] # ty: ignore[invalid-argument-type]
                 next(self.iter_tags('DT_RELSZ'))['d_val'], False)
 
             relentsz = next(self.iter_tags('DT_RELENT'))['d_val']
@@ -210,7 +230,7 @@ class Dynamic:
 
         if list(self.iter_tags('DT_RELA')):
             result['RELA'] = RelocationTable(self.elffile,
-                self.get_table_offset('DT_RELA')[1],
+                self.get_table_offset('DT_RELA')[1],  # type: ignore[arg-type] # ty: ignore[invalid-argument-type]
                 next(self.iter_tags('DT_RELASZ'))['d_val'], True)
 
             relentsz = next(self.iter_tags('DT_RELAENT'))['d_val']
@@ -219,13 +239,13 @@ class Dynamic:
 
         if list(self.iter_tags('DT_RELR')):
             result['RELR'] = RelrRelocationTable(self.elffile,
-                self.get_table_offset('DT_RELR')[1],
+                self.get_table_offset('DT_RELR')[1],  # type: ignore[arg-type] # ty: ignore[invalid-argument-type]
                 next(self.iter_tags('DT_RELRSZ'))['d_val'],
                 next(self.iter_tags('DT_RELRENT'))['d_val'])
 
         if list(self.iter_tags('DT_JMPREL')):
             result['JMPREL'] = RelocationTable(self.elffile,
-                self.get_table_offset('DT_JMPREL')[1],
+                self.get_table_offset('DT_JMPREL')[1],  # type: ignore[arg-type] # ty: ignore[invalid-argument-type]
                 next(self.iter_tags('DT_PLTRELSZ'))['d_val'],
                 next(self.iter_tags('DT_PLTREL'))['d_val'] == ENUM_D_TAG['DT_RELA'])
 
@@ -235,7 +255,7 @@ class Dynamic:
 class DynamicSection(Section, Dynamic):
     """ ELF dynamic table section.  Knows how to process the list of tags.
     """
-    def __init__(self, header, name, elffile):
+    def __init__(self, header: Container, name: str, elffile: ELFFile) -> None:
         Section.__init__(self, header, name, elffile)
         stringtable = elffile.get_section(header['sh_link'], ('SHT_STRTAB', 'SHT_NOBITS', 'SHT_NULL'))
         Dynamic.__init__(self, self.stream, self.elffile, stringtable,
@@ -245,7 +265,7 @@ class DynamicSection(Section, Dynamic):
 class DynamicSegment(Segment, Dynamic):
     """ ELF dynamic table segment.  Knows how to process the list of tags.
     """
-    def __init__(self, header, stream, elffile):
+    def __init__(self, header: Container, stream: IO[bytes], elffile: ELFFile) -> None:
         # The string table section to be used to resolve string names in
         # the dynamic tag array is the one pointed at by the sh_link field
         # of the dynamic section header.
@@ -318,7 +338,7 @@ class DynamicSegment(Segment, Dynamic):
 
         raise ELFError('Cannot determine the end of DT_SYMTAB.')
 
-    def get_symbol(self, index):
+    def get_symbol(self, index: int) -> Symbol:
         """ Get the symbol at index #index from the table (Symbol object)
         """
         tab_ptr, tab_offset = self.get_table_offset('DT_SYMTAB')
@@ -335,7 +355,7 @@ class DynamicSegment(Segment, Dynamic):
 
         return Symbol(symbol, symbol_name)
 
-    def get_symbol_by_name(self, name):
+    def get_symbol_by_name(self, name: str) -> list[Symbol] | None:
         """ Get a symbol(s) by name. Return None if no symbol by the given name
             exists.
         """
@@ -349,7 +369,7 @@ class DynamicSegment(Segment, Dynamic):
             smap[sym.name].append(i)
         return smap
 
-    def iter_symbols(self):
+    def iter_symbols(self) -> Iterator[Symbol]:
         """ Yield all symbols in this dynamic segment. The symbols are usually
             the same as returned by SymbolTableSection.iter_symbols. However,
             in stripped binaries, SymbolTableSection might have been removed.

--- a/elftools/elf/elffile.py
+++ b/elftools/elf/elffile.py
@@ -6,12 +6,15 @@
 # Eli Bendersky (eliben@gmail.com)
 # This code is in the public domain
 #-------------------------------------------------------------------------------
+from __future__ import annotations
+
 import io
 import os
 import struct
 import zlib
 from functools import cached_property
 from io import BytesIO
+from typing import IO, TYPE_CHECKING, Any
 
 from ..common.exceptions import ELFError, ELFParseError
 from ..common.utils import struct_parse, elf_assert
@@ -32,6 +35,16 @@ from ..ehabi.ehabiinfo import EHABIInfo
 from .hash import ELFHashSection, GNUHashSection
 from .constants import SHN_INDICES
 from ..dwarf.dwarf_util import _file_crc32
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterator
+    from collections.abc import Container as TContainer
+    from types import TracebackType
+
+    from typing_extensions import Self  # 3.11+
+
+    from ..construct.lib.container import Container
+
 
 class ELFFile:
     """ Creation: the constructor accepts a stream (file-like object) with the
@@ -66,7 +79,11 @@ class ELFFile:
             e_ident_raw:
                 the raw e_ident field of the header
     """
-    def __init__(self, stream, stream_loader=None):
+    def __init__(
+        self,
+        stream: IO[bytes],
+        stream_loader: Callable[[str], IO[bytes]] | None = None,
+    ) -> None:
         self.stream = stream
         self.stream.seek(0, io.SEEK_END)
         self.stream_len = self.stream.tell()
@@ -88,7 +105,7 @@ class ELFFile:
         self.stream_loader = stream_loader
 
     @classmethod
-    def load_from_path(cls, path):
+    def load_from_path(cls, path: str | bytes) -> ELFFile:
         """Takes a local filesystem path accepted by open(), and returns an
         ELFFile from it, setting up a stream_loader that resolves linked files
         using normalized string paths relative to the original file.
@@ -97,7 +114,7 @@ class ELFFile:
         return ELFFile(stream, ELFFile.make_relative_loader(os.fsdecode(path)))
 
     @staticmethod
-    def make_relative_loader(base_path):
+    def make_relative_loader(base_path) -> Callable[[str], IO[bytes]]:
         """ Return a function that takes a potentially relative path,
             resolves it against base_path (str), and opens a file at that.
 
@@ -108,7 +125,8 @@ class ELFFile:
         if not isinstance(base_path, str):
             raise TypeError('base_path must be str')
         base_directory = os.path.realpath(os.path.dirname(base_path))
-        def loader(rel_path):
+
+        def loader(rel_path) -> IO[bytes]:
             if not isinstance(rel_path, str):
                 raise TypeError('rel_path must be str')
 
@@ -143,7 +161,7 @@ class ELFFile:
             return section_header['sh_size']
         return self['e_shnum']
 
-    def get_section(self, n, type=None):
+    def get_section(self, n: int, type: TContainer[str] | None = None) -> Section:
         """ Get the section at index #n from the file (Section object or a
             subclass)
         """
@@ -152,7 +170,7 @@ class ELFFile:
             raise ELFError("Unexpected section type %s, expected %s" % (section_header['sh_type'], type))
         return self._make_section(section_header)
 
-    def _get_linked_symtab_section(self, n):
+    def _get_linked_symtab_section(self, n: int) -> SymbolTableSection:
         """ Get the section at index #n from the file, throws
             if it's not a SYMTAB/DYNTAB.
             Used for resolving section links with target type validation.
@@ -164,7 +182,7 @@ class ELFFile:
         assert isinstance(section, SymbolTableSection)
         return section
 
-    def _get_linked_strtab_section(self, n):
+    def _get_linked_strtab_section(self, n: int) -> StringTableSection:
         """ Get the section at index #n from the file, throws
             if it's not a STRTAB.
             Used for resolving section links with target type validation.
@@ -176,7 +194,7 @@ class ELFFile:
         assert isinstance(section, StringTableSection)
         return section
 
-    def get_section_by_name(self, name):
+    def get_section_by_name(self, name: str) -> Section | None:
         """ Get a section from the file, by name. Return None if no such
             section exists.
         """
@@ -194,7 +212,7 @@ class ELFFile:
         """
         return section_name in self._section_name_map
 
-    def iter_sections(self, type=None):
+    def iter_sections(self, type: str | None = None) -> Iterator[Section]:
         """ Yield all the sections in the file. If the optional |type|
             parameter is passed, this method will only yield sections of the
             given type. The parameter value must be a string containing the
@@ -221,13 +239,13 @@ class ELFFile:
         else:
             return self.get_section(0)['sh_info']
 
-    def get_segment(self, n):
+    def get_segment(self, n: int) -> Segment:
         """ Get the segment at index #n from the file (Segment object)
         """
         segment_header = self._get_segment_header(n)
         return self._make_segment(segment_header)
 
-    def iter_segments(self, type=None):
+    def iter_segments(self, type: str | None = None) -> Iterator[Segment]:
         """ Yield all the segments in the file. If the optional |type|
             parameter is passed, this method will only yield segments of the
             given type. The parameter value must be a string containing the
@@ -239,7 +257,7 @@ class ELFFile:
             if type is None or segment['p_type'] == type:
                 yield segment
 
-    def address_offsets(self, start, size=1):
+    def address_offsets(self, start: int, size: int = 1) -> Iterator[int]:
         """ Yield a file offset for each ELF segment containing a memory region.
 
             A memory region is defined by the range [start...start+size). The
@@ -265,7 +283,11 @@ class ELFFile:
             self.has_section('.zdebug_info') or
             (not strict and self.has_section('.eh_frame')))
 
-    def get_dwarf_info(self, relocate_dwarf_sections=True, follow_links=True):
+    def get_dwarf_info(
+        self,
+        relocate_dwarf_sections: bool = True,
+        follow_links: bool = True,
+    ) -> DWARFInfo:
         """ Return a DWARFInfo object representing the debugging information in
             this file.
 
@@ -320,7 +342,7 @@ class ELFFile:
          debug_sup_name, gnu_debugaltlink_name, debug_types_sec_name,
          eh_frame_sec_name) = section_names
 
-        debug_sections = {}
+        debug_sections: dict[str, DebugSectionDescriptor | None] = {}
         for secname in section_names:
             section = self.get_section_by_name(secname)
             if section is None:
@@ -372,13 +394,13 @@ class ELFFile:
         """
         return self.has_section('.gnu_debuglink')
 
-    def get_dwarf_link(self):
+    def get_dwarf_link(self) -> Container | None:
         """ Read the .gnu_debuglink section, return an object with filename (as bytes) and checksum (as number) in it.
         """
         section = self.get_section_by_name('.gnu_debuglink')
         return struct_parse(self.structs.Gnu_debuglink, section.stream, section.header.sh_offset) if section else None
 
-    def get_supplementary_dwarfinfo(self, dwarfinfo):
+    def get_supplementary_dwarfinfo(self, dwarfinfo: DWARFInfo) -> DWARFInfo | None:
         """
         Read supplementary dwarfinfo, from either the standared .debug_sup
         section, the GNU proprietary .gnu_debugaltlink, or .gnu_debuglink.
@@ -398,7 +420,7 @@ class ELFFile:
         """
         return any(self.iter_sections(type='SHT_ARM_EXIDX'))
 
-    def get_ehabi_infos(self):
+    def get_ehabi_infos(self) -> list[EHABIInfo] | None:
         """ Generally, shared library and executable contain 1 .ARM.exidx section.
             Object file contains many .ARM.exidx sections.
             So we must traverse every section and filter sections whose type is SHT_ARM_EXIDX.
@@ -623,7 +645,7 @@ class ELFFile:
 
     #-------------------------------- PRIVATE --------------------------------#
 
-    def __getitem__(self, name):
+    def __getitem__(self, name: str) -> Any:
         """ Implement dict-like access to header entries
         """
         return self.header[name]
@@ -670,7 +692,7 @@ class ELFFile:
             raise ELFError('Too small e_phentsize: %s' % phentsize)
         return self['e_phoff'] + n * phentsize
 
-    def _make_segment(self, segment_header):
+    def _make_segment(self, segment_header: Container) -> Segment:
         """ Create a Segment object of the appropriate type
         """
         segtype = segment_header['p_type']
@@ -683,7 +705,7 @@ class ELFFile:
         else:
             return Segment(segment_header, self.stream)
 
-    def _get_section_header(self, n):
+    def _get_section_header(self, n: int) -> Container | None:
         """ Find the header of section #n, parse it and return the struct
         """
 
@@ -696,14 +718,14 @@ class ELFFile:
             self.stream,
             stream_pos=stream_pos)
 
-    def _get_section_name(self, section_header):
+    def _get_section_name(self, section_header: Container) -> str:
         """ Given a section header, find this section's name in the file's
             string table
         """
         name_offset = section_header['sh_name']
         return self._section_header_stringtable.get_string(name_offset)
 
-    def _make_section(self, section_header):
+    def _make_section(self, section_header: Container) -> Section:
         """ Create a section object of the appropriate type
         """
         name = self._get_section_name(section_header)
@@ -753,7 +775,11 @@ class ELFFile:
             for i, sec in enumerate(self.iter_sections())
         }
 
-    def _make_symbol_table_section(self, section_header, name):
+    def _make_symbol_table_section(
+        self,
+        section_header: Container,
+        name: str,
+    ) -> SymbolTableSection:
         """ Create a SymbolTableSection
         """
         linked_strtab_index = section_header['sh_link']
@@ -763,7 +789,11 @@ class ELFFile:
             elffile=self,
             stringtable=strtab_section)
 
-    def _make_symbol_table_index_section(self, section_header, name):
+    def _make_symbol_table_index_section(
+        self,
+        section_header: Container,
+        name: str,
+    ) -> SymbolTableIndexSection:
         """ Create a SymbolTableIndexSection object
         """
         linked_symtab_index = section_header['sh_link']
@@ -771,7 +801,11 @@ class ELFFile:
             section_header, name, elffile=self,
             symboltable=linked_symtab_index)
 
-    def _make_sunwsyminfo_table_section(self, section_header, name):
+    def _make_sunwsyminfo_table_section(
+        self,
+        section_header: Container,
+        name: str,
+    ) -> SUNWSyminfoTableSection:
         """ Create a SUNWSyminfoTableSection
         """
         linked_strtab_index = section_header['sh_link']
@@ -781,7 +815,7 @@ class ELFFile:
             elffile=self,
             symboltable=strtab_section)
 
-    def _make_gnu_verneed_section(self, section_header, name):
+    def _make_gnu_verneed_section(self, section_header: Container, name: str) -> GNUVerNeedSection:
         """ Create a GNUVerNeedSection
         """
         linked_strtab_index = section_header['sh_link']
@@ -791,7 +825,7 @@ class ELFFile:
             elffile=self,
             stringtable=strtab_section)
 
-    def _make_gnu_verdef_section(self, section_header, name):
+    def _make_gnu_verdef_section(self, section_header: Container, name: str) -> GNUVerDefSection:
         """ Create a GNUVerDefSection
         """
         linked_strtab_index = section_header['sh_link']
@@ -801,7 +835,7 @@ class ELFFile:
             elffile=self,
             stringtable=strtab_section)
 
-    def _make_gnu_versym_section(self, section_header, name):
+    def _make_gnu_versym_section(self, section_header: Container, name: str) -> GNUVerSymSection:
         """ Create a GNUVerSymSection
         """
         linked_symtab_index = section_header['sh_link']
@@ -811,21 +845,21 @@ class ELFFile:
             elffile=self,
             symboltable=symtab_section)
 
-    def _make_elf_hash_section(self, section_header, name):
+    def _make_elf_hash_section(self, section_header: Container, name: str) -> ELFHashSection:
         linked_symtab_index = section_header['sh_link']
         symtab_section = self._get_linked_symtab_section(linked_symtab_index)
         return ELFHashSection(
             section_header, name, self, symtab_section
         )
 
-    def _make_gnu_hash_section(self, section_header, name):
+    def _make_gnu_hash_section(self, section_header: Container, name: str) -> GNUHashSection:
         linked_symtab_index = section_header['sh_link']
         symtab_section = self._get_linked_symtab_section(linked_symtab_index)
         return GNUHashSection(
             section_header, name, self, symtab_section
         )
 
-    def _get_segment_header(self, n):
+    def _get_segment_header(self, n: int) -> Container:  # Elf_Phdr:
         """ Find the header of segment #n, parse it and return the struct
         """
         return struct_parse(
@@ -849,13 +883,17 @@ class ELFFile:
                 name='',
                 elffile=self)
 
-    def _parse_elf_header(self):
+    def _parse_elf_header(self) -> Container:
         """ Parses the ELF file header and assigns the result to attributes
             of this object.
         """
         return struct_parse(self.structs.Elf_Ehdr, self.stream, stream_pos=0)
 
-    def _read_dwarf_section(self, section, relocate_dwarf_sections):
+    def _read_dwarf_section(
+        self,
+        section: Section,
+        relocate_dwarf_sections: bool,
+    ) -> DebugSectionDescriptor:
         """ Read the contents of a DWARF section from the stream and return a
             DebugSectionDescriptor. Apply relocations if asked to.
         """
@@ -884,7 +922,7 @@ class ELFFile:
                 address=section['sh_addr'])
 
     @staticmethod
-    def _decompress_dwarf_section(section):
+    def _decompress_dwarf_section(section: DebugSectionDescriptor) -> DebugSectionDescriptor:
         """ Returns the uncompressed contents of the provided DWARF section.
         """
         # TODO: support other compression formats from readelf.c
@@ -921,10 +959,15 @@ class ELFFile:
     def close(self) -> None:
         self.stream.close()
 
-    def __enter__(self):
+    def __enter__(self) -> Self:
         return self
 
-    def __exit__(self, type, value, traceback):
+    def __exit__(
+        self,
+        type: type[BaseException] | None,
+        value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
         self.close()
 
     def has_phantom_bytes(self) -> bool:

--- a/elftools/elf/gnuversions.py
+++ b/elftools/elf/gnuversions.py
@@ -6,10 +6,21 @@
 # Yann Rouillard (yann@pleiades.fr.eu.org)
 # This code is in the public domain
 #------------------------------------------------------------------------------
+from __future__ import annotations
+
 from functools import cached_property
+from typing import TYPE_CHECKING, Any
 
 from ..common.utils import struct_parse, elf_assert
 from .sections import Section, Symbol
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from ..construct.core import Struct
+    from ..construct.lib.container import Container
+    from .elffile import ELFFile
+    from .sections import StringTableSection, SymbolTableSection
 
 
 class Version:
@@ -25,11 +36,11 @@ class Version:
         Similarly to Section objects, allows dictionary-like access to
         verdef/verneed entry
     """
-    def __init__(self, entry, name=None):
+    def __init__(self, entry: Container, name: str | None = None) -> None:
         self.entry = entry
         self.name = name
 
-    def __getitem__(self, name):
+    def __getitem__(self, name: str) -> Any:
         """ Implement dict-like access to entry
         """
         return self.entry[name]
@@ -42,11 +53,11 @@ class VersionAuxiliary:
         Similarly to Section objects, allows dictionary-like access to the
         verdaux/vernaux entry
     """
-    def __init__(self, entry, name):
+    def __init__(self, entry: Container, name: str) -> None:
         self.entry = entry
         self.name = name
 
-    def __getitem__(self, name):
+    def __getitem__(self, name: str) -> Any:
         """ Implement dict-like access to entries
         """
         return self.entry[name]
@@ -57,8 +68,16 @@ class GNUVersionSection(Section):
         sections class which contains shareable code
     """
 
-    def __init__(self, header, name, elffile, stringtable,
-                 field_prefix, version_struct, version_auxiliaries_struct):
+    def __init__(
+        self,
+        header: Container,
+        name: str,
+        elffile: ELFFile,
+        stringtable: StringTableSection,
+        field_prefix: str,
+        version_struct: Struct,
+        version_auxiliaries_struct: Struct,
+    ) -> None:
         super().__init__(header, name, elffile)
         self.stringtable = stringtable
         self.field_prefix = field_prefix
@@ -70,14 +89,18 @@ class GNUVersionSection(Section):
         """
         return self['sh_info']
 
-    def _field_name(self, name, auxiliary=False):
+    def _field_name(self, name: str, auxiliary: bool = False) -> str:
         """ Return the real field's name of version or a version auxiliary
             entry
         """
         middle = 'a_' if auxiliary else '_'
         return self.field_prefix + middle + name
 
-    def _iter_version_auxiliaries(self, entry_offset, count):
+    def _iter_version_auxiliaries(
+        self,
+        entry_offset: int,
+        count: int,
+    ) -> Iterator[VersionAuxiliary]:
         """ Yield all auxiliary entries of a version entry
         """
         name_field = self._field_name('name', auxiliary=True)
@@ -95,7 +118,7 @@ class GNUVersionSection(Section):
 
             entry_offset += entry[next_field]
 
-    def iter_versions(self):
+    def iter_versions(self) -> Iterator[tuple[Version, Iterator[VersionAuxiliary]]]:
         """ Yield all the version entries in the section
             Each time it returns the main version structure
             and an iterator to walk through its auxiliaries entries
@@ -130,7 +153,13 @@ class GNUVerNeedSection(GNUVersionSection):
     """ ELF SUNW or GNU Version Needed table section.
         Has an associated StringTableSection that's passed in the constructor.
     """
-    def __init__(self, header, name, elffile, stringtable):
+    def __init__(
+        self,
+        header: Container,
+        name: str,
+        elffile: ELFFile,
+        stringtable: StringTableSection,
+    ) -> None:
         super().__init__(
                 header, name, elffile, stringtable, 'vn',
                 elffile.structs.Elf_Verneed, elffile.structs.Elf_Vernaux)
@@ -150,12 +179,12 @@ class GNUVerNeedSection(GNUVersionSection):
             for vernaux in vernaux_iter
         )
 
-    def iter_versions(self):
+    def iter_versions(self) -> Iterator[tuple[Version, Iterator[VersionAuxiliary]]]:
         for verneed, vernaux in super().iter_versions():
             verneed.name = self.stringtable.get_string(verneed['vn_file'])
             yield verneed, vernaux
 
-    def get_version(self, index):
+    def get_version(self, index: int) -> tuple[Version, VersionAuxiliary] | None:
         """ Get the version information located at index #n in the table
             Return boths the verneed structure and the vernaux structure
             that contains the name of the version
@@ -172,12 +201,18 @@ class GNUVerDefSection(GNUVersionSection):
     """ ELF SUNW or GNU Version Definition table section.
         Has an associated StringTableSection that's passed in the constructor.
     """
-    def __init__(self, header, name, elffile, stringtable):
+    def __init__(
+        self,
+        header: Container,
+        name: str,
+        elffile: ELFFile,
+        stringtable: StringTableSection,
+    ) -> None:
         super().__init__(
                 header, name, elffile, stringtable, 'vd',
                 elffile.structs.Elf_Verdef, elffile.structs.Elf_Verdaux)
 
-    def get_version(self, index):
+    def get_version(self, index: int) -> tuple[Version, Iterator[VersionAuxiliary]] | None:
         """ Get the version information located at index #n in the table
             Return boths the verdef structure and an iterator to retrieve
             both the version names and dependencies in the form of
@@ -194,7 +229,13 @@ class GNUVerSymSection(Section):
     """ ELF SUNW or GNU Versym table section.
         Has an associated SymbolTableSection that's passed in the constructor.
     """
-    def __init__(self, header, name, elffile, symboltable):
+    def __init__(
+            self,
+            header: Container,
+            name: str,
+            elffile: ELFFile,
+            symboltable: SymbolTableSection,
+    ) -> None:
         super().__init__(header, name, elffile)
         self.symboltable = symboltable
 
@@ -203,7 +244,7 @@ class GNUVerSymSection(Section):
         """
         return self['sh_size'] // self['sh_entsize']
 
-    def get_symbol(self, n):
+    def get_symbol(self, n: int) -> Symbol:
         """ Get the symbol at index #n from the table (Symbol object)
             It begins at 1 and not 0 since the first entry is used to
             store the current version of the syminfo table
@@ -218,7 +259,7 @@ class GNUVerSymSection(Section):
         name = self.symboltable.get_symbol(n).name
         return Symbol(entry, name)
 
-    def iter_symbols(self):
+    def iter_symbols(self) -> Iterator[Symbol]:
         """ Yield all the symbols in the table
         """
         for i in range(self.num_symbols()):

--- a/elftools/elf/hash.py
+++ b/elftools/elf/hash.py
@@ -6,11 +6,18 @@
 # Andreas Ziegler (andreas.ziegler@fau.de)
 # This code is in the public domain
 #-------------------------------------------------------------------------------
+from __future__ import annotations
 
 import struct
+from typing import TYPE_CHECKING
 
 from ..common.utils import struct_parse
+from ..construct.lib.container import Container
 from .sections import Section
+
+if TYPE_CHECKING:
+    from .elffile import ELFFile
+    from .sections import Symbol
 
 
 class ELFHashTable:
@@ -27,7 +34,13 @@ class ELFHashTable:
         supports symbol lookup without access to a symbol table section.
     """
 
-    def __init__(self, elffile, start_offset, size, symboltable):
+    def __init__(
+        self,
+        elffile: ELFFile,
+        start_offset: int,
+        size: int | None,
+        symboltable,
+    ) -> None:
         """
         Args:
             elffile (ELFFile): The ELF file.
@@ -38,12 +51,12 @@ class ELFHashTable:
         self.elffile = elffile
         self._symboltable = symboltable
         if size == 0:  # size may also be None if its unknown
-            self.params = {
+            self.params = Container(**{
                 'nbuckets': 0,
                 'nchains': 0,
                 'buckets': [],
                 'chains': [],
-            }
+            })
         else:
             self.params = struct_parse(self.elffile.structs.Elf_Hash,
                                        self.elffile.stream,
@@ -54,7 +67,7 @@ class ELFHashTable:
         """
         return self.params['nchains']
 
-    def get_symbol(self, name):
+    def get_symbol(self, name: str) -> Symbol | None:
         """ Look up a symbol from this hash table with the given name.
         """
         if self.params['nbuckets'] == 0:
@@ -90,7 +103,13 @@ class ELFHashSection(Section, ELFHashTable):
         allows us to use the common functions defined on Section objects when
         dealing with the hash table.
     """
-    def __init__(self, header, name, elffile, symboltable):
+    def __init__(
+        self,
+        header: Container,
+        name: str,
+        elffile: ELFFile,
+        symboltable,
+    ) -> None:
         Section.__init__(self, header, name, elffile)
         ELFHashTable.__init__(self, elffile, self['sh_offset'], self['sh_size'], symboltable)
 
@@ -108,10 +127,15 @@ class GNUHashTable:
         one should use the DynamicSegment object as the symboltable as it
         supports symbol lookup without access to a symbol table section.
     """
-    def __init__(self, elffile, start_offset, symboltable):
+    def __init__(
+        self,
+        elffile: ELFFile,
+        start_offset: int,
+        symboltable,
+    ) -> None:
         self.elffile = elffile
         self._symboltable = symboltable
-        self.params = struct_parse(self.elffile.structs.Gnu_Hash,
+        self.params: Container = struct_parse(self.elffile.structs.Gnu_Hash,
                                    self.elffile.stream,
                                    start_offset)
         # Element sizes in the hash table
@@ -154,7 +178,7 @@ class GNUHashTable:
         BITMASK = (1 << (H1 % arch_bits)) | (1 << (H2 % arch_bits))
         return (self.params['bloom'][word_idx] & BITMASK) == BITMASK
 
-    def get_symbol(self, name):
+    def get_symbol(self, name: str) -> Symbol | None:
         """ Look up a symbol from this hash table with the given name.
         """
         namehash = self.gnu_hash(name)
@@ -196,6 +220,12 @@ class GNUHashSection(Section, GNUHashTable):
         allows us to use the common functions defined on Section objects when
         dealing with the hash table.
     """
-    def __init__(self, header, name, elffile, symboltable):
+    def __init__(
+        self,
+        header: Container,
+        name: str,
+        elffile: ELFFile,
+        symboltable,
+    ) -> None:
         Section.__init__(self, header, name, elffile)
         GNUHashTable.__init__(self, elffile, self['sh_offset'], symboltable)

--- a/elftools/elf/notes.py
+++ b/elftools/elf/notes.py
@@ -6,11 +6,21 @@
 # Eli Bendersky (eliben@gmail.com)
 # This code is in the public domain
 #-------------------------------------------------------------------------------
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from ..common.utils import struct_parse, roundup, bytes2str
 from ..construct import CString
 
+if TYPE_CHECKING:
+    from collections.abc import Iterator
 
-def iter_notes(elffile, offset, size):
+    from ..construct.lib.container import Container
+    from .elffile import ELFFile
+
+
+def iter_notes(elffile: ELFFile, offset: int, size: int) -> Iterator[Container]:
     """ Yield all the notes in a section or segment.
     """
     end = offset + size
@@ -18,7 +28,7 @@ def iter_notes(elffile, offset, size):
     # Note: a note's name and data are 4-byte aligned, but it's possible there's
     # additional padding at the end to satisfy the alignment requirement of the segment.
     while offset + nhdr_size < end:
-        note = struct_parse(
+        note: Container = struct_parse(
             elffile.structs.Elf_Nhdr,
             elffile.stream,
             stream_pos=offset)
@@ -54,12 +64,12 @@ def iter_notes(elffile, offset, size):
                                           offset)
         elif note['n_type'] == 'NT_GNU_PROPERTY_TYPE_0' and note['n_name'] == 'GNU':
             off = offset
-            props = []
+            props: list[Container] = []
             # n_descsz contains the size of the note "descriptor" (the data payload),
             # excluding padding. See "Note Section" in https://refspecs.linuxfoundation.org/elf/elf.pdf
             current_note_end: int = offset + note['n_descsz']
             while off < current_note_end:
-                p = struct_parse(elffile.structs.Elf_Prop, elffile.stream, off)
+                p: Container = struct_parse(elffile.structs.Elf_Prop, elffile.stream, off)
                 off += roundup(p.pr_datasz + 8, 2 if elffile.elfclass == 32 else 3)
                 props.append(p)
             note['n_desc'] = props

--- a/elftools/elf/relocation.py
+++ b/elftools/elf/relocation.py
@@ -6,17 +6,24 @@
 # Eli Bendersky (eliben@gmail.com)
 # This code is in the public domain
 #-------------------------------------------------------------------------------
+from __future__ import annotations
+
 from functools import cached_property
-from typing import Callable, NamedTuple
+from typing import IO, TYPE_CHECKING, Any, Callable, NamedTuple
 
 from ..common.exceptions import ELFRelocationError
 from ..common.utils import elf_assert, struct_parse
-from .sections import Section
+from .sections import Section, SymbolTableSection
 from .enums import (
     ENUM_RELOC_TYPE_i386, ENUM_RELOC_TYPE_x64, ENUM_RELOC_TYPE_MIPS,
     ENUM_RELOC_TYPE_ARM, ENUM_RELOC_TYPE_AARCH64, ENUM_RELOC_TYPE_PPC64,
     ENUM_RELOC_TYPE_S390X, ENUM_RELOC_TYPE_BPF, ENUM_RELOC_TYPE_LOONGARCH)
 from ..construct import Container
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from .elffile import ELFFile
 
 
 class Relocation:
@@ -25,7 +32,7 @@ class Relocation:
 
         Can be either a REL or RELA relocation.
     """
-    def __init__(self, entry, elffile):
+    def __init__(self, entry: Container, elffile: ELFFile) -> None:
         self.entry = entry
         self.elffile = elffile
 
@@ -34,7 +41,7 @@ class Relocation:
         """
         return 'r_addend' in self.entry
 
-    def __getitem__(self, name):
+    def __getitem__(self, name: str) -> Any:
         """ Dict-like access to entries
         """
         return self.entry[name]
@@ -52,7 +59,13 @@ class RelocationTable:
     """ Shared functionality between relocation sections and relocation tables
     """
 
-    def __init__(self, elffile, offset, size, is_rela):
+    def __init__(
+        self,
+        elffile: ELFFile,
+        offset: int,
+        size: int,
+        is_rela: bool,
+    ) -> None:
         self._stream = elffile.stream
         self._elffile = elffile
         self._elfstructs = elffile.structs
@@ -77,7 +90,7 @@ class RelocationTable:
         """
         return self._size // self.entry_size
 
-    def get_relocation(self, n):
+    def get_relocation(self, n: int) -> Relocation:
         """ Get the relocation at index #n from the section (Relocation object)
         """
         entry_offset = self._offset + n * self.entry_size
@@ -87,7 +100,7 @@ class RelocationTable:
             stream_pos=entry_offset)
         return Relocation(entry, self._elffile)
 
-    def iter_relocations(self):
+    def iter_relocations(self) -> Iterator[Relocation]:
         """ Yield all the relocations in the section
         """
         for i in range(self.num_relocations()):
@@ -97,7 +110,7 @@ class RelocationTable:
 class RelocationSection(Section, RelocationTable):
     """ ELF relocation section. Serves as a collection of Relocation entries.
     """
-    def __init__(self, header, name, elffile):
+    def __init__(self, header: Container, name: str, elffile: ELFFile) -> None:
         Section.__init__(self, header, name, elffile)
         RelocationTable.__init__(self, self.elffile,
             self['sh_offset'], self['sh_size'], header['sh_type'] == 'SHT_RELA')
@@ -119,7 +132,7 @@ class RelrRelocationTable:
         relocations).
     """
 
-    def __init__(self, elffile, offset, size, entrysize):
+    def __init__(self, elffile: ELFFile, offset: int, size: int, entrysize: int) -> None:
         self._elffile = elffile
         self._offset = offset
         self._size = size
@@ -130,7 +143,7 @@ class RelrRelocationTable:
             'Expected RELR entry size to be %s, got %s' % (
                 self._entrysize, entrysize))
 
-    def iter_relocations(self):
+    def iter_relocations(self) -> Iterator[Relocation]:
         """ Yield all the relocations in the section
         """
 
@@ -184,7 +197,7 @@ class RelrRelocationTable:
         """
         return len(self._cached_relocations)
 
-    def get_relocation(self, n):
+    def get_relocation(self, n: int) -> Relocation:
         """ Get the relocation at index #n from the section (Relocation object)
         """
         return self._cached_relocations[n]
@@ -197,7 +210,7 @@ class RelrRelocationTable:
 class RelrRelocationSection(Section, RelrRelocationTable):
     """ ELF RELR relocation section. Serves as a collection of RELR relocation entries.
     """
-    def __init__(self, header, name, elffile):
+    def __init__(self, header: Container, name: str, elffile: ELFFile) -> None:
         Section.__init__(self, header, name, elffile)
         RelrRelocationTable.__init__(self, self.elffile,
             self['sh_offset'], self['sh_size'], self['sh_entsize'])
@@ -238,10 +251,10 @@ def _bpf_64_32_reloc_calc_sym_plus_addend(value: int, sym_value: int, offset: in
 class RelocationHandler:
     """ Handles the logic of relocations in ELF files.
     """
-    def __init__(self, elffile):
+    def __init__(self, elffile: ELFFile) -> None:
         self.elffile = elffile
 
-    def find_relocations_for_section(self, section):
+    def find_relocations_for_section(self, section: Section) -> RelocationSection | None:
         """ Given a section, find the relocation section for it in the ELF
             file. Return a RelocationSection object, or None if none was
             found.
@@ -258,17 +271,27 @@ class RelocationHandler:
                 return relsection
         return None
 
-    def apply_section_relocations(self, stream, reloc_section):
+    def apply_section_relocations(
+        self,
+        stream: IO[bytes],
+        reloc_section: RelocationSection,
+    ) -> None:
         """ Apply all relocations in reloc_section (a RelocationSection object)
             to the given stream, that contains the data of the section that is
             being relocated. The stream is modified as a result.
         """
         # The symbol table associated with this relocation section
         symtab = self.elffile.get_section(reloc_section['sh_link'])
+        assert isinstance(symtab, SymbolTableSection)
         for reloc in reloc_section.iter_relocations():
             self._do_apply_relocation(stream, reloc, symtab)
 
-    def _do_apply_relocation(self, stream, reloc, symtab):
+    def _do_apply_relocation(
+        self,
+        stream: IO[bytes],
+        reloc: Relocation,
+        symtab: SymbolTableSection,
+    ) -> None:
         # Preparations for performing the relocation: obtain the value of
         # the symbol mentioned in the relocation, as well as the relocation
         # recipe which tells us how to actually perform it.

--- a/elftools/elf/sections.py
+++ b/elftools/elf/sections.py
@@ -6,14 +6,24 @@
 # Eli Bendersky (eliben@gmail.com)
 # This code is in the public domain
 #-------------------------------------------------------------------------------
-from functools import cached_property
+from __future__ import annotations
+
 import zlib
+from functools import cached_property
+from typing import IO, TYPE_CHECKING, Any
 
 from ..common.exceptions import ELFCompressionError
 from ..common.utils import struct_parse, elf_assert, parse_cstring_from_stream
 from collections import defaultdict
 from .constants import SH_FLAGS
 from .notes import iter_notes
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from ..construct.lib.container import Container
+    from .elffile import ELFFile
+    from .structs import ELFStructs
 
 
 class Section:
@@ -24,12 +34,12 @@ class Section:
          > sec = Section(...)
          > sec['sh_type']  # section type
     """
-    def __init__(self, header, name, elffile):
+    def __init__(self, header: Container, name: str, elffile: ELFFile) -> None:
         self.header = header
         self.name = name
         self.elffile = elffile
-        self.stream = self.elffile.stream
-        self.structs = self.elffile.structs
+        self.stream: IO[bytes] = self.elffile.stream
+        self.structs: ELFStructs = self.elffile.structs
         self._compressed: int = header['sh_flags'] & SH_FLAGS.SHF_COMPRESSED
 
         if self.compressed:
@@ -116,7 +126,7 @@ class Section:
         """
         return False
 
-    def __getitem__(self, name):
+    def __getitem__(self, name: str) -> Any:
         """ Implement dict-like access to header entries
         """
         return self.header[name]
@@ -153,7 +163,13 @@ class SymbolTableIndexSection(Section):
         SHN_XINDEX (0xffff). The format of the section is described at
         https://refspecs.linuxfoundation.org/elf/gabi4+/ch4.sheader.html
     """
-    def __init__(self, header, name, elffile, symboltable):
+    def __init__(
+        self,
+        header: Container,
+        name: str,
+        elffile: ELFFile,
+        symboltable: Container,
+    ) -> None:
         super().__init__(header, name, elffile)
         self.symboltable = symboltable
 
@@ -170,7 +186,13 @@ class SymbolTableSection(Section):
     """ ELF symbol table section. Has an associated StringTableSection that's
         passed in the constructor.
     """
-    def __init__(self, header, name, elffile, stringtable):
+    def __init__(
+        self,
+        header: Container,
+        name: str,
+        elffile: ELFFile,
+        stringtable: StringTableSection,
+    ) -> None:
         super().__init__(header, name, elffile)
         self.stringtable = stringtable
         elf_assert(self['sh_entsize'] > 0,
@@ -183,7 +205,7 @@ class SymbolTableSection(Section):
         """
         return self['sh_size'] // self['sh_entsize']
 
-    def get_symbol(self, n):
+    def get_symbol(self, n: int) -> Symbol:
         """ Get the symbol at index #n from the table (Symbol object)
         """
         # Grab the symbol's entry from the stream
@@ -196,7 +218,7 @@ class SymbolTableSection(Section):
         name = self.stringtable.get_string(entry['st_name'])
         return Symbol(entry, name)
 
-    def get_symbol_by_name(self, name):
+    def get_symbol_by_name(self, name: str) -> list[Symbol] | None:
         """ Get a symbol(s) by name. Return None if no symbol by the given name
             exists.
         """
@@ -210,7 +232,7 @@ class SymbolTableSection(Section):
             smap[sym.name].append(i)
         return smap
 
-    def iter_symbols(self):
+    def iter_symbols(self) -> Iterator[Symbol]:
         """ Yield all the symbols in the table
         """
         for i in range(self.num_symbols()):
@@ -224,11 +246,11 @@ class Symbol:
         Similarly to Section objects, allows dictionary-like access to the
         symbol entry.
     """
-    def __init__(self, entry, name):
+    def __init__(self, entry: Container, name: str) -> None:
         self.entry = entry
         self.name = name
 
-    def __getitem__(self, name):
+    def __getitem__(self, name: str) -> Any:
         """ Implement dict-like access to entries
         """
         return self.entry[name]
@@ -238,7 +260,13 @@ class SUNWSyminfoTableSection(Section):
     """ ELF .SUNW Syminfo table section.
         Has an associated SymbolTableSection that's passed in the constructor.
     """
-    def __init__(self, header, name, elffile, symboltable):
+    def __init__(
+        self,
+        header: Container,
+        name: str,
+        elffile: ELFFile,
+        symboltable: SymbolTableSection,
+    ) -> None:
         super().__init__(header, name, elffile)
         self.symboltable = symboltable
 
@@ -247,7 +275,7 @@ class SUNWSyminfoTableSection(Section):
         """
         return self['sh_size'] // self['sh_entsize'] - 1
 
-    def get_symbol(self, n):
+    def get_symbol(self, n: int) -> Symbol:
         """ Get the symbol at index #n from the table (Symbol object).
             It begins at 1 and not 0 since the first entry is used to
             store the current version of the syminfo table.
@@ -262,7 +290,7 @@ class SUNWSyminfoTableSection(Section):
         name = self.symboltable.get_symbol(n).name
         return Symbol(entry, name)
 
-    def iter_symbols(self):
+    def iter_symbols(self) -> Iterator[Symbol]:
         """ Yield all the symbols in the table
         """
         for i in range(1, self.num_symbols() + 1):
@@ -272,7 +300,7 @@ class SUNWSyminfoTableSection(Section):
 class NoteSection(Section):
     """ ELF NOTE section. Knows how to parse notes.
     """
-    def iter_notes(self):
+    def iter_notes(self) -> Iterator[Container]:
         """ Yield all the notes in the section.  Each result is a dictionary-
             like object with "n_name", "n_type", and "n_desc" fields, amongst
             others.
@@ -283,7 +311,7 @@ class NoteSection(Section):
 class StabSection(Section):
     """ ELF stab section.
     """
-    def iter_stabs(self):
+    def iter_stabs(self) -> Iterator[Container]:
         """ Yield all stab entries.  Result type is ELFStructs.Elf_Stabs.
         """
         offset: int = self['sh_offset']
@@ -303,12 +331,12 @@ class Attribute:
     """ Attribute object - representing a build attribute of ELF files.
     """
 
-    def __init__(self, structs, stream):
+    def __init__(self, structs: ELFStructs, stream: IO[bytes]) -> None:
         self._tag = self._parse(structs, stream)
-        self.extra = None
+        self.extra: Any | None = None
 
     @classmethod
-    def _parse(cls, structs, stream):
+    def _parse(cls, structs: ELFStructs, stream: IO[bytes]) -> Container:
         raise NotImplementedError
 
     @property
@@ -325,7 +353,7 @@ class Attribute:
 class AttributesSubsubsection(Section):
     """ Subsubsection of an ELF attribute section's subsection.
     """
-    def __init__(self, stream, structs, offset):
+    def __init__(self, stream: IO[bytes], structs: ELFStructs, offset: int) -> None:
         self.stream = stream
         self.offset = offset
         self.structs = structs
@@ -334,7 +362,7 @@ class AttributesSubsubsection(Section):
 
         self.attr_start = self.stream.tell()
 
-    def iter_attributes(self, tag=None):
+    def iter_attributes(self, tag: str | None = None) -> Iterator[Attribute]:
         """ Yield all attributes (limit to |tag| if specified).
         """
         for attribute in self._make_attributes():
@@ -348,12 +376,12 @@ class AttributesSubsubsection(Section):
         return sum(1 for _ in self.iter_attributes()) + 1
 
     @property
-    def attributes(self):
+    def attributes(self) -> list[Attribute]:
         """ List of all attributes in the subsubsection.
         """
         return [self.header, *(self.iter_attributes())]
 
-    def _make_attributes(self):
+    def _make_attributes(self) -> Iterator[Attribute]:
         """ Create all attributes for this subsubsection except the first one
             which is the header.
         """
@@ -375,7 +403,7 @@ class AttributesSubsection(Section):
     """
     subsubsection = AttributesSubsubsection
 
-    def __init__(self, stream, structs, offset):
+    def __init__(self, stream: IO[bytes], structs: ELFStructs, offset: int) -> None:
         self.stream = stream
         self.offset = offset
         self.structs = structs
@@ -384,7 +412,7 @@ class AttributesSubsection(Section):
 
         self.subsubsec_start = self.stream.tell()
 
-    def iter_subsubsections(self, scope=None):
+    def iter_subsubsections(self, scope: str | None = None) -> Iterator[AttributesSubsubsection]:
         """ Yield all subsubsections (limit to |scope| if specified).
         """
         for subsubsec in self._make_subsubsections():
@@ -398,12 +426,12 @@ class AttributesSubsection(Section):
         return sum(1 for _ in self.iter_subsubsections())
 
     @property
-    def subsubsections(self):
+    def subsubsections(self) -> list[AttributesSubsubsection]:
         """ List of all subsubsections in the subsection.
         """
         return list(self.iter_subsubsections())
 
-    def _make_subsubsections(self):
+    def _make_subsubsections(self) -> Iterator[AttributesSubsubsection]:
         """ Create all subsubsections for this subsection.
         """
         end = self.offset + self['length']
@@ -417,7 +445,7 @@ class AttributesSubsection(Section):
             self.stream.seek(self.subsubsec_start + subsubsec.header.value)
             yield subsubsec
 
-    def __getitem__(self, name):
+    def __getitem__(self, name: str) -> Any:
         """ Implement dict-like access to header entries.
         """
         return self.header[name]
@@ -433,7 +461,7 @@ class AttributesSection(Section):
     """
     subsection = AttributesSubsection
 
-    def __init__(self, header, name, elffile):
+    def __init__(self, header: Container, name: str, elffile: ELFFile) -> None:
         super().__init__(header, name, elffile)
 
         fv: int = struct_parse(self.structs.Elf_byte('format_version'),
@@ -445,7 +473,7 @@ class AttributesSection(Section):
 
         self.subsec_start = self.stream.tell()
 
-    def iter_subsections(self, vendor_name=None):
+    def iter_subsections(self, vendor_name: str | None = None) -> Iterator[AttributesSubsection]:
         """ Yield all subsections (limit to |vendor_name| if specified).
         """
         for subsec in self._make_subsections():
@@ -459,12 +487,12 @@ class AttributesSection(Section):
         return sum(1 for _ in self.iter_subsections())
 
     @property
-    def subsections(self):
+    def subsections(self) -> list[AttributesSubsection]:
         """ List of all subsections in the section.
         """
         return list(self.iter_subsections())
 
-    def _make_subsections(self):
+    def _make_subsections(self) -> Iterator[AttributesSubsection]:
         """ Create all subsections for this section.
         """
         end = self['sh_offset'] + self.data_size
@@ -484,10 +512,10 @@ class ARMAttribute(Attribute):
     """
 
     @classmethod
-    def _parse(cls, structs, stream):
+    def _parse(cls, structs: ELFStructs, stream: IO[bytes]) -> Container:
         return struct_parse(structs.Elf_Arm_Attribute_Tag, stream)
 
-    def __init__(self, structs, stream):
+    def __init__(self, structs: ELFStructs, stream: IO[bytes]) -> None:
         super().__init__(structs, stream)
 
         if self.tag in ('TAG_FILE', 'TAG_SECTION', 'TAG_SYMBOL'):
@@ -548,10 +576,10 @@ class RISCVAttribute(Attribute):
     """
 
     @classmethod
-    def _parse(cls, structs, stream):
+    def _parse(cls, structs: ELFStructs, stream: IO[bytes]) -> Container:
         return struct_parse(structs.Elf_RiscV_Attribute_Tag, stream)
 
-    def __init__(self, structs, stream):
+    def __init__(self, structs: ELFStructs, stream: IO[bytes]) -> None:
         super().__init__(structs, stream)
 
         if self.tag in ('TAG_FILE', 'TAG_SECTION', 'TAG_SYMBOL'):

--- a/elftools/elf/segments.py
+++ b/elftools/elf/segments.py
@@ -6,14 +6,25 @@
 # Eli Bendersky (eliben@gmail.com)
 # This code is in the public domain
 #-------------------------------------------------------------------------------
+from __future__ import annotations
+
+from typing import IO, TYPE_CHECKING, Any
+
 from ..construct import CString
 from ..common.utils import struct_parse
 from .constants import SH_FLAGS
 from .notes import iter_notes
 
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from ..construct import Container
+    from .elffile import ELFFile
+    from .sections import Section
+
 
 class Segment:
-    def __init__(self, header, stream):
+    def __init__(self, header: Container, stream: IO[bytes]) -> None:
         self.header = header
         self.stream = stream
 
@@ -23,12 +34,12 @@ class Segment:
         self.stream.seek(self['p_offset'])
         return self.stream.read(self['p_filesz'])
 
-    def __getitem__(self, name):
+    def __getitem__(self, name: str) -> Any:
         """ Implement dict-like access to header entries
         """
         return self.header[name]
 
-    def section_in_segment(self, section):
+    def section_in_segment(self, section: Section) -> bool:
         """ Is the given section contained in this segment?
 
             Note: this tries to reproduce the intricate rules of the
@@ -98,7 +109,7 @@ class InterpSegment(Segment):
     """ INTERP segment. Knows how to obtain the path to the interpreter used
         for this ELF file.
     """
-    def __init__(self, header, stream):
+    def __init__(self, header: Container, stream: IO[bytes]) -> None:
         super().__init__(header, stream)
 
     def get_interp_name(self) -> str:
@@ -114,12 +125,11 @@ class InterpSegment(Segment):
 class NoteSegment(Segment):
     """ NOTE segment. Knows how to parse notes.
     """
-    def __init__(self, header, stream, elffile):
+    def __init__(self, header: Container, stream: IO[bytes], elffile: ELFFile) -> None:
         super().__init__(header, stream)
         self.elffile = elffile
 
-    def iter_notes(self):
-
+    def iter_notes(self) -> Iterator[Container]:
         """ Yield all the notes in the segment.  Each result is a dictionary-
             like object with "n_name", "n_type", and "n_desc" fields, amongst
             others.


### PR DESCRIPTION
More typing for `elftools.elf` from #611
- more or less the boring part as most special cases are exempted
- `elfstools.elf.descriptions` has some issues: "you have a basket (`dict[int, …]`) full of vegetables and you're asking Python, if it contains a car `str`". While that's perfect valid Python code, the type-checkers call you nuts and complain. As such the `# type: ignore` is required to silence them.
- `stringtables` need some special handling; will come later
- `make_relative_loader()` and `load()` need some special handling for `test/test_debuglink.py`; will come later
- `__getitem__()` will need some `@overload`s; will come later
- Also some `Protocols` and `TypeVars` will come later