### PR TITLE
Convert to functools.cached_property

### DIFF
--- a/elftools/dwarf/callframe.py
+++ b/elftools/dwarf/callframe.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import copy
 import os
 from collections.abc import Iterator
+from functools import cached_property
 from typing import IO, TYPE_CHECKING, Any, Literal, NamedTuple, cast
 from warnings import warn
 
@@ -534,7 +535,6 @@ class CFIEntry:
         self.instructions = instructions
         self.offset = offset
         self.cie = cie
-        self._decoded_table: DecodedCallFrameTable | None = None
         self.augmentation_dict = augmentation_dict or {}
         self.augmentation_bytes = augmentation_bytes
 
@@ -543,15 +543,14 @@ class CFIEntry:
             DecodedCallFrameTable object representing it. See the documentation
             of that class to understand how to interpret the decoded table.
         """
-        if self._decoded_table is None:
-            self._decoded_table = self._decode_CFI_table()
-        return self._decoded_table
+        return self._decode_CFI_table
 
     def __getitem__(self, name: str) -> Any:
         """ Implement dict-like access to header entries
         """
         return self.header[name]
 
+    @cached_property
     def _decode_CFI_table(self) -> DecodedCallFrameTable:
         """ Decode the instructions contained in the given CFI entry and return
             a DecodedCallFrameTable.

--- a/elftools/dwarf/compileunit.py
+++ b/elftools/dwarf/compileunit.py
@@ -6,9 +6,17 @@
 # Eli Bendersky (eliben@gmail.com)
 # This code is in the public domain
 #-------------------------------------------------------------------------------
+from __future__ import annotations
+
 from bisect import bisect_right
+from functools import cached_property
+from typing import TYPE_CHECKING
+
 from .die import DIE
 from ..common.utils import dwarf_assert
+
+if TYPE_CHECKING:
+    from .abbrevtable import AbbrevTable
 
 
 class CompileUnit:
@@ -51,10 +59,6 @@ class CompileUnit:
         self.cu_offset = cu_offset
         self.cu_die_offset = cu_die_offset
 
-        # The abbreviation table for this CU. Filled lazily when DIEs are
-        # requested.
-        self._abbrev_table = None
-
         # A list of DIEs belonging to this CU.
         # This list is lazily constructed as DIEs are iterated over.
         self._dielist = []
@@ -74,10 +78,11 @@ class CompileUnit:
     def get_abbrev_table(self):
         """ Get the abbreviation table (AbbrevTable object) for this CU
         """
-        if self._abbrev_table is None:
-            self._abbrev_table = self.dwarfinfo.get_abbrev_table(
-                self['debug_abbrev_offset'])
         return self._abbrev_table
+
+    @cached_property
+    def _abbrev_table(self) -> AbbrevTable:
+        return self.dwarfinfo.get_abbrev_table(self['debug_abbrev_offset'])
 
     def get_top_DIE(self):
         """ Get the top DIE (which is either a DW_TAG_compile_unit or

--- a/elftools/dwarf/dwarfinfo.py
+++ b/elftools/dwarf/dwarfinfo.py
@@ -7,6 +7,7 @@
 # This code is in the public domain
 #-------------------------------------------------------------------------------
 from bisect import bisect_right
+from functools import cached_property
 from typing import IO, NamedTuple
 
 from ..construct.lib.container import Container
@@ -142,9 +143,6 @@ class DWARFInfo:
         self._cu_cache = []
         self._cu_offsets_map: list[int] = []
 
-        # DWARF v4 type units by sig8 - ordered dict created when needed
-        self._type_units_by_sig = None
-
     @property
     def has_debug_info(self) -> bool:
         """ Return whether this contains debug information.
@@ -203,7 +201,6 @@ class DWARFInfo:
             In DWARF v4 type units are identified by their appearance in the
             .debug_types section.
         """
-        self._parse_debug_types()
         tu = self._type_units_by_sig.get(sig8)
         if tu is None:
             raise KeyError("Signature %016x not found in .debug_types" % sig8)
@@ -273,7 +270,6 @@ class DWARFInfo:
             .debug_types section.
 
         """
-        self._parse_debug_types()
         tu = self._type_units_by_sig.get(sig8)
         if tu is None:
             raise KeyError("Signature %016x not found in .debug_types" % sig8)
@@ -505,31 +501,29 @@ class DWARFInfo:
 
             yield tu
 
-    def _parse_debug_types(self):
+    @cached_property
+    def _type_units_by_sig(self) -> dict[int, TypeUnit]:
         """ Check if the .debug_types section is previously parsed. If not,
             parse all TUs and store them in an ordered dict using their unique
             64-bit signature as the key.
 
             See .get_TU_by_sig8().
         """
-        if self._type_units_by_sig is not None:
-            return
-        self._type_units_by_sig = {}
-
         if self.debug_types_sec is None:
-            return
+            return {}
 
         # Parse all the Type Units in the types section for access by sig8
+        units = {}
         offset = 0
         while offset < self.debug_types_sec.size:
             tu = self._parse_TU_at_offset(offset)
             # Compute the offset of the next TU in the section. The unit_length
             # field of the TU header contains its size not including the length
             # field itself.
-            offset = (offset +
-                      tu['unit_length'] +
-                      tu.structs.initial_length_field_size())
-            self._type_units_by_sig[tu['signature']] = tu
+            offset += tu['unit_length'] + tu.structs.initial_length_field_size()
+            units[tu['signature']] = tu
+
+        return units
 
     def _cached_CU_at_offset(self, offset):
         """ Return the CU with unit header at the given offset into the

--- a/elftools/dwarf/lineprogram.py
+++ b/elftools/dwarf/lineprogram.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import os
 import copy
+from functools import cached_property
 from typing import IO, TYPE_CHECKING, Any, NamedTuple
 
 from ..common.utils import struct_parse, dwarf_assert
@@ -120,7 +121,6 @@ class LineProgram:
         self.structs = structs
         self.program_start_offset = program_start_offset
         self.program_end_offset = program_end_offset
-        self._decoded_entries: list[LineProgramEntry] | None = None
 
     def get_entries(self) -> list[LineProgramEntry]:
         """ Get the decoded entries for this line program. Return a list of
@@ -131,9 +131,7 @@ class LineProgram:
             state. The extra information is mainly for the purposes of display
             with readelf and debugging.
         """
-        if self._decoded_entries is None:
-            self._decoded_entries = self._decode_line_program()
-        return self._decoded_entries
+        return self._decode_line_program
 
     #------ PRIVATE ------#
 
@@ -142,6 +140,7 @@ class LineProgram:
         """
         return self.header[name]
 
+    @cached_property
     def _decode_line_program(self) -> list[LineProgramEntry]:
         entries = []
         state = LineState(self.header['default_is_stmt'])

--- a/elftools/dwarf/namelut.py
+++ b/elftools/dwarf/namelut.py
@@ -9,6 +9,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
+from functools import cached_property
 from typing import IO, TYPE_CHECKING, NamedTuple, TypeVar, overload
 
 from ..common.utils import struct_parse
@@ -73,14 +74,9 @@ class NameLUT(Mapping[str, NameLUTEntry]):
     """
 
     def __init__(self, stream: IO[bytes], size: int, structs: DWARFStructs) -> None:
-
         self._stream = stream
         self._size = size
         self._structs = structs
-        # entries are lazily loaded on demand.
-        self._entries: dict[str, NameLUTEntry] | None = None
-        # CU headers (for readelf).
-        self._cu_headers: list[Container] | None = None
 
     def get_entries(self) -> dict[str, NameLUTEntry]:
         """
@@ -92,8 +88,6 @@ class NameLUT(Mapping[str, NameLUTEntry]):
         entries. The returned entries can be pickled to a file and restored by
         calling set_entries on subsequent loads.
         """
-        if self._entries is None:
-            self._entries, self._cu_headers = self._get_entries()
         return self._entries
 
     def set_entries(self, entries: dict[str, NameLUTEntry], cu_headers: list[Container]) -> None:
@@ -113,8 +107,6 @@ class NameLUT(Mapping[str, NameLUTEntry]):
         """
         Returns the number of entries in the NameLUT.
         """
-        if self._entries is None:
-            self._entries, self._cu_headers = self._get_entries()
         return len(self._entries)
 
     def __getitem__(self, name: str) -> NameLUTEntry:
@@ -122,24 +114,18 @@ class NameLUT(Mapping[str, NameLUTEntry]):
         Returns a namedtuple - NameLUTEntry(cu_ofs, die_ofs) - that corresponds
         to the given symbol name.
         """
-        if self._entries is None:
-            self._entries, self._cu_headers = self._get_entries()
         return self._entries[name]
 
     def __iter__(self) -> Iterator[str]:
         """
         Returns an iterator to the NameLUT dictionary.
         """
-        if self._entries is None:
-            self._entries, self._cu_headers = self._get_entries()
         return iter(self._entries)
 
     def items(self) -> ItemsView[str, NameLUTEntry]:
         """
         Returns the NameLUT dictionary items.
         """
-        if self._entries is None:
-            self._entries, self._cu_headers = self._get_entries()
         return self._entries.items()
 
     @overload
@@ -151,25 +137,27 @@ class NameLUT(Mapping[str, NameLUTEntry]):
         Returns NameLUTEntry(cu_ofs, die_ofs) for the provided symbol name or
         None if the symbol does not exist in the corresponding section.
         """
-        if self._entries is None:
-            self._entries, self._cu_headers = self._get_entries()
         return self._entries.get(name, default)
 
     def get_cu_headers(self) -> list[Container]:
         """
         Returns all CU headers. Mainly required for readelf.
         """
-        if self._cu_headers is None:
-            self._entries, self._cu_headers = self._get_entries()
-
         return self._cu_headers
 
-    def _get_entries(self) -> tuple[dict[str, NameLUTEntry], list[Container]]:
-        """
-        Parse the (name, cu_ofs, die_ofs) information from this section and
-        store as a dictionary.
-        """
+    @cached_property
+    def _entries(self) -> dict[str, NameLUTEntry]:
+        return self.__entries[0]
 
+    @cached_property
+    def _cu_headers(self) -> list[Container]:
+        return self.__entries[1]
+
+    @cached_property
+    def __entries(self) -> tuple[dict[str, NameLUTEntry], list[Container]]:
+        """
+        Parse the (name, cu_ofs, die_ofs) information from this section.
+        """
         self._stream.seek(0)
         entries: dict[str, NameLUTEntry] = {}
         cu_headers: list[Container] = []

--- a/elftools/dwarf/typeunit.py
+++ b/elftools/dwarf/typeunit.py
@@ -6,9 +6,17 @@
 # Dinkar Khandalekar (contact@dinkar.dev)
 # This code is in the public domain
 #-------------------------------------------------------------------------------
+from __future__ import annotations
+
 from bisect import bisect_right
+from functools import cached_property
+from typing import TYPE_CHECKING
+
 from .die import DIE
 from ..common.utils import dwarf_assert
+
+if TYPE_CHECKING:
+    from .abbrevtable import AbbrevTable
 
 
 class TypeUnit:
@@ -56,10 +64,6 @@ class TypeUnit:
         self.tu_offset = tu_offset
         self.tu_die_offset = tu_die_offset
 
-        # The abbreviation table for this TU. Filled lazily when DIEs are
-        # requested.
-        self._abbrev_table = None
-
         # A list of DIEs belonging to this TU.
         # This list is lazily constructed as DIEs are iterated over.
         self._dielist = []
@@ -91,10 +95,11 @@ class TypeUnit:
     def get_abbrev_table(self):
         """ Get the abbreviation table (AbbrevTable object) for this TU
         """
-        if self._abbrev_table is None:
-            self._abbrev_table = self.dwarfinfo.get_abbrev_table(
-                self['debug_abbrev_offset'])
         return self._abbrev_table
+
+    @cached_property
+    def _abbrev_table(self) -> AbbrevTable:
+        return self.dwarfinfo.get_abbrev_table(self['debug_abbrev_offset'])
 
     def get_top_DIE(self):
         """ Get the top DIE (which is DW_TAG_type_unit entry) of this TU

--- a/elftools/ehabi/ehabiinfo.py
+++ b/elftools/ehabi/ehabiinfo.py
@@ -8,6 +8,7 @@
 # -------------------------------------------------------------------------------
 from __future__ import annotations
 
+from functools import cached_property
 from typing import TYPE_CHECKING
 
 from ..common.utils import struct_parse
@@ -36,7 +37,6 @@ class EHABIInfo:
     def __init__(self, arm_idx_section: Section, little_endian: bool) -> None:
         self._arm_idx_section = arm_idx_section
         self._struct = EHABIStructs(little_endian)
-        self._num_entry: int | None = None
 
     def section_name(self) -> str:
         return self._arm_idx_section.name
@@ -47,9 +47,11 @@ class EHABIInfo:
     def num_entry(self) -> int:
         """ Number of exception handler entry in the section.
         """
-        if self._num_entry is None:
-            self._num_entry = self._arm_idx_section['sh_size'] // EHABI_INDEX_ENTRY_SIZE
         return self._num_entry
+
+    @cached_property
+    def _num_entry(self) -> int:
+        return self._arm_idx_section['sh_size'] // EHABI_INDEX_ENTRY_SIZE
 
     def get_entry(self, n: int) -> EHABIEntry:
         """ Get the exception handler entry at index #n. (EHABIEntry object or a subclass)

--- a/elftools/elf/dynamic.py
+++ b/elftools/elf/dynamic.py
@@ -7,6 +7,7 @@
 # This code is in the public domain
 #-------------------------------------------------------------------------------
 import itertools
+from functools import cached_property
 
 from collections import defaultdict
 from .hash import ELFHashTable, GNUHashTable
@@ -261,65 +262,61 @@ class DynamicSegment(Segment, Dynamic):
         Dynamic.__init__(self, stream, elffile, stringtable, self['p_offset'],
              self['p_filesz'] == 0)
         self._symbol_size = self.elfstructs.Elf_Sym.sizeof()
-        self._num_symbols: int | None = None
-        self._symbol_name_map: dict[str, list[int]] | None = None
 
     def num_symbols(self) -> int:
         """ Number of symbols in the table recovered from DT_SYMTAB
         """
-        if self._num_symbols is not None:
-            return self._num_symbols
+        return self._num_symbols
 
+    @cached_property
+    def _num_symbols(self) -> int:
         # Check if a DT_GNU_HASH tag exists and recover the number of symbols
         # from the corresponding hash table
         _, gnu_hash_offset = self.get_table_offset('DT_GNU_HASH')
         if gnu_hash_offset is not None:
             hash_section = GNUHashTable(self.elffile, gnu_hash_offset, self)
-            self._num_symbols = hash_section.get_number_of_symbols()
+            return hash_section.get_number_of_symbols()
 
         # If DT_GNU_HASH did not exist, maybe we can use DT_HASH
-        if self._num_symbols is None:
-            _, hash_offset = self.get_table_offset('DT_HASH')
-            if hash_offset is not None:
-                # Get the hash table from the DT_HASH offset
-                hash_section = ELFHashTable(self.elffile, hash_offset, None, self)
-                self._num_symbols = hash_section.get_number_of_symbols()
+        _, hash_offset = self.get_table_offset('DT_HASH')
+        if hash_offset is not None:
+            # Get the hash table from the DT_HASH offset
+            hash_section = ELFHashTable(self.elffile, hash_offset, None, self)
+            return hash_section.get_number_of_symbols()
 
-        if self._num_symbols is None:
-            # Find closest higher pointer than tab_ptr. We'll use that to mark
-            # the end of the symbol table.
-            tab_ptr, tab_offset = self.get_table_offset('DT_SYMTAB')
-            if tab_ptr is None or tab_offset is None:
-                raise ELFError('Segment does not contain DT_SYMTAB.')
+        # Find closest higher pointer than tab_ptr. We'll use that to mark
+        # the end of the symbol table.
+        tab_ptr, tab_offset = self.get_table_offset('DT_SYMTAB')
+        if tab_ptr is None or tab_offset is None:
+            raise ELFError('Segment does not contain DT_SYMTAB.')
 
-            nearest_ptr: int | None = None
-            for tag in self.iter_tags():
-                tag_ptr = tag['d_ptr']
-                if tag['d_tag'] == 'DT_SYMENT':
-                    if self._symbol_size != tag['d_val']:
-                        # DT_SYMENT is the size of one symbol entry. It must be
-                        # the same as returned by Elf_Sym.sizeof.
-                        raise ELFError('DT_SYMENT (%d) != Elf_Sym (%d).' %
-                                       (tag['d_val'], self._symbol_size))
-                if (tag_ptr > tab_ptr and
-                        (nearest_ptr is None or nearest_ptr > tag_ptr)):
-                    nearest_ptr = tag_ptr
+        nearest_ptr: int | None = None
+        for tag in self.iter_tags():
+            tag_ptr = tag['d_ptr']
+            if tag['d_tag'] == 'DT_SYMENT':
+                if self._symbol_size != tag['d_val']:
+                    # DT_SYMENT is the size of one symbol entry. It must be
+                    # the same as returned by Elf_Sym.sizeof.
+                    raise ELFError('DT_SYMENT (%d) != Elf_Sym (%d).' %
+                                   (tag['d_val'], self._symbol_size))
+            if (tag_ptr > tab_ptr and
+                    (nearest_ptr is None or nearest_ptr > tag_ptr)):
+                nearest_ptr = tag_ptr
 
-            if nearest_ptr is None:
-                # Use the end of last segment that contains DT_SYMTAB (or ends on it)
-                for segment in self.elffile.iter_segments(type='PT_LOAD'):
-                    start = segment['p_vaddr']
-                    end = start + segment['p_filesz']
-                    if start <= tab_ptr <= end:
-                        nearest_ptr = end
+        if nearest_ptr is not None:
+            return (nearest_ptr - tab_ptr) // self._symbol_size
 
-            if nearest_ptr is not None:
-                self._num_symbols = (nearest_ptr - tab_ptr) // self._symbol_size
+        # Use the end of last segment that contains DT_SYMTAB (or ends on it)
+        for segment in self.elffile.iter_segments(type='PT_LOAD'):
+            start = segment['p_vaddr']
+            end = start + segment['p_filesz']
+            if start <= tab_ptr <= end:
+                nearest_ptr = end
 
-        if self._num_symbols is None:
-            raise ELFError('Cannot determine the end of DT_SYMTAB.')
+        if nearest_ptr is not None:
+            return (nearest_ptr - tab_ptr) // self._symbol_size
 
-        return self._num_symbols
+        raise ELFError('Cannot determine the end of DT_SYMTAB.')
 
     def get_symbol(self, index):
         """ Get the symbol at index #index from the table (Symbol object)
@@ -342,15 +339,15 @@ class DynamicSegment(Segment, Dynamic):
         """ Get a symbol(s) by name. Return None if no symbol by the given name
             exists.
         """
-        # The first time this method is called, construct a name to number
-        # mapping
-        #
-        if self._symbol_name_map is None:
-            self._symbol_name_map = defaultdict(list)
-            for i, sym in enumerate(self.iter_symbols()):
-                self._symbol_name_map[sym.name].append(i)
         symnums = self._symbol_name_map.get(name)
         return [self.get_symbol(i) for i in symnums] if symnums else None
+
+    @cached_property
+    def _symbol_name_map(self) -> dict[str, list[int]]:
+        smap = defaultdict(list)
+        for i, sym in enumerate(self.iter_symbols()):
+            smap[sym.name].append(i)
+        return smap
 
     def iter_symbols(self):
         """ Yield all symbols in this dynamic segment. The symbols are usually

--- a/elftools/elf/elffile.py
+++ b/elftools/elf/elffile.py
@@ -7,10 +7,11 @@
 # This code is in the public domain
 #-------------------------------------------------------------------------------
 import io
-from io import BytesIO
 import os
 import struct
 import zlib
+from functools import cached_property
+from io import BytesIO
 
 from ..common.exceptions import ELFError, ELFParseError
 from ..common.utils import struct_parse, elf_assert
@@ -84,8 +85,6 @@ class ELFFile:
         self.stream.seek(0)
         self.e_ident_raw = self.stream.read(16)
 
-        self._section_header_stringtable = None # Lazy load
-        self._section_name_map: dict[str, int] | None = None
         self.stream_loader = stream_loader
 
     @classmethod
@@ -181,11 +180,6 @@ class ELFFile:
         """ Get a section from the file, by name. Return None if no such
             section exists.
         """
-        # The first time this method is called, construct a name to number
-        # mapping
-        #
-        if self._section_name_map is None:
-            self._make_section_name_map()
         secnum = self._section_name_map.get(name, None)
         return None if secnum is None else self.get_section(secnum)
 
@@ -193,18 +187,11 @@ class ELFFile:
         """ Gets the index of the section by name. Return None if no such
             section name exists.
         """
-        # The first time this method is called, construct a name to number
-        # mapping
-        #
-        if self._section_name_map is None:
-            self._make_section_name_map()
         return self._section_name_map.get(section_name, None)
 
     def has_section(self, section_name: str) -> bool:
         """ Section existence check by name, without the overhead of parsing if found.
         """
-        if self._section_name_map is None:
-            self._make_section_name_map()
         return section_name in self._section_name_map
 
     def iter_sections(self, type=None):
@@ -713,11 +700,6 @@ class ELFFile:
         """ Given a section header, find this section's name in the file's
             string table
         """
-        if self._section_header_stringtable is None: # Try to lazy load
-            self._section_header_stringtable = self._get_section_header_stringtable()
-            if self._section_header_stringtable is None: # If absent (or badly malformed)
-                raise ELFParseError("String Table not found")
-
         name_offset = section_header['sh_name']
         return self._section_header_stringtable.get_string(name_offset)
 
@@ -764,10 +746,12 @@ class ELFFile:
         else:
             return Section(section_header, name, self)
 
-    def _make_section_name_map(self) -> None:
-        self._section_name_map = {}
-        for i, sec in enumerate(self.iter_sections()):
-            self._section_name_map[sec.name] = i
+    @cached_property
+    def _section_name_map(self) -> dict[str, int]:
+        return {
+            sec.name: i
+            for i, sec in enumerate(self.iter_sections())
+        }
 
     def _make_symbol_table_section(self, section_header, name):
         """ Create a SymbolTableSection
@@ -849,7 +833,8 @@ class ELFFile:
             self.stream,
             stream_pos=self._segment_offset(n))
 
-    def _get_section_header_stringtable(self):
+    @cached_property
+    def _section_header_stringtable(self) -> StringTableSection:
         """ Get the string table section corresponding to the section header
             table.
         """
@@ -857,7 +842,7 @@ class ELFFile:
 
         stringtable_section_header = self._get_section_header(stringtable_section_num)
         if stringtable_section_header is None:
-            return None
+            raise ELFParseError("String Table not found")
 
         return StringTableSection(
                 header=stringtable_section_header,

--- a/elftools/elf/gnuversions.py
+++ b/elftools/elf/gnuversions.py
@@ -6,6 +6,8 @@
 # Yann Rouillard (yann@pleiades.fr.eu.org)
 # This code is in the public domain
 #------------------------------------------------------------------------------
+from functools import cached_property
+
 from ..common.utils import struct_parse, elf_assert
 from .sections import Section, Symbol
 
@@ -132,22 +134,21 @@ class GNUVerNeedSection(GNUVersionSection):
         super().__init__(
                 header, name, elffile, stringtable, 'vn',
                 elffile.structs.Elf_Verneed, elffile.structs.Elf_Vernaux)
-        self._has_indexes: bool | None = None
 
     def has_indexes(self) -> bool:
         """ Return True if at least one version definition entry has an index
             that is stored in the vna_other field.
             This information is used for symbol versioning
         """
-        if self._has_indexes is None:
-            self._has_indexes = False
-            for _, vernaux_iter in self.iter_versions():
-                for vernaux in vernaux_iter:
-                    if vernaux['vna_other']:
-                        self._has_indexes = True
-                        break
-
         return self._has_indexes
+
+    @cached_property
+    def _has_indexes(self) -> bool:
+        return any(
+            vernaux['vna_other']
+            for _, vernaux_iter in self.iter_versions()
+            for vernaux in vernaux_iter
+        )
 
     def iter_versions(self):
         for verneed, vernaux in super().iter_versions():

--- a/elftools/elf/relocation.py
+++ b/elftools/elf/relocation.py
@@ -6,6 +6,7 @@
 # Eli Bendersky (eliben@gmail.com)
 # This code is in the public domain
 #-------------------------------------------------------------------------------
+from functools import cached_property
 from typing import Callable, NamedTuple
 
 from ..common.exceptions import ELFRelocationError
@@ -124,7 +125,6 @@ class RelrRelocationTable:
         self._size = size
         self._relr_struct = self._elffile.structs.Elf_Relr
         self._entrysize = self._relr_struct.sizeof()
-        self._cached_relocations = None
 
         elf_assert(self._entrysize == entrysize,
             'Expected RELR entry size to be %s, got %s' % (
@@ -182,16 +182,16 @@ class RelrRelocationTable:
     def num_relocations(self) -> int:
         """ Number of relocations in the section
         """
-        if self._cached_relocations is None:
-            self._cached_relocations = list(self.iter_relocations())
         return len(self._cached_relocations)
 
     def get_relocation(self, n):
         """ Get the relocation at index #n from the section (Relocation object)
         """
-        if self._cached_relocations is None:
-            self._cached_relocations = list(self.iter_relocations())
         return self._cached_relocations[n]
+
+    @cached_property
+    def _cached_relocations(self) -> list[Relocation]:
+        return list(self.iter_relocations())
 
 
 class RelrRelocationSection(Section, RelrRelocationTable):

--- a/elftools/elf/sections.py
+++ b/elftools/elf/sections.py
@@ -6,13 +6,14 @@
 # Eli Bendersky (eliben@gmail.com)
 # This code is in the public domain
 #-------------------------------------------------------------------------------
+from functools import cached_property
+import zlib
+
 from ..common.exceptions import ELFCompressionError
 from ..common.utils import struct_parse, elf_assert, parse_cstring_from_stream
 from collections import defaultdict
 from .constants import SH_FLAGS
 from .notes import iter_notes
-
-import zlib
 
 
 class Section:
@@ -176,7 +177,6 @@ class SymbolTableSection(Section):
                 'Expected entry size of section %r to be > 0' % name)
         elf_assert(self['sh_size'] % self['sh_entsize'] == 0,
                 'Expected section size to be a multiple of entry size in section %r' % name)
-        self._symbol_name_map: dict[str, list[int]] | None = None
 
     def num_symbols(self) -> int:
         """ Number of symbols in the table
@@ -200,15 +200,15 @@ class SymbolTableSection(Section):
         """ Get a symbol(s) by name. Return None if no symbol by the given name
             exists.
         """
-        # The first time this method is called, construct a name to number
-        # mapping
-        #
-        if self._symbol_name_map is None:
-            self._symbol_name_map = defaultdict(list)
-            for i, sym in enumerate(self.iter_symbols()):
-                self._symbol_name_map[sym.name].append(i)
         symnums = self._symbol_name_map.get(name)
         return [self.get_symbol(i) for i in symnums] if symnums else None
+
+    @cached_property
+    def _symbol_name_map(self) -> dict[str, list[int]]:
+        smap = defaultdict(list)
+        for i, sym in enumerate(self.iter_symbols()):
+            smap[sym.name].append(i)
+        return smap
 
     def iter_symbols(self):
         """ Yield all the symbols in the table

--- a/scripts/readelf.py
+++ b/scripts/readelf.py
@@ -7,12 +7,16 @@
 # Eli Bendersky (eliben@gmail.com)
 # This code is in the public domain
 #-------------------------------------------------------------------------------
+from __future__ import annotations
+
 import argparse
 import os
 import sys
 import re
 import traceback
 import itertools
+from functools import cached_property
+from typing import TYPE_CHECKING, TypedDict
 
 # For running from development directory. It should take precedence over the
 # installed pyelftools.
@@ -59,6 +63,17 @@ from elftools.dwarf.ranges import RangeEntry, BaseAddressEntry as RangeBaseAddre
 from elftools.dwarf.callframe import CIE, FDE, ZERO
 from elftools.ehabi.ehabiinfo import CorruptEHABIEntry, CannotUnwindEHABIEntry, GenericEHABIEntry
 from elftools.dwarf.enums import ENUM_DW_UT
+
+if TYPE_CHECKING:
+    from elftools.construct.lib.container import Container
+    from elftools.dwarf.dwarfinfo import DWARFInfo
+
+    class VersionInfo(TypedDict):
+        versym: GNUVerSymSection | None
+        verdef: GNUVerDefSection | None
+        verneed: GNUVerNeedSection | None
+        type: str | None
+
 
 def _get_cu_base(cu):
     top_die = cu.get_top_DIE()
@@ -107,13 +122,6 @@ class ReadElf:
         """
         self.elffile = ELFFile(file)
         self.output = output
-
-        # Lazily initialized if a debug dump is requested
-        self._dwarfinfo = None
-
-        self._versioninfo = None
-
-        self._shndx_sections = None
 
     def display_file_header(self) -> None:
         """ Display the ELF file header
@@ -428,8 +436,6 @@ class ReadElf:
     def display_symbol_tables(self) -> None:
         """ Display the symbol tables contained in the file
         """
-        self._init_versioninfo()
-
         symbol_tables = [(idx, s) for idx, s in enumerate(self.elffile.iter_sections())
                          if isinstance(s, SymbolTableSection)]
 
@@ -694,8 +700,6 @@ class ReadElf:
     def display_version_info(self) -> None:
         """ Display the version info contained in the file
         """
-        self._init_versioninfo()
-
         if not self._versioninfo['type']:
             self._emitline("\nNo version information found in this file.")
             return
@@ -898,7 +902,6 @@ class ReadElf:
     def display_debug_dump(self, dump_what: str) -> None:
         """ Dump a DWARF section
         """
-        self._init_dwarfinfo()
         if self._dwarfinfo is None:
             return
 
@@ -996,39 +999,36 @@ class ReadElf:
             )
         )
 
-    def _init_versioninfo(self) -> None:
+    @cached_property
+    def _versioninfo(self) -> VersionInfo:
         """ Search and initialize informations about version related sections
             and the kind of versioning used (GNU or Solaris).
         """
-        if self._versioninfo is not None:
-            return
-
-        self._versioninfo = {'versym': None, 'verdef': None,
+        info = {'versym': None, 'verdef': None,
                              'verneed': None, 'type': None}
 
         for section in self.elffile.iter_sections():
             if isinstance(section, GNUVerSymSection):
-                self._versioninfo['versym'] = section
+                info['versym'] = section
             elif isinstance(section, GNUVerDefSection):
-                self._versioninfo['verdef'] = section
+                info['verdef'] = section
             elif isinstance(section, GNUVerNeedSection):
-                self._versioninfo['verneed'] = section
+                info['verneed'] = section
             elif isinstance(section, DynamicSection):
                 for tag in section.iter_tags():
                     if tag['d_tag'] == 'DT_VERSYM':
-                        self._versioninfo['type'] = 'GNU'
+                        info['type'] = 'GNU'
                         break
 
-        if not self._versioninfo['type'] and (
-                self._versioninfo['verneed'] or self._versioninfo['verdef']):
-            self._versioninfo['type'] = 'Solaris'
+        if not info['type'] and (info['verneed'] or info['verdef']):
+            info['type'] = 'Solaris'
+
+        return info
 
     def _symbol_version(self, nsym):
         """ Return a dict containing information on the
             or None if no version information is available
         """
-        self._init_versioninfo()
-
         symbol_version = dict.fromkeys(('index', 'name', 'filename', 'hidden'))
 
         if (not self._versioninfo['versym'] or
@@ -1084,12 +1084,15 @@ class ReadElf:
         if symbol_shndx != SHN_INDICES.SHN_XINDEX:
             return symbol_shndx
 
-        # Check for or lazily construct index section mapping (symbol table
-        # index -> corresponding symbol table index section object)
-        if self._shndx_sections is None:
-            self._shndx_sections = {sec.symboltable: sec for sec in self.elffile.iter_sections()
-                                    if isinstance(sec, SymbolTableIndexSection)}
         return self._shndx_sections[symtab_index].get_section_index(symbol_index)
+
+    @cached_property
+    def _shndx_sections(self) -> dict[Container, SymbolTableIndexSection]:
+        return  {
+            sec.symboltable: sec
+            for sec in self.elffile.iter_sections()
+            if isinstance(sec, SymbolTableIndexSection)
+        }
 
     def _note_relocs_for_section(self, section):
         """ If there are relocation sections pointing to the givne section,
@@ -1102,18 +1105,12 @@ class ReadElf:
                     self._emitline('  Note: This section has relocations against it, but these have NOT been applied to this dump.')
                     return
 
-    def _init_dwarfinfo(self) -> None:
-        """ Initialize the DWARF info contained in the file and assign it to
-            self._dwarfinfo.
+    @cached_property
+    def _dwarfinfo(self) -> DWARFInfo | None:
+        """ Initialize the DWARF info contained in the file.
             Leave self._dwarfinfo at None if no DWARF info was found in the file
         """
-        if self._dwarfinfo is not None:
-            return
-
-        if self.elffile.has_dwarf_info():
-            self._dwarfinfo = self.elffile.get_dwarf_info()
-        else:
-            self._dwarfinfo = None
+        return self.elffile.get_dwarf_info() if self.elffile.has_dwarf_info() else None
 
     def _dump_debug_info(self) -> None:
         """ Dump the debugging info section.

--- a/test/test_get_section_index.py
+++ b/test/test_get_section_index.py
@@ -41,8 +41,6 @@ class TestGetSectionIndex(unittest.TestCase):
                                'simple_gcc.elf.arm'), 'rb') as f:
             elf = ELFFile(f)
 
-            elf._section_name_map = None
-
             # Find the symbol table.
             data_section_index = elf.get_section_index('.data')
             self.assertIsNotNone(data_section_index)


### PR DESCRIPTION
While working on #650 and #651 I noticed a reoccurring topic: there are several private variables, which are used to lazy evaluate and then cache certain things. They are initialized with `None` in `__init__()`, which then requires many checks for `is not None`. This gets worse with type-checking as type-checkers require explicit `assert is not None`s to narrow down those union types.

Luckily there is [functools.cached_property](https://docs.python.org/3/library/functools.html#functools.cached_property), which automates those cases: Instead of manually lazy-loading some variables, use `functools.cached_property` to get this for free: `AttributeError` on `__dict__` is handled by [`__getattr__()`](https://docs.python.org/3/reference/datamodel.html#object.__getattr__), which then calls the registered function once and stored the result back in `__dict__`, so the value is there for all future uses.

This reduces duplicate code, type annotations and saves several (future) `assert`s.