### PR TITLE
typing: elfrools.dwarf

### DIFF
--- a/elftools/dwarf/compileunit.py
+++ b/elftools/dwarf/compileunit.py
@@ -10,13 +10,18 @@ from __future__ import annotations
 
 from bisect import bisect_right
 from functools import cached_property
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from .die import DIE
 from ..common.utils import dwarf_assert
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from ..construct.lib.container import Container
     from .abbrevtable import AbbrevTable
+    from .dwarfinfo import DWARFInfo
+    from .structs import DWARFStructs
 
 
 class CompileUnit:
@@ -37,7 +42,14 @@ class CompileUnit:
         To get the top-level DIE describing the compilation unit, call the
         get_top_DIE method.
     """
-    def __init__(self, header, dwarfinfo, structs, cu_offset, cu_die_offset):
+    def __init__(
+        self,
+        header: Container,
+        dwarfinfo: DWARFInfo,
+        structs: DWARFStructs,
+        cu_offset: int,
+        cu_die_offset: int,
+    ) -> None:
         """ header:
                 CU header for this compile unit
 
@@ -61,7 +73,7 @@ class CompileUnit:
 
         # A list of DIEs belonging to this CU.
         # This list is lazily constructed as DIEs are iterated over.
-        self._dielist = []
+        self._dielist: list[DIE] = []
         # A list of file offsets, corresponding (by index) to the DIEs
         # in `self._dielist`. This list exists separately from
         # `self._dielist` to make it binary searchable, enabling the
@@ -75,7 +87,7 @@ class CompileUnit:
         """
         return self.structs.dwarf_format
 
-    def get_abbrev_table(self):
+    def get_abbrev_table(self) -> AbbrevTable:
         """ Get the abbreviation table (AbbrevTable object) for this CU
         """
         return self._abbrev_table
@@ -84,7 +96,7 @@ class CompileUnit:
     def _abbrev_table(self) -> AbbrevTable:
         return self.dwarfinfo.get_abbrev_table(self['debug_abbrev_offset'])
 
-    def get_top_DIE(self):
+    def get_top_DIE(self) -> DIE:
         """ Get the top DIE (which is either a DW_TAG_compile_unit or
             DW_TAG_partial_unit) of this CU
         """
@@ -94,6 +106,7 @@ class CompileUnit:
         if self._diemap:
             return self._dielist[0]
 
+        assert self.dwarfinfo.debug_info_sec is not None
         top = DIE(
                 cu=self,
                 stream=self.dwarfinfo.debug_info_sec.stream,
@@ -116,7 +129,7 @@ class CompileUnit:
     def size(self) -> int:
         return self['unit_length'] + self.structs.initial_length_field_size()
 
-    def get_DIE_from_refaddr(self, refaddr):
+    def get_DIE_from_refaddr(self, refaddr: int) -> DIE:
         """ Obtain a DIE contained in this CU from a reference.
 
             refaddr:
@@ -134,10 +147,11 @@ class CompileUnit:
 
         return self._get_cached_DIE(refaddr)
 
-    def iter_DIEs(self):
+    def iter_DIEs(self) -> Iterator[DIE]:
         """ Iterate over all the DIEs in the CU, in order of their appearance.
             Note that null DIEs will also be returned.
         """
+        assert self.dwarfinfo.debug_info_sec is not None
         stm = self.dwarfinfo.debug_info_sec.stream
         pos = self.cu_die_offset
         end_pos = self.cu_offset + self.size
@@ -145,7 +159,7 @@ class CompileUnit:
         die = self.get_top_DIE()
         yield die
         pos += die.size
-        parent = die
+        parent: DIE | None = die
         i = 1
         while pos < end_pos:
             if i < len(self._diemap) and self._diemap[i] == pos: # DIE already cached
@@ -158,7 +172,7 @@ class CompileUnit:
 
             die._parent = parent
 
-            if die.tag is None:
+            if die.tag is None and parent is not None:
                 parent._terminator = die
                 parent = parent._parent
 
@@ -175,7 +189,7 @@ class CompileUnit:
             pos += die.size
 
 
-    def iter_DIE_children(self, die):
+    def iter_DIE_children(self, die: DIE) -> Iterator[DIE]:
         """ Given a DIE, yields either its children, without null DIE list
             terminator, or nothing, if that DIE has no children.
 
@@ -224,17 +238,18 @@ class CompileUnit:
                 if child._terminator is None:
                     for _ in self.iter_DIE_children(child):
                         pass
+                    assert child._terminator is not None
 
                 cur_offset = child._terminator.offset + child._terminator.size
 
     #------ PRIVATE ------#
 
-    def __getitem__(self, name):
+    def __getitem__(self, name: str) -> Any:
         """ Implement dict-like access to header entries
         """
         return self.header[name]
 
-    def _iter_DIE_subtree(self, die):
+    def _iter_DIE_subtree(self, die: DIE) -> Iterator[DIE]:
         """ Given a DIE, this yields it with its subtree including null DIEs
             (child list terminators).
         """
@@ -246,9 +261,10 @@ class CompileUnit:
         if die.has_children:
             for c in die.iter_children():
                 yield from die.cu._iter_DIE_subtree(c)
+            assert die._terminator is not None
             yield die._terminator
 
-    def _get_cached_DIE(self, offset):
+    def _get_cached_DIE(self, offset: int) -> DIE:
         """ Given a DIE offset, look it up in the cache.  If not present,
             parse the DIE and insert it into the cache.
 

--- a/elftools/dwarf/datatype_cpp.py
+++ b/elftools/dwarf/datatype_cpp.py
@@ -7,7 +7,15 @@
 # Eli Bendersky (eliben@gmail.com)
 # This code is in the public domain
 #-------------------------------------------------------------------------------
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from ..common.utils import bytes2str
+
+if TYPE_CHECKING:
+    from .die import DIE
+
 
 cpp_symbols = dict(
     pointer   = "*",
@@ -15,10 +23,10 @@ cpp_symbols = dict(
     const     = "const",
     volatile  = "volatile")
 
-def describe_cpp_datatype(var_die):
+def describe_cpp_datatype(var_die: DIE) -> str:
     return str(parse_cpp_datatype(var_die))
 
-def parse_cpp_datatype(var_die):
+def parse_cpp_datatype(var_die: DIE) -> TypeDesc:
     """Given a DIE that describes a variable, a parameter, or a member
     with DW_AT_type in it, tries to return the C++ datatype as a string
 
@@ -134,7 +142,7 @@ class TypeDesc:
 
     """
     def __init__(self) -> None:
-        self.name = None
+        self.name: str
         self.modifiers: tuple[str, ...] = () # Reads left to right
         self.scopes: tuple[str, ...] = () # Reads left to right
         self.tag: str | None = None
@@ -174,13 +182,13 @@ class TypeDesc:
 
         return " ".join(parts)+dims
 
-def DIE_name(die):
+def DIE_name(die: DIE) -> str:
     return bytes2str(die.attributes['DW_AT_name'].value)
 
-def safe_DIE_name(die, default = ''):
+def safe_DIE_name(die: DIE, default: str = '') -> str:
     return bytes2str(die.attributes['DW_AT_name'].value) if 'DW_AT_name' in die.attributes else default
 
-def DIE_type(die):
+def DIE_type(die: DIE) -> DIE:
     return die.get_DIE_from_attribute("DW_AT_type")
 
 class ClassDesc:
@@ -188,7 +196,7 @@ class ClassDesc:
         self.scopes: tuple[str, ...] = ()
         self.const_member: bool = False
 
-def get_class_spec_if_member(func_spec, the_func):
+def get_class_spec_if_member(func_spec: DIE, the_func: DIE) -> ClassDesc | None:
     if 'DW_AT_object_pointer' in the_func.attributes:
         this_param = the_func.get_DIE_from_attribute('DW_AT_object_pointer')
         this_type = parse_cpp_datatype(this_param)
@@ -212,26 +220,26 @@ def get_class_spec_if_member(func_spec, the_func):
 
     return None
 
-def format_function_param(param_spec, param):
+def format_function_param(param_spec: DIE, param: DIE) -> str:
     if param_spec.tag == 'DW_TAG_formal_parameter':
         type = parse_cpp_datatype(param_spec)
         return  str(type)
     else: # unspecified_parameters AKA variadic
         return "..."
 
-def DIE_is_ptr_to_member_struct(type_die):
+def DIE_is_ptr_to_member_struct(type_die: DIE) -> bool:
     if type_die.tag == 'DW_TAG_structure_type':
         members = tuple(die for die in type_die.iter_children() if die.tag == "DW_TAG_member")
         return len(members) == 2 and safe_DIE_name(members[0]) == "__pfn" and safe_DIE_name(members[1]) == "__delta"
     return False
 
-def _strip_type_tag(die):
+def _strip_type_tag(die: DIE) -> str:
     """Given a DIE with DW_TAG_foo_type, returns foo"""
     if not isinstance(die.tag, str): # User-defined tag
         return ""
     return die.tag[7:-5]
 
-def _array_subtype_size(sub):
+def _array_subtype_size(sub: DIE) -> int:
     if 'DW_AT_upper_bound' in sub.attributes:
         return sub.attributes['DW_AT_upper_bound'].value + 1
     if 'DW_AT_count' in sub.attributes:

--- a/elftools/dwarf/descriptions.py
+++ b/elftools/dwarf/descriptions.py
@@ -6,7 +6,10 @@
 # Eli Bendersky (eliben@gmail.com)
 # This code is in the public domain
 #-------------------------------------------------------------------------------
+from __future__ import annotations
+
 from collections import defaultdict
+from typing import TYPE_CHECKING, Any
 
 from .constants import (
     DW_ACCESS, DW_ATE, DW_CC, DW_CFA, DW_ID, DW_INL, DW_LANG, DW_ORD, DW_VIRTUALITY, DW_VIS,
@@ -16,13 +19,21 @@ from .die import DIE
 from ..common.utils import preserve_stream_pos, dwarf_assert, bytes2str
 from .callframe import CIE, FDE
 
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterable, Mapping
+    from typing import TypeVar
+
+    from .callframe import CallFrameInstruction, CFARule, CFIEntry, RegisterRule
+    from .die import AttributeValue
+    from .structs import DWARFStructs
+
 
 def set_global_machine_arch(machine_arch: str) -> None:
     global _MACHINE_ARCH
     _MACHINE_ARCH = machine_arch
 
 
-def describe_attr_value(attr, die, section_offset):
+def describe_attr_value(attr: AttributeValue, die: DIE, section_offset: int) -> str:
     """ Given an attribute attr, return the textual representation of its
         value, suitable for tools like readelf.
 
@@ -40,11 +51,11 @@ def describe_attr_value(attr, die, section_offset):
     return str(val_description) + '\t' + extra_info
 
 
-def describe_CFI_instructions(entry):
+def describe_CFI_instructions(entry: CFIEntry) -> str:
     """ Given a CFI entry (CIE or FDE), return the textual description of its
         instructions.
     """
-    def _assert_FDE_instruction(instr):
+    def _assert_FDE_instruction(instr: CallFrameInstruction) -> None:
         dwarf_assert(
             isinstance(entry, FDE),
             'Unexpected instruction "%s" for a CIE' % instr)
@@ -58,7 +69,9 @@ def describe_CFI_instructions(entry):
 
     if isinstance(entry, CIE):
         cie = entry
+        pc: int | None = None
     else: # FDE
+        assert entry.cie is not None
         cie = entry.cie
         pc = entry['initial_location']
 
@@ -116,23 +129,28 @@ def describe_CFI_instructions(entry):
     return s
 
 
-def describe_CFI_register_rule(rule):
+def describe_CFI_register_rule(rule: RegisterRule) -> str:
     s = _DESCR_CFI_REGISTER_RULE_TYPE[rule.type]
     if rule.type in ('OFFSET', 'VAL_OFFSET'):
+        assert isinstance(rule.arg, int)
         s += '%+d' % rule.arg
     elif rule.type == 'REGISTER':
-        s += describe_reg_name(rule.arg)
+        assert isinstance(rule.arg, int)
+        reg = describe_reg_name(rule.arg)
+        s += reg
     return s
 
 
-def describe_CFI_CFA_rule(rule):
+def describe_CFI_CFA_rule(rule: CFARule) -> str:
     if rule.expr:
         return 'exp'
     else:
+        assert isinstance(rule.reg, int)
+        assert isinstance(rule.offset, int)
         return '%s%+d' % (describe_reg_name(rule.reg), rule.offset)
 
 
-def describe_DWARF_expr(expr, structs, cu_offset=None):
+def describe_DWARF_expr(expr: Any, structs: DWARFStructs, cu_offset: int | None = None) -> str:
     """ Textual description of a DWARF expression encoded in 'expr'.
         structs should come from the entity encompassing the expression - it's
         needed to be able to parse it correctly.
@@ -188,50 +206,54 @@ _MACHINE_ARCH: str | None = None
 def _format_hex(n: int) -> str:
     return '0x%x' % n if n != 0 else '0'
 
-def _describe_attr_ref(attr, die, section_offset):
+def _describe_attr_ref(attr: AttributeValue, die: DIE, section_offset: int) -> str:
     return '<%s>' % _format_hex(attr.value + die.cu.cu_offset)
 
-def _describe_attr_ref_sig8(attr, die, section_offset):
+def _describe_attr_ref_sig8(attr: AttributeValue, die: DIE, section_offset: int) -> str:
     return 'signature: %s' % _format_hex(attr.value)
 
-def _describe_attr_value_passthrough(attr, die, section_offset):
+def _describe_attr_value_passthrough(
+    attr: AttributeValue,
+    die: DIE,
+    section_offset: int,
+) -> str | int:
     return attr.value
 
-def _describe_attr_hex(attr, die, section_offset):
+def _describe_attr_hex(attr: AttributeValue, die: DIE, section_offset: int) -> str:
     return '%s' % _format_hex(attr.value)
 
-def _describe_attr_hex_addr(attr, die, section_offset):
+def _describe_attr_hex_addr(attr: AttributeValue, die: DIE, section_offset: int) -> str:
     return '<%s>' % _format_hex(attr.value)
 
-def _describe_attr_split_64bit(attr, die, section_offset):
+def _describe_attr_split_64bit(attr: AttributeValue, die: DIE, section_offset: int) -> str:
     low_word = attr.value & 0xFFFFFFFF
     high_word = (attr.value >> 32) & 0xFFFFFFFF
     return '%s %s' % (_format_hex(low_word), _format_hex(high_word))
 
-def _describe_attr_strp(attr, die, section_offset):
+def _describe_attr_strp(attr: AttributeValue, die: DIE, section_offset: int) -> str:
     return '(indirect string, offset: %s): %s' % (
         _format_hex(attr.raw_value), bytes2str(attr.value))
 
-def _describe_attr_line_strp(attr, die, section_offset):
+def _describe_attr_line_strp(attr: AttributeValue, die: DIE, section_offset: int) -> str:
     return '(indirect line string, offset: %s): %s' % (
         _format_hex(attr.raw_value), bytes2str(attr.value))
 
-def _describe_attr_string(attr, die, section_offset):
+def _describe_attr_string(attr: AttributeValue, die: DIE, section_offset: int) -> str:
     return bytes2str(attr.value)
 
-def _describe_attr_debool(attr, die, section_offset):
+def _describe_attr_debool(attr: AttributeValue, die: DIE, section_offset: int) -> str:
     """ To be consistent with readelf, generate 1 for True flags, 0 for False
         flags.
     """
     return '1' if attr.value else '0'
 
-def _describe_attr_present(attr, die, section_offset):
+def _describe_attr_present(attr: AttributeValue, die: DIE, section_offset: int) -> str:
     """ Some forms may simply mean that an attribute is present,
         without providing any value.
     """
     return '1'
 
-def _describe_attr_block(attr, die, section_offset):
+def _describe_attr_block(attr: AttributeValue, die: DIE, section_offset: int) -> str:
     s = '%s byte block: ' % len(attr.value)
     s += ' '.join('%x' % item for item in attr.value) + ' '
     return s
@@ -424,30 +446,36 @@ _DESCR_CFI_REGISTER_RULE_TYPE = dict(
     ARCHITECTURAL='a',
 )
 
-def _make_extra_mapper(mapping, default, default_interpolate_value=False):
+def _make_extra_mapper(
+    mapping,
+    default: str,
+    default_interpolate_value: bool = False,
+) -> Callable[[AttributeValue, DIE, int], str]:
     """ Create a mapping function from attribute parameters to an extra
         value that should be displayed.
     """
-    def mapper(attr, die, section_offset):
+
+    def mapper(attr: AttributeValue, die: DIE, section_offset: int) -> str:
         if default_interpolate_value:
             d = default % attr.value
         else:
             d = default
         return mapping.get(attr.value, d)
+
     return mapper
 
 
-def _make_extra_string(s=''):
+def _make_extra_string(s: str = '') -> Callable[[AttributeValue, DIE, int], str]:
     """ Create an extra function that just returns a constant string.
     """
-    def extra(attr, die, section_offset):
+    def extra(attr: AttributeValue, die: DIE, section_offset: int) -> str:
         return s
     return extra
 
 
-_DWARF_EXPR_DUMPER_CACHE = {}
+_DWARF_EXPR_DUMPER_CACHE: dict[int, ExprDumper] = {}
 
-def _location_list_extra(attr, die, section_offset):
+def _location_list_extra(attr: AttributeValue, die: DIE, section_offset: int) -> str:
     # According to section 2.6 of the DWARF spec v3, class loclistptr means
     # a location list, and class block means a location expression.
     # DW_FORM.sec_offset is new in DWARFv4 as a section offset.
@@ -457,7 +485,7 @@ def _location_list_extra(attr, die, section_offset):
         return describe_DWARF_expr(attr.value, die.cu.structs, die.cu.cu_offset)
 
 
-def _data_member_location_extra(attr, die, section_offset):
+def _data_member_location_extra(attr: AttributeValue, die: DIE, section_offset: int) -> str:
     # According to section 5.5.6 of the DWARF spec v4, a data member location
     # can be an integer offset, or a location description.
     #
@@ -469,7 +497,7 @@ def _data_member_location_extra(attr, die, section_offset):
         return describe_DWARF_expr(attr.value, die.cu.structs, die.cu.cu_offset)
 
 
-def _import_extra(attr, die, section_offset):
+def _import_extra(attr: AttributeValue, die: DIE, section_offset: int) -> str:
     # For DW_AT_import the value points to a DIE (that can be either in the
     # current DIE's CU or in another CU, depending on the FORM). The extra
     # information for it is the abbreviation number in this DIE and its tag.
@@ -586,12 +614,12 @@ class ExprDumper:
 
         Usage: after creation, call dump_expr repeatedly - it's stateless.
     """
-    def __init__(self, structs):
+    def __init__(self, structs: DWARFStructs) -> None:
         self.structs = structs
         self.expr_parser = DWARFExprParser(self.structs)
         self._init_lookups()
 
-    def dump_expr(self, expr, cu_offset=None):
+    def dump_expr(self, expr: bytes | Iterable[int], cu_offset: int | None = None) -> str:
         """ Parse and dump a DWARF expression.
             expr should be bytes or a list of (integer) byte values.
             cu_offset is the cu_offset
@@ -624,7 +652,13 @@ class ExprDumper:
         self._ops_with_hex_arg = {
             'DW_OP_addr', 'DW_OP_call2', 'DW_OP_call4', 'DW_OP_call_ref'}
 
-    def _dump_to_string(self, opcode, opcode_name, args, cu_offset=None):
+    def _dump_to_string(
+        self,
+        opcode: int,
+        opcode_name: str,
+        args: list[Any],
+        cu_offset: int | None = None,
+    ) -> str:
         # Some GNU ops contain an offset from the current CU as an argument,
         # but readelf emits those ops with offset from the info section
         # so we need the base offset of the parent CU.

--- a/elftools/dwarf/die.py
+++ b/elftools/dwarf/die.py
@@ -6,14 +6,22 @@
 # Eli Bendersky (eliben@gmail.com)
 # This code is in the public domain
 #-------------------------------------------------------------------------------
+from __future__ import annotations
+
 import os
-from typing import Any, NamedTuple
+from typing import IO, TYPE_CHECKING, Any, NamedTuple
 
 from ..common.exceptions import DWARFError, ELFParseError
 from ..common.utils import bytes2str, struct_parse
 from .enums import DW_FORM_raw2name
 from .dwarf_util import _resolve_via_offset_table, _get_base_offset
 from ..construct import ConstructError
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from .compileunit import CompileUnit
+    from .typeunit import TypeUnit
 
 
 # AttributeValue - describes an attribute value in the DIE:
@@ -78,7 +86,7 @@ class DIE:
 
         See also the public methods.
     """
-    def __init__(self, cu, stream, offset):
+    def __init__(self, cu: CompileUnit | TypeUnit, stream: IO[bytes], offset: int) -> None:
         """ cu:
                 CompileUnit object this DIE belongs to. Used to obtain context
                 information (structs, abbrev table, etc.)
@@ -98,8 +106,8 @@ class DIE:
         self.size = 0
         # Null DIE terminator. It can be used to obtain offset range occupied
         # by this DIE including its whole subtree.
-        self._terminator = None
-        self._parent = None
+        self._terminator: DIE | None = None
+        self._parent: DIE | None = None
 
         self._parse_DIE()
 
@@ -108,7 +116,7 @@ class DIE:
         """
         return self.tag is None
 
-    def get_DIE_from_attribute(self, name):
+    def get_DIE_from_attribute(self, name: str) -> DIE:
         """ Return the DIE referenced by the named attribute of this DIE.
             The attribute must be in the reference attribute class.
 
@@ -132,7 +140,7 @@ class DIE:
         else:
             raise DWARFError('%s is not a reference class form attribute' % attr)
 
-    def get_parent(self):
+    def get_parent(self) -> DIE | None:
         """ Return the parent DIE of this DIE, or None if the DIE has no
             parent (i.e. is a top-level DIE).
         """
@@ -154,12 +162,12 @@ class DIE:
         fname = bytes2str(fname_attr.value) if fname_attr else ''
         return os.path.join(comp_dir, fname)
 
-    def iter_children(self):
+    def iter_children(self) -> Iterator[DIE]:
         """ Iterates all children of this DIE
         """
         return self.cu.iter_DIE_children(self)
 
-    def iter_siblings(self):
+    def iter_siblings(self) -> Iterator[DIE]:
         """ Yield all siblings of this DIE
         """
         parent = self.get_parent()
@@ -174,7 +182,7 @@ class DIE:
     # interesting to consumers
     #
 
-    def set_parent(self, die):
+    def set_parent(self, die: DIE) -> None:
         self._parent = die
 
     #------ PRIVATE ------#
@@ -194,7 +202,7 @@ class DIE:
         # called for siblings, it is more efficient if siblings references are
         # provided and no worse than a single walk if they are missing, while
         # stopping iteration early could result in O(n^2) walks.
-        search = self.cu.get_top_DIE()
+        search: DIE = self.cu.get_top_DIE()
         while search.offset < self.offset:
             prev = search
             for child in search.iter_children():
@@ -239,6 +247,7 @@ class DIE:
             # that manipulate the stream by reading data from it.
             stream.seek(self.offset)
             self.abbrev_code = structs.the_Dwarf_uleb128.parse_stream(stream)
+            assert self.abbrev_code is not None
 
             # This may be a null entry
             if self.abbrev_code == 0:
@@ -329,14 +338,17 @@ class DIE:
         elif form in ('DW_FORM_addrx', 'DW_FORM_addrx1', 'DW_FORM_addrx2', 'DW_FORM_addrx3', 'DW_FORM_addrx4') and translate_indirect:
             return self.cu.dwarfinfo.get_addr(self.cu, raw_value)
         elif form in ('DW_FORM_strx', 'DW_FORM_strx1', 'DW_FORM_strx2', 'DW_FORM_strx3', 'DW_FORM_strx4') and translate_indirect:
+            assert self.dwarfinfo.debug_str_offsets_sec is not None
             stream = self.dwarfinfo.debug_str_offsets_sec.stream
             base_offset = _get_base_offset(self.cu, 'DW_AT_str_offsets_base')
             offset_size = 4 if self.cu.structs.dwarf_format == 32 else 8
             str_offset = struct_parse(self.cu.structs.the_Dwarf_offset, stream, base_offset + raw_value*offset_size)
             return self.dwarfinfo.get_string_from_table(str_offset)
         elif form == 'DW_FORM_loclistx' and translate_indirect:
+            assert self.dwarfinfo.debug_loclists_sec is not None
             return _resolve_via_offset_table(self.dwarfinfo.debug_loclists_sec.stream, self.cu, raw_value, 'DW_AT_loclists_base')
         elif form == 'DW_FORM_rnglistx' and translate_indirect:
+            assert self.dwarfinfo.debug_rnglists_sec is not None
             return _resolve_via_offset_table(self.dwarfinfo.debug_rnglists_sec.stream, self.cu, raw_value, 'DW_AT_rnglists_base')
         return raw_value
 

--- a/elftools/dwarf/dwarf_util.py
+++ b/elftools/dwarf/dwarf_util.py
@@ -6,14 +6,26 @@
 # Eli Bendersky (eliben@gmail.com)
 # This code is in the public domain
 #-------------------------------------------------------------------------------
+from __future__ import annotations
 
 import os
 import binascii
+from typing import IO, TYPE_CHECKING, Any
+
 from ..construct.macros import Array
 from ..common.exceptions import DWARFError
 from ..common.utils import preserve_stream_pos, struct_parse
 
-def _get_base_offset(cu, base_attribute_name):
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from ..construct import Struct
+    from .compileunit import CompileUnit
+    from .structs import DWARFStructs
+    from .typeunit import TypeUnit
+
+
+def _get_base_offset(cu: CompileUnit | TypeUnit, base_attribute_name: str) -> int:
     """Retrieves a required, base offset-type atribute
     from the top DIE in the CU. Applies to several indirectly
     encoded objects - range lists, location lists, strings, addresses.
@@ -23,7 +35,12 @@ def _get_base_offset(cu, base_attribute_name):
         raise DWARFError("The CU at offset 0x%x needs %s" % (cu.cu_offset, base_attribute_name))
     return cu_top_die.attributes[base_attribute_name].value
 
-def _resolve_via_offset_table(stream, cu, index, base_attribute_name):
+def _resolve_via_offset_table(
+    stream: IO[bytes],
+    cu: CompileUnit | TypeUnit,
+    index: int,
+    base_attribute_name: str,
+) -> int:
     """Given an index in the offset table and directions where to find it,
     retrieves an offset. Works for loclists, rnglists.
 
@@ -41,7 +58,11 @@ def _resolve_via_offset_table(stream, cu, index, base_attribute_name):
     with preserve_stream_pos(stream):
         return base_offset + struct_parse(cu.structs.the_Dwarf_offset, stream, base_offset + index*offset_size)
 
-def _iter_CUs_in_section(stream, structs, parser):
+def _iter_CUs_in_section(
+    stream: IO[bytes],
+    structs: DWARFStructs,
+    parser: Struct,
+) -> Iterator[Any]:
     """Iterates through the list of CU sections in loclists or rangelists. Almost identical structures there.
 
     get_parser is a lambda that takes structs, returns the parser
@@ -61,7 +82,7 @@ def _iter_CUs_in_section(stream, structs, parser):
         yield header
         offset = header.offset_after_length + header.unit_length
 
-def _file_crc32(file):
+def _file_crc32(file: IO[bytes]) -> int:
     """ Provided a readable binary stream, reads the stream to the end
         and computes the CRC32 checksum of its contents,
         with the initial value of 0.

--- a/elftools/dwarf/dwarfinfo.py
+++ b/elftools/dwarf/dwarfinfo.py
@@ -6,9 +6,11 @@
 # Eli Bendersky (eliben@gmail.com)
 # This code is in the public domain
 #-------------------------------------------------------------------------------
+from __future__ import annotations
+
 from bisect import bisect_right
 from functools import cached_property
-from typing import IO, NamedTuple
+from typing import IO, TYPE_CHECKING, NamedTuple
 
 from ..construct.lib.container import Container
 from ..common.exceptions import DWARFError
@@ -25,6 +27,14 @@ from .ranges import RangeLists, RangeListsPair
 from .aranges import ARanges
 from .namelut import NameLUT
 from .dwarf_util import _get_base_offset
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterator
+
+    from ..construct.lib.container import ListContainer
+    from .callframe import ZERO, CFIEntry
+    from .die import DIE
+    from .namelut import NameLUTEntry
 
 
 # Describes a debug section
@@ -69,28 +79,29 @@ class DWARFInfo:
     """ Acts also as a "context" to other major objects, bridging between
         various parts of the debug information.
     """
-    def __init__(self,
-            config,
-            debug_info_sec,
-            debug_aranges_sec,
-            debug_abbrev_sec,
-            debug_frame_sec,
-            eh_frame_sec,
-            debug_str_sec,
-            debug_loc_sec,
-            debug_ranges_sec,
-            debug_line_sec,
-            debug_pubtypes_sec,
-            debug_pubnames_sec,
-            debug_addr_sec,
-            debug_str_offsets_sec,
-            debug_line_str_sec,
-            debug_loclists_sec,
-            debug_rnglists_sec,
-            debug_sup_sec,
-            gnu_debugaltlink_sec,
-            debug_types_sec
-            ):
+    def __init__(
+        self,
+        config: DwarfConfig,
+        debug_info_sec: DebugSectionDescriptor | None,
+        debug_aranges_sec: DebugSectionDescriptor | None,
+        debug_abbrev_sec: DebugSectionDescriptor | None,
+        debug_frame_sec: DebugSectionDescriptor | None,
+        eh_frame_sec: DebugSectionDescriptor | None,
+        debug_str_sec: DebugSectionDescriptor | None,
+        debug_loc_sec: DebugSectionDescriptor | None,
+        debug_ranges_sec: DebugSectionDescriptor | None,
+        debug_line_sec: DebugSectionDescriptor | None,
+        debug_pubtypes_sec: DebugSectionDescriptor | None,
+        debug_pubnames_sec: DebugSectionDescriptor | None,
+        debug_addr_sec: DebugSectionDescriptor | None,
+        debug_str_offsets_sec: DebugSectionDescriptor | None,
+        debug_line_str_sec: DebugSectionDescriptor | None,
+        debug_loclists_sec: DebugSectionDescriptor | None,
+        debug_rnglists_sec: DebugSectionDescriptor | None,
+        debug_sup_sec: DebugSectionDescriptor | None,
+        gnu_debugaltlink_sec: DebugSectionDescriptor | None,
+        debug_types_sec: DebugSectionDescriptor | None,
+    ) -> None:
         """ config:
                 A DwarfConfig object
 
@@ -123,7 +134,7 @@ class DWARFInfo:
         # Sets the supplementary_dwarfinfo to None. Client code can set this
         # to something else, typically a DWARFInfo file read from an ELFFile
         # which path is stored in the debug_sup_sec or gnu_debugaltlink_sec.
-        self.supplementary_dwarfinfo = None
+        self.supplementary_dwarfinfo: DWARFInfo | None = None
 
         # This is the DWARFStructs the context uses, so it doesn't depend on
         # DWARF format and address_size (these are determined per CU) - set them
@@ -134,13 +145,13 @@ class DWARFInfo:
             address_size=self.config.default_address_size)
 
         # Cache for abbrev tables: a dict keyed by offset
-        self._abbrevtable_cache = {}
+        self._abbrevtable_cache: dict[int, AbbrevTable] = {}
         # Cache for program lines tables: a dict keyed by offset
-        self._linetable_cache = {}
+        self._linetable_cache: dict[int, LineProgram] = {}
 
         # Cache of compile units and map of their offsets for bisect lookup.
         # Access with .iter_CUs(), .get_CU_containing(), and/or .get_CU_at().
-        self._cu_cache = []
+        self._cu_cache: list[CompileUnit] = []
         self._cu_offsets_map: list[int] = []
 
     @property
@@ -157,7 +168,7 @@ class DWARFInfo:
         """
         return bool(self.debug_types_sec)
 
-    def get_DIE_from_lut_entry(self, lut_entry):
+    def get_DIE_from_lut_entry(self, lut_entry: NameLUTEntry) -> DIE:
         """ Get the DIE from the pubnames or putbtypes lookup table entry.
 
             lut_entry:
@@ -167,7 +178,7 @@ class DWARFInfo:
         cu = self.get_CU_at(lut_entry.cu_ofs)
         return self.get_DIE_from_refaddr(lut_entry.die_ofs, cu)
 
-    def get_DIE_from_refaddr(self, refaddr, cu=None):
+    def get_DIE_from_refaddr(self, refaddr: int, cu: CompileUnit | None = None) -> DIE:
         """ Given a .debug_info section offset of a DIE, return the DIE.
 
             refaddr:
@@ -181,7 +192,7 @@ class DWARFInfo:
             cu = self.get_CU_containing(refaddr)
         return cu.get_DIE_from_refaddr(refaddr)
 
-    def get_DIE_by_sig8(self, sig8):
+    def get_DIE_by_sig8(self, sig8: int) -> DIE:
         """ Find and return a DIE referenced by its type signature.
             sig8:
                 The 8 byte signature (as a 64-bit unsigned integer)
@@ -206,7 +217,7 @@ class DWARFInfo:
             raise KeyError("Signature %016x not found in .debug_types" % sig8)
         return tu._get_cached_DIE(tu.tu_offset + tu['type_offset'])
 
-    def get_CU_containing(self, refaddr):
+    def get_CU_containing(self, refaddr: int) -> CompileUnit:
         """ Find the CU that includes the given reference address in the
             .debug_info section.
 
@@ -222,6 +233,7 @@ class DWARFInfo:
         dwarf_assert(
             self.has_debug_info,
             'CU lookup but no debug info section')
+        assert self.debug_info_sec is not None
         dwarf_assert(
             0 <= refaddr < self.debug_info_sec.size,
             "refaddr %s beyond .debug_info size" % refaddr)
@@ -240,7 +252,7 @@ class DWARFInfo:
 
         raise ValueError("CU for reference address %s not found" % refaddr)
 
-    def get_CU_at(self, offset):
+    def get_CU_at(self, offset: int) -> CompileUnit:
         """ Given a CU header offset, return the parsed CU.
 
             offset:
@@ -254,13 +266,14 @@ class DWARFInfo:
         dwarf_assert(
             self.has_debug_info,
             'CU lookup but no debug info section')
+        assert self.debug_info_sec is not None
         dwarf_assert(
             0 <= offset < self.debug_info_sec.size,
             "offset %s beyond .debug_info size" % offset)
 
         return self._cached_CU_at_offset(offset)
 
-    def get_TU_by_sig8(self, sig8):
+    def get_TU_by_sig8(self, sig8: int) -> TypeUnit:
         """ Find and return a Type Unit referenced by its signature
 
             sig8:
@@ -275,17 +288,17 @@ class DWARFInfo:
             raise KeyError("Signature %016x not found in .debug_types" % sig8)
         return tu
 
-    def iter_CUs(self):
+    def iter_CUs(self) -> Iterator[CompileUnit]:
         """ Yield all the compile units (CompileUnit objects) in the debug info
         """
         return self._parse_CUs_iter()
 
-    def iter_TUs(self):
+    def iter_TUs(self) -> Iterator[TypeUnit]:
         """Yield all the type units (TypeUnit objects) in the debug_types
         """
         return self._parse_TUs_iter()
 
-    def get_abbrev_table(self, offset):
+    def get_abbrev_table(self, offset: int) -> AbbrevTable:
         """ Get an AbbrevTable from the given offset in the debug_abbrev
             section.
 
@@ -297,6 +310,7 @@ class DWARFInfo:
             AbbrevTable objects are cached internally (two calls for the same
             offset will return the same object).
         """
+        assert self.debug_abbrev_sec is not None
         dwarf_assert(
             offset < self.debug_abbrev_sec.size,
             "Offset '0x%x' to abbrev table out of section bounds" % offset)
@@ -311,15 +325,17 @@ class DWARFInfo:
         """ Obtain a string from the string table section, given an offset
             relative to the section.
         """
+        assert self.debug_str_sec is not None
         return parse_cstring_from_stream(self.debug_str_sec.stream, offset)
 
     def get_string_from_linetable(self, offset: int) -> bytes | None:
         """ Obtain a string from the string table section, given an offset
             relative to the section.
         """
+        assert self.debug_line_str_sec is not None
         return parse_cstring_from_stream(self.debug_line_str_sec.stream, offset)
 
-    def line_program_for_CU(self, CU):
+    def line_program_for_CU(self, CU: CompileUnit) -> LineProgram | None:
         """ Given a CU object, fetch the line program it points to from the
             .debug_line section.
             If the CU doesn't point to a line program, return None.
@@ -346,9 +362,10 @@ class DWARFInfo:
         """
         return self.debug_frame_sec is not None
 
-    def CFI_entries(self):
+    def CFI_entries(self) -> list[CFIEntry | ZERO]:
         """ Get a list of dwarf_frame CFI entries from the .debug_frame section.
         """
+        assert self.debug_frame_sec is not None
         cfi = CallFrameInfo(
             stream=self.debug_frame_sec.stream,
             size=self.debug_frame_sec.size,
@@ -361,9 +378,10 @@ class DWARFInfo:
         """
         return self.eh_frame_sec is not None
 
-    def EH_CFI_entries(self):
+    def EH_CFI_entries(self) -> list[CFIEntry | ZERO]:
         """ Get a list of eh_frame CFI entries from the .eh_frame section.
         """
+        assert self.eh_frame_sec is not None
         cfi = CallFrameInfo(
             stream=self.eh_frame_sec.stream,
             size=self.eh_frame_sec.size,
@@ -372,7 +390,7 @@ class DWARFInfo:
             for_eh_frame=True)
         return cfi.get_entries()
 
-    def get_pubtypes(self):
+    def get_pubtypes(self) -> NameLUT | None:
         """
         Returns a NameLUT object that contains information read from the
         .debug_pubtypes section in the ELF file.
@@ -388,7 +406,7 @@ class DWARFInfo:
         else:
             return None
 
-    def get_pubnames(self):
+    def get_pubnames(self) -> NameLUT | None:
         """
         Returns a NameLUT object that contains information read from the
         .debug_pubnames section in the ELF file.
@@ -404,7 +422,7 @@ class DWARFInfo:
         else:
             return None
 
-    def get_aranges(self):
+    def get_aranges(self) -> ARanges | None:
         """ Get an ARanges object representing the .debug_aranges section of
             the DWARF data, or None if the section doesn't exist
         """
@@ -415,7 +433,7 @@ class DWARFInfo:
         else:
             return None
 
-    def location_lists(self):
+    def location_lists(self) -> LocationLists | LocationListsPair | None:
         """ Get a LocationLists object representing the .debug_loc/debug_loclists section of
             the DWARF data, or None if this section doesn't exist.
 
@@ -430,7 +448,7 @@ class DWARFInfo:
         else:
             return None
 
-    def range_lists(self):
+    def range_lists(self) -> RangeLists | RangeListsPair | None:
         """ Get a RangeLists object representing the .debug_ranges/.debug_rnglists section of
             the DWARF data, or None if this section doesn't exist.
 
@@ -445,7 +463,7 @@ class DWARFInfo:
         else:
             return None
 
-    def get_addr(self, cu, addr_index):
+    def get_addr(self, cu: CompileUnit | TypeUnit, addr_index: int) -> int:
         """Provided a CU and an index, retrieves an address from the debug_addr section
         """
         if not self.debug_addr_sec:
@@ -456,7 +474,7 @@ class DWARFInfo:
 
     #------ PRIVATE ------#
 
-    def _parse_CUs_iter(self, offset=0):
+    def _parse_CUs_iter(self, offset: int = 0) -> Iterator[CompileUnit]:
         """ Iterate CU objects in order of appearance in the debug_info section.
 
             offset:
@@ -478,7 +496,7 @@ class DWARFInfo:
                       cu.structs.initial_length_field_size())
             yield cu
 
-    def _parse_TUs_iter(self, offset=0):
+    def _parse_TUs_iter(self, offset: int = 0) -> Iterator[TypeUnit]:
         """ Iterate Type Unit objects in order of appearance in the debug_types section.
 
             offset:
@@ -525,7 +543,7 @@ class DWARFInfo:
 
         return units
 
-    def _cached_CU_at_offset(self, offset):
+    def _cached_CU_at_offset(self, offset: int) -> CompileUnit:
         """ Return the CU with unit header at the given offset into the
             debug_info section from the cache.  If not present, the unit is
             header is parsed and the object is installed in the cache.
@@ -551,7 +569,7 @@ class DWARFInfo:
         self._cu_cache.insert(i, cu)
         return cu
 
-    def _parse_CU_at_offset(self, offset):
+    def _parse_CU_at_offset(self, offset: int) -> CompileUnit:
         """ Parse and return a CU at the given offset in the debug_info stream.
         """
         # Section 7.4 (32-bit and 64-bit DWARF Formats) of the DWARF spec v3
@@ -562,6 +580,7 @@ class DWARFInfo:
         # dwarf format. Based on it, we then create a new DWARFStructs
         # instance suitable for this CU and use it to parse the rest.
         #
+        assert self.debug_info_sec is not None
         initial_length = struct_parse(
             self.structs.the_Dwarf_uint32, self.debug_info_sec.stream, offset)
         dwarf_format = 64 if initial_length == 0xFFFFFFFF else 32
@@ -597,7 +616,7 @@ class DWARFInfo:
                 cu_offset=offset,
                 cu_die_offset=cu_die_offset)
 
-    def _parse_TU_at_offset(self, offset):
+    def _parse_TU_at_offset(self, offset: int) -> TypeUnit:
         """ Parse and return a Type Unit (TU) at the given offset in the debug_types stream.
         """
         # Section 7.4 (32-bit and 64-bit DWARF Formats) of the DWARF spec v4
@@ -608,6 +627,7 @@ class DWARFInfo:
         # dwarf format. Based on it, we then create a new DWARFStructs
         # instance suitable for this TU and use it to parse the rest.
         #
+        assert self.debug_types_sec is not None
         initial_length = struct_parse(
             self.structs.the_Dwarf_uint32, self.debug_types_sec.stream, offset)
         dwarf_format = 64 if initial_length == 0xFFFFFFFF else 32
@@ -647,7 +667,7 @@ class DWARFInfo:
         """
         return 2 <= version <= 5
 
-    def _parse_line_program_at_offset(self, offset, structs):
+    def _parse_line_program_at_offset(self, offset: int, structs: DWARFStructs) -> LineProgram:
         """ Given an offset to the .debug_line section, parse the line program
             starting at this offset in the section and return it.
             structs is the DWARFStructs object used to do this parsing.
@@ -656,17 +676,27 @@ class DWARFInfo:
         if offset in self._linetable_cache:
             return self._linetable_cache[offset]
 
+        assert self.debug_line_sec is not None
         lineprog_header = struct_parse(
             structs.Dwarf_lineprog_header,
             self.debug_line_sec.stream,
             offset)
 
         # DWARF5: resolve names
-        def resolve_strings(lineprog_header, format_field, data_field) -> None:
+        def resolve_strings(
+            lineprog_header: Container,
+            format_field: str,
+            data_field: str,
+        ) -> None:
             if lineprog_header.get(format_field, False):
                 data = lineprog_header[data_field]
                 for field in lineprog_header[format_field]:
-                    def replace_value(data, content_type, replacer):
+
+                    def replace_value(
+                        data: ListContainer,
+                        content_type: str,
+                        replacer: Callable[[int], bytes | None],
+                    ) -> None:
                         for entry in data:
                             entry[content_type] = replacer(entry[content_type])
 

--- a/elftools/dwarf/locationlists.py
+++ b/elftools/dwarf/locationlists.py
@@ -6,12 +6,24 @@
 # Eli Bendersky (eliben@gmail.com)
 # This code is in the public domain
 #-------------------------------------------------------------------------------
+from __future__ import annotations
+
 import os
-from typing import NamedTuple
+from typing import IO, TYPE_CHECKING, NamedTuple
 
 from ..common.exceptions import DWARFError
 from ..common.utils import struct_parse
 from .dwarf_util import _iter_CUs_in_section
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterator, Mapping
+
+    from ..construct.lib.container import Container
+    from .compileunit import CompileUnit
+    from .die import DIE, AttributeValue
+    from .dwarfinfo import DWARFInfo
+    from .structs import DWARFStructs
+    from .typeunit import TypeUnit
 
 
 class LocationExpr(NamedTuple):
@@ -39,19 +51,23 @@ class LocationViewPair(NamedTuple):
     end: int
 
 
-def _translate_startx_length(e, cu):
+if TYPE_CHECKING:
+    _Location = LocationExpr | LocationEntry | BaseAddressEntry | LocationViewPair
+
+
+def _translate_startx_length(e: Container, cu: CompileUnit | TypeUnit) -> LocationEntry:
     start_offset: int = cu.dwarfinfo.get_addr(cu, e.start_index)
     return LocationEntry(e.entry_offset, e.entry_length, start_offset, start_offset + e.length, e.loc_expr, True)
 
 # Maps parsed entries to the tuples above; LocationViewPair is mapped elsewhere
-entry_translate = {
+entry_translate: dict[str, Callable[[Container, CompileUnit | TypeUnit], _Location]] = {
     'DW_LLE_base_address'    : lambda e, cu: BaseAddressEntry(e.entry_offset, e.entry_length, e.address),
     'DW_LLE_offset_pair'     : lambda e, cu: LocationEntry(e.entry_offset, e.entry_length, e.start_offset, e.end_offset, e.loc_expr, False),
     'DW_LLE_start_length'    : lambda e, cu: LocationEntry(e.entry_offset, e.entry_length, e.start_address, e.start_address + e.length, e.loc_expr, True),
     'DW_LLE_start_end'       : lambda e, cu: LocationEntry(e.entry_offset, e.entry_length, e.start_address, e.end_address, e.loc_expr, True),
     'DW_LLE_default_location': lambda e, cu: LocationEntry(e.entry_offset, e.entry_length, -1, -1, e.loc_expr, True),
-    'DW_LLE_base_addressx'   : lambda e, cu: BaseAddressEntry(e.entry_offset, e.entry_length, cu.dwarfinfo.get_addr(cu, e.index)),
-    'DW_LLE_startx_endx'     : lambda e, cu: LocationEntry(e.entry_offset, e.entry_length, cu.dwarfinfo.get_addr(cu, e.start_index), cu.dwarfinfo.get_addr(cu, e.end_index), e.loc_expr, True),
+    'DW_LLE_base_addressx'   : lambda e, cu: BaseAddressEntry(e.entry_offset, e.entry_length, cu.dwarfinfo.get_addr(cu, e.index)),  # type: ignore[has-type]
+    'DW_LLE_startx_endx'     : lambda e, cu: LocationEntry(e.entry_offset, e.entry_length, cu.dwarfinfo.get_addr(cu, e.start_index), cu.dwarfinfo.get_addr(cu, e.end_index), e.loc_expr, True),  # type: ignore[has-type]
     'DW_LLE_startx_length'   : _translate_startx_length
 }
 
@@ -59,11 +75,17 @@ class LocationListsPair:
     """For those binaries that contain both a debug_loc and a debug_loclists section,
     it holds a LocationLists object for both and forwards API calls to the right one.
     """
-    def __init__(self, streamv4, streamv5, structs, dwarfinfo=None):
+    def __init__(
+        self,
+        streamv4: IO[bytes],
+        streamv5: IO[bytes],
+        structs: DWARFStructs,
+        dwarfinfo: DWARFInfo | None = None,
+    ) -> None:
         self._loc = LocationLists(streamv4, structs, 4, dwarfinfo)
         self._loclists = LocationLists(streamv5, structs, 5, dwarfinfo)
 
-    def get_location_list_at_offset(self, offset, die=None):
+    def get_location_list_at_offset(self, offset: int, die: DIE | None = None) -> list[_Location]:
         """See LocationLists.get_location_list_at_offset().
         """
         if die is None:
@@ -71,13 +93,13 @@ class LocationListsPair:
         section = self._loclists if die.cu.header.version >= 5 else self._loc
         return section.get_location_list_at_offset(offset, die)
 
-    def iter_location_lists(self):
+    def iter_location_lists(self) -> Iterator[BaseAddressEntry | LocationEntry]:
         """Tricky proposition, since the structure of loc and loclists
         is not identical. A realistic readelf implementation needs to be aware of both
         """
         raise DWARFError("Iterating through two sections is not supported")
 
-    def iter_CUs(self):
+    def iter_CUs(self) -> Iterator[CompileUnit]:
         """See LocationLists.iter_CUs()
 
         There are no CUs in DWARFv4 sections.
@@ -102,14 +124,20 @@ class LocationLists:
         that contain references to other sections (e. g. DW_LLE_startx_endx),
         and only for location list enumeration.
     """
-    def __init__(self, stream, structs, version=4, dwarfinfo=None):
+    def __init__(
+        self,
+        stream: IO[bytes],
+        structs: DWARFStructs,
+        version: int = 4,
+        dwarfinfo: DWARFInfo | None = None,
+    ) -> None:
         self.stream = stream
         self.structs = structs
         self.dwarfinfo = dwarfinfo
         self.version = version
         self._max_addr: int = 2 ** (self.structs.address_size * 8) - 1
 
-    def get_location_list_at_offset(self, offset, die=None):
+    def get_location_list_at_offset(self, offset: int, die: DIE | None = None) -> list[_Location]:
         """ Get a location list at the given offset in the section.
         Passing the die is only neccessary in DWARF5+, for decoding
         location entry encodings that contain references to other sections.
@@ -121,7 +149,7 @@ class LocationLists:
             return self._parse_location_list_from_stream_v5(die.cu)
         return self._parse_location_list_from_stream()
 
-    def iter_location_lists(self):
+    def iter_location_lists(self) -> Iterator[list[_Location]]:
         """ Iterates through location lists and view pairs. Returns lists of
         LocationEntry, BaseAddressEntry, and LocationViewPair objects.
         """
@@ -151,6 +179,7 @@ class LocationLists:
         all_offsets = set() # Set of offsets where either a locview pair set can be found, or a view-less loclist
         locviews = dict() # Map of locview offset to the respective loclist offset
         cu_map = dict() # Map of loclist offsets to CUs
+        assert self.dwarfinfo is not None
         for cu in self.dwarfinfo.iter_CUs():
             cu_ver: int = cu['version']
             if (cu_ver >= 5) == ver5:
@@ -214,19 +243,20 @@ class LocationLists:
                     entries = self._parse_location_list_from_stream()
                     yield locview_pairs + entries
 
-    def iter_CUs(self):
+    def iter_CUs(self) -> Iterator[CompileUnit]:
         """For DWARF5 returns an array of objects, where each one has an array of offsets
         """
         if self.version < 5:
             raise DWARFError("CU iteration in loclists is not supported with DWARF<5")
 
+        assert self.dwarfinfo is not None
         structs = next(self.dwarfinfo.iter_CUs()).structs # Just pick one
         return _iter_CUs_in_section(self.stream, structs, structs.Dwarf_loclists_CU_header)
 
     #------ PRIVATE ------#
 
-    def _parse_location_list_from_stream(self):
-        lst = []
+    def _parse_location_list_from_stream(self) -> list[_Location]:
+        lst: list[_Location] = []
         while True:
             entry_offset = self.stream.tell()
             begin_offset: int = struct_parse(
@@ -257,7 +287,10 @@ class LocationLists:
                     is_absolute = False))
         return lst
 
-    def _parse_location_list_from_stream_v5(self, cu=None):
+    def _parse_location_list_from_stream_v5(
+        self,
+        cu: CompileUnit | TypeUnit | None = None,
+    ) -> list[_Location]:
         """ Returns an array with BaseAddressEntry and LocationEntry.
             No terminator entries.
 
@@ -265,12 +298,12 @@ class LocationLists:
             DWARFv5 debug_loclists one, and the target loclist
             contains indirect encodings.
         """
-        return [entry_translate[entry.entry_type](entry, cu)
+        return [entry_translate[entry.entry_type](entry, cu)  # type: ignore[arg-type] # ty: ignore[invalid-argument-type]
             for entry
             in struct_parse(self.structs.Dwarf_loclists_entries, self.stream)]
 
     # From V5 style entries to a LocationEntry/BaseAddressEntry
-    def _translate_entry_v5(self, entry, die):
+    def _translate_entry_v5(self, entry: Container, die: DIE) -> _Location:
         off: int = entry.entry_offset
         len: int = entry.entry_end_offset - off
         type: str = entry.entry_type
@@ -292,10 +325,10 @@ class LocationLists:
             raise DWARFError(False, "Unknown DW_LLE code: %s" % (type,))
 
     # Locviews is the dict, mapping locview offsets to corresponding loclist offsets
-    def _parse_locview_pairs(self, locviews):
+    def _parse_locview_pairs(self, locviews: Mapping[int, int]) -> list[LocationViewPair]:
         stream = self.stream
         list_offset: int | None = locviews.get(stream.tell(), None)
-        pairs = []
+        pairs: list[LocationViewPair] = []
         if list_offset is not None:
             while stream.tell() < list_offset:
                 pair = struct_parse(self.structs.Dwarf_locview_pair, stream)
@@ -310,18 +343,23 @@ class LocationParser:
         location lists in the .debug_loc section (represented as a
         list).
     """
-    def __init__(self, location_lists):
+    def __init__(self, location_lists: LocationLists | LocationListsPair | None) -> None:
         self.location_lists = location_lists
 
     @staticmethod
-    def attribute_has_location(attr, dwarf_version):
+    def attribute_has_location(attr: AttributeValue, dwarf_version: int) -> bool:
         """ Checks if a DIE attribute contains location information.
         """
         return (LocationParser._attribute_is_loclistptr_class(attr) and
                 (LocationParser._attribute_has_loc_expr(attr, dwarf_version) or
                  LocationParser._attribute_has_loc_list(attr, dwarf_version)))
 
-    def parse_from_attribute(self, attr, dwarf_version, die = None):
+    def parse_from_attribute(
+        self,
+        attr: AttributeValue,
+        dwarf_version: int,
+        die: DIE | None = None,
+    ) -> LocationExpr | list[_Location]:
         """ Parses a DIE attribute and returns either a LocationExpr or
             a list.
         """
@@ -329,6 +367,7 @@ class LocationParser:
             if self._attribute_has_loc_expr(attr, dwarf_version):
                 return LocationExpr(attr.value)
             elif self._attribute_has_loc_list(attr, dwarf_version):
+                assert self.location_lists is not None
                 return self.location_lists.get_location_list_at_offset(
                     attr.value, die)
                 # We don't yet know if the DIE context will be needed.
@@ -340,13 +379,13 @@ class LocationParser:
     #------ PRIVATE ------#
 
     @staticmethod
-    def _attribute_has_loc_expr(attr, dwarf_version):
+    def _attribute_has_loc_expr(attr: AttributeValue, dwarf_version: int) -> bool:
         return ((dwarf_version < 4 and attr.form.startswith('DW_FORM_block') and
             not attr.name == 'DW_AT_const_value') or
             attr.form == 'DW_FORM_exprloc')
 
     @staticmethod
-    def _attribute_has_loc_list(attr, dwarf_version):
+    def _attribute_has_loc_list(attr: AttributeValue, dwarf_version: int) -> bool:
         return (((dwarf_version < 4 and
                  attr.form in ('DW_FORM_data1', 'DW_FORM_data2', 'DW_FORM_data4', 'DW_FORM_data8') and
                  not attr.name == 'DW_AT_const_value') or
@@ -358,13 +397,13 @@ class LocationParser:
     # As for DW_AT_upper_bound/DW_AT_count, we've seen it in form DW_FORM_locexpr in a V5 binary. usually it's a constant,
     # but the constant sholdn't be misinterpreted as a loclist pointer.
     @staticmethod
-    def _attribute_is_constant(attr, dwarf_version):
+    def _attribute_is_constant(attr: AttributeValue, dwarf_version: int) -> bool:
         return (((dwarf_version >= 3 and attr.name == 'DW_AT_data_member_location') or
                  (attr.name in ('DW_AT_upper_bound', 'DW_AT_count'))) and
             attr.form in ('DW_FORM_data1', 'DW_FORM_data2', 'DW_FORM_data4', 'DW_FORM_data8', 'DW_FORM_sdata', 'DW_FORM_udata'))
 
     @staticmethod
-    def _attribute_is_loclistptr_class(attr):
+    def _attribute_is_loclistptr_class(attr: AttributeValue) -> bool:
         return (attr.name in ( 'DW_AT_location', 'DW_AT_string_length',
                                'DW_AT_const_value', 'DW_AT_return_addr',
                                'DW_AT_data_member_location',

--- a/elftools/dwarf/ranges.py
+++ b/elftools/dwarf/ranges.py
@@ -6,12 +6,22 @@
 # Eli Bendersky (eliben@gmail.com)
 # This code is in the public domain
 #-------------------------------------------------------------------------------
+from __future__ import annotations
+
 import os
-from typing import NamedTuple
+from typing import IO, TYPE_CHECKING, NamedTuple, NoReturn
 
 from ..common.utils import struct_parse
 from ..common.exceptions import DWARFError
 from .dwarf_util import _iter_CUs_in_section
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterator
+
+    from ..construct.lib.container import Container
+    from .compileunit import CompileUnit
+    from .dwarfinfo import DWARFInfo
+    from .structs import DWARFStructs
 
 
 class RangeEntry(NamedTuple):
@@ -28,18 +38,18 @@ class BaseAddressEntry(NamedTuple):
 
 # If we ever see a list with a base entry at the end, there will be an error that entry_length is not a field.
 
-def _translate_startx_length(e, cu):
+def _translate_startx_length(e: Container, cu: CompileUnit) -> RangeEntry:
     start_offset = cu.dwarfinfo.get_addr(cu, e.start_index)
     return RangeEntry(e.entry_offset, e.entry_length, start_offset, start_offset + e.length, True)
 
 # Maps parsed entry types to RangeEntry/BaseAddressEntry objects
-entry_translate = {
+entry_translate: dict[str, Callable[[Container, CompileUnit], RangeEntry | BaseAddressEntry]] = {
     'DW_RLE_base_address' : lambda e, cu: BaseAddressEntry(e.entry_offset, e.address),
     'DW_RLE_offset_pair'  : lambda e, cu: RangeEntry(e.entry_offset, e.entry_length, e.start_offset, e.end_offset, False),
     'DW_RLE_start_end'    : lambda e, cu: RangeEntry(e.entry_offset, e.entry_length, e.start_address, e.end_address, True),
     'DW_RLE_start_length' : lambda e, cu: RangeEntry(e.entry_offset, e.entry_length, e.start_address, e.start_address + e.length, True),
-    'DW_RLE_base_addressx': lambda e, cu: BaseAddressEntry(e.entry_offset, cu.dwarfinfo.get_addr(cu, e.index)),
-    'DW_RLE_startx_endx'  : lambda e, cu: RangeEntry(e.entry_offset, e.entry_length, cu.dwarfinfo.get_addr(cu, e.start_index), cu.dwarfinfo.get_addr(cu, e.end_index), True),
+    'DW_RLE_base_addressx': lambda e, cu: BaseAddressEntry(e.entry_offset, cu.dwarfinfo.get_addr(cu, e.index)),  # type: ignore[has-type]
+    'DW_RLE_startx_endx'  : lambda e, cu: RangeEntry(e.entry_offset, e.entry_length, cu.dwarfinfo.get_addr(cu, e.start_index), cu.dwarfinfo.get_addr(cu, e.end_index), True),  # type: ignore[has-type]
     'DW_RLE_startx_length': _translate_startx_length
 }
 
@@ -48,11 +58,21 @@ class RangeListsPair:
     it holds a RangeLists object for both and forwards API calls to the right one based
     on the CU version.
     """
-    def __init__(self, streamv4, streamv5, structs, dwarfinfo=None):
+    def __init__(
+        self,
+        streamv4: IO[bytes],
+        streamv5: IO[bytes],
+        structs: DWARFStructs,
+        dwarfinfo: DWARFInfo | None = None,
+    ) -> None:
         self._ranges = RangeLists(streamv4, structs, 4, dwarfinfo)
         self._rnglists = RangeLists(streamv5, structs, 5, dwarfinfo)
 
-    def get_range_list_at_offset(self, offset, cu=None):
+    def get_range_list_at_offset(
+        self,
+        offset: int,
+        cu: CompileUnit | None = None,
+    ) -> list[RangeEntry | BaseAddressEntry]:
         """Forwards the call to either v4 section or v5 one,
         depending on DWARF version in the CU.
         """
@@ -61,18 +81,18 @@ class RangeListsPair:
         section = self._rnglists if cu.header.version >= 5 else self._ranges
         return section.get_range_list_at_offset(offset, cu)
 
-    def get_range_list_at_offset_ex(self, offset):
+    def get_range_list_at_offset_ex(self, offset: int) -> Container:
         """Gets an untranslated v5 rangelist from the v5 section.
         """
         return self._rnglists.get_range_list_at_offset_ex(offset)
 
-    def iter_range_lists(self):
+    def iter_range_lists(self) -> NoReturn:
         """Tricky proposition, since the structure of ranges and rnglists
         is not identical. A realistic readelf implementation needs to be aware of both.
         """
         raise DWARFError("Iterating through two sections is not supported")
 
-    def iter_CUs(self):
+    def iter_CUs(self) -> Iterator[CompileUnit]:
         """See RangeLists.iter_CUs()
 
         CU structure is only present in DWARFv5 rnglists sections. A well written
@@ -80,7 +100,7 @@ class RangeListsPair:
         """
         return self._rnglists.iter_CUs()
 
-    def iter_CU_range_lists_ex(self, cu):
+    def iter_CU_range_lists_ex(self, cu: Container) -> Iterator[CompileUnit]:
         """See RangeLists.iter_CU_range_lists_ex()
 
         CU structure is only present in DWARFv5 rnglists sections. A well written
@@ -88,7 +108,11 @@ class RangeListsPair:
         """
         return self._rnglists.iter_CU_range_lists_ex(cu)
 
-    def translate_v5_entry(self, entry, cu):
+    def translate_v5_entry(
+        self,
+        entry: Container,
+        cu: CompileUnit,
+    ) -> RangeEntry | BaseAddressEntry:
         """Forwards a V5 entry translation request to the V5 section
         """
         return self._rnglists.translate_v5_entry(entry, cu)
@@ -105,14 +129,24 @@ class RangeLists:
         The dwarfinfo is needed for enumeration, because enumeration
         requires scanning the DIEs, because ranges may overlap, even on DWARF<=4
     """
-    def __init__(self, stream, structs, version, dwarfinfo):
+    def __init__(
+        self,
+        stream: IO[bytes],
+        structs: DWARFStructs,
+        version: int,
+        dwarfinfo: DWARFInfo | None,
+    ) -> None:
         self.stream = stream
         self.structs = structs
         self._max_addr = 2 ** (self.structs.address_size * 8) - 1
         self.version = version
         self._dwarfinfo = dwarfinfo
 
-    def get_range_list_at_offset(self, offset, cu=None):
+    def get_range_list_at_offset(
+        self,
+        offset: int,
+        cu: CompileUnit | None = None,
+    ) -> list[RangeEntry | BaseAddressEntry]:
         """ Get a range list at the given offset in the section.
 
             The cu argument is necessary if the ranges section is a
@@ -122,13 +156,13 @@ class RangeLists:
         self.stream.seek(offset, os.SEEK_SET)
         return self._parse_range_list_from_stream(cu)
 
-    def get_range_list_at_offset_ex(self, offset):
+    def get_range_list_at_offset_ex(self, offset: int) -> Container:
         """Get a DWARF v5 range list, addresses and offsets unresolved,
         at the given offset in the section
         """
         return struct_parse(self.structs.Dwarf_rnglists_entries, self.stream, offset)
 
-    def iter_range_lists(self):
+    def iter_range_lists(self) -> Iterator[list[RangeEntry | BaseAddressEntry]]:
         """ Yields all range lists found in the section according to readelf rules.
         Scans the DIEs for rangelist offsets, then pulls those.
         Returned rangelists are always translated into lists of BaseAddressEntry/RangeEntry objects.
@@ -145,7 +179,7 @@ class RangeLists:
         ver5 = self.version >= 5
         # This maps list offset to CU
         cu_map = {die.attributes['DW_AT_ranges'].value : cu
-            for cu in self._dwarfinfo.iter_CUs()
+            for cu in self._dwarfinfo.iter_CUs()  # type: ignore[union-attr] # ty: ignore[unresolved-attribute]
             for die in cu.iter_DIEs()
             if 'DW_AT_ranges' in die.attributes and (cu['version'] >= 5) == ver5}
         all_offsets = list(cu_map.keys())
@@ -154,16 +188,17 @@ class RangeLists:
         for offset in all_offsets:
             yield self.get_range_list_at_offset(offset, cu_map[offset])
 
-    def iter_CUs(self):
+    def iter_CUs(self) -> Iterator[CompileUnit]:
         """For DWARF5 returns an array of objects, where each one has an array of offsets
         """
         if self.version < 5:
             raise DWARFError("CU iteration in rnglists is not supported with DWARF<5")
 
+        assert self._dwarfinfo is not None
         structs = next(self._dwarfinfo.iter_CUs()).structs # Just pick one
         return _iter_CUs_in_section(self.stream, structs, structs.Dwarf_rnglists_CU_header)
 
-    def iter_CU_range_lists_ex(self, cu):
+    def iter_CU_range_lists_ex(self, cu: Container) -> Iterator[CompileUnit]:
         """For DWARF5, returns untranslated rangelists in the CU, where CU comes from iter_CUs above
         """
         stream = self.stream
@@ -171,7 +206,11 @@ class RangeLists:
         while stream.tell() < cu.offset_after_length + cu.unit_length:
             yield struct_parse(self.structs.Dwarf_rnglists_entries, stream)
 
-    def translate_v5_entry(self, entry, cu):
+    def translate_v5_entry(
+        self,
+        entry: Container,
+        cu: CompileUnit,
+    ) -> RangeEntry | BaseAddressEntry:
         """Translates entries in a DWARFv5 rangelist from raw parsed format to
         a list of BaseAddressEntry/RangeEntry, using the CU
         """
@@ -179,13 +218,17 @@ class RangeLists:
 
     #------ PRIVATE ------#
 
-    def _parse_range_list_from_stream(self, cu):
+    def _parse_range_list_from_stream(
+        self,
+        cu: CompileUnit | None,
+    ) -> list[RangeEntry | BaseAddressEntry]:
         if self.version >= 5:
+            assert cu is not None
             return list(entry_translate[entry.entry_type](entry, cu)
                 for entry
                 in struct_parse(self.structs.Dwarf_rnglists_entries, self.stream))
         else:
-            lst = []
+            lst: list[RangeEntry | BaseAddressEntry] = []
             while True:
                 entry_offset = self.stream.tell()
                 begin_offset = struct_parse(

--- a/elftools/dwarf/typeunit.py
+++ b/elftools/dwarf/typeunit.py
@@ -10,13 +10,18 @@ from __future__ import annotations
 
 from bisect import bisect_right
 from functools import cached_property
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from .die import DIE
 from ..common.utils import dwarf_assert
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from ..construct.lib.container import Container
     from .abbrevtable import AbbrevTable
+    from .dwarfinfo import DWARFInfo
+    from .structs import DWARFStructs
 
 
 class TypeUnit:
@@ -42,7 +47,14 @@ class TypeUnit:
         To get the top-level DIE describing the type unit, call the
         get_top_DIE method.
     """
-    def __init__(self, header, dwarfinfo, structs, tu_offset, tu_die_offset):
+    def __init__(
+        self,
+        header: Container,
+        dwarfinfo: DWARFInfo,
+        structs: DWARFStructs,
+        tu_offset: int,
+        tu_die_offset: int,
+    ) -> None:
         """ header:
                 TU header for this type unit
 
@@ -66,7 +78,7 @@ class TypeUnit:
 
         # A list of DIEs belonging to this TU.
         # This list is lazily constructed as DIEs are iterated over.
-        self._dielist = []
+        self._dielist: list[DIE] = []
         # A list of file offsets, corresponding (by index) to the DIEs
         # in `self._dielist`. This list exists separately from
         # `self._dielist` to make it binary searchable, enabling the
@@ -92,7 +104,7 @@ class TypeUnit:
         """
         return self.structs.dwarf_format
 
-    def get_abbrev_table(self):
+    def get_abbrev_table(self) -> AbbrevTable:
         """ Get the abbreviation table (AbbrevTable object) for this TU
         """
         return self._abbrev_table
@@ -101,7 +113,7 @@ class TypeUnit:
     def _abbrev_table(self) -> AbbrevTable:
         return self.dwarfinfo.get_abbrev_table(self['debug_abbrev_offset'])
 
-    def get_top_DIE(self):
+    def get_top_DIE(self) -> DIE:
         """ Get the top DIE (which is DW_TAG_type_unit entry) of this TU
         """
 
@@ -110,6 +122,7 @@ class TypeUnit:
         if self._diemap:
             return self._dielist[0]
 
+        assert self.dwarfinfo.debug_types_sec is not None
         top = DIE(
                 cu=self,
                 stream=self.dwarfinfo.debug_types_sec.stream,
@@ -132,13 +145,13 @@ class TypeUnit:
     def size(self) -> int:
         return self['unit_length'] + self.structs.initial_length_field_size()
 
-    def iter_DIEs(self):
+    def iter_DIEs(self) -> Iterator[DIE]:
         """ Iterate over all the DIEs in the TU, in order of their appearance.
             Note that null DIEs will also be returned.
         """
         return self._iter_DIE_subtree(self.get_top_DIE())
 
-    def iter_DIE_children(self, die):
+    def iter_DIE_children(self, die: DIE) -> Iterator[DIE]:
         """ Given a DIE, yields either its children, without null DIE list
             terminator, or nothing, if that DIE has no children.
 
@@ -187,10 +200,11 @@ class TypeUnit:
                 if child._terminator is None:
                     for _ in self.iter_DIE_children(child):
                         pass
+                    assert child._terminator is not None
 
                 cur_offset = child._terminator.offset + child._terminator.size
 
-    def get_DIE_from_refaddr(self, refaddr):
+    def get_DIE_from_refaddr(self, refaddr: int) -> DIE:
         """ Obtain a DIE contained in this CU from a reference.
             refaddr:
                 The offset into the .debug_info section, which must be
@@ -208,12 +222,12 @@ class TypeUnit:
 
     #------ PRIVATE ------#
 
-    def __getitem__(self, name):
+    def __getitem__(self, name: str) -> Any:
         """ Implement dict-like access to header entries
         """
         return self.header[name]
 
-    def _iter_DIE_subtree(self, die):
+    def _iter_DIE_subtree(self, die: DIE) -> Iterator[DIE]:
         """ Given a DIE, this yields it with its subtree including null DIEs
             (child list terminators).
         """
@@ -225,9 +239,10 @@ class TypeUnit:
         if die.has_children:
             for c in die.iter_children():
                 yield from die.cu._iter_DIE_subtree(c)
+            assert die._terminator is not None
             yield die._terminator
 
-    def _get_cached_DIE(self, offset):
+    def _get_cached_DIE(self, offset: int) -> DIE:
         """ Given a DIE offset, look it up in the cache.  If not present,
             parse the DIE and insert it into the cache.
 


### PR DESCRIPTION
More typing for `elftools.dwarf` from https://github.com/eliben/pyelftools/pull/611

- more or less the boring part as most special cases are exempted
- some `TypeVars` and `@overloads` will follow later.
- several variables can be `None` and thus require an explicit `assert` for type-checking.
- Some of these `assert`s duplicate what `dwarf_assert()` already checked, which may be converted into a . [typing.TypeGuard](https://docs.python.org/3/library/typing.html#typing.TypeGuard), but I have not yet done that. I leave that to some future work.