### PR TITLE
Fix elftools/elf/dynamic.DynamicSegment.num_symbols()

### DIFF
--- a/elftools/elf/dynamic.py
+++ b/elftools/elf/dynamic.py
@@ -291,6 +291,7 @@ class DynamicSegment(Segment, Dynamic):
             tab_ptr, tab_offset = self.get_table_offset('DT_SYMTAB')
             if tab_ptr is None or tab_offset is None:
                 raise ELFError('Segment does not contain DT_SYMTAB.')
+
             nearest_ptr: int | None = None
             for tag in self.iter_tags():
                 tag_ptr = tag['d_ptr']
@@ -305,11 +306,12 @@ class DynamicSegment(Segment, Dynamic):
                     nearest_ptr = tag_ptr
 
             if nearest_ptr is None:
-                # Use the end of segment that contains DT_SYMTAB.
-                for segment in self.elffile.iter_segments():
-                    if (segment['p_vaddr'] <= tab_ptr and
-                            tab_ptr <= (segment['p_vaddr'] + segment['p_filesz'])):
-                        nearest_ptr = segment['p_vaddr'] + segment['p_filesz']
+                # Use the end of last segment that contains DT_SYMTAB (or ends on it)
+                for segment in self.elffile.iter_segments(type='PT_LOAD'):
+                    start = segment['p_vaddr']
+                    end = start + segment['p_filesz']
+                    if start <= tab_ptr <= end:
+                        nearest_ptr = end
 
             if nearest_ptr is not None:
                 self._num_symbols = (nearest_ptr - tab_ptr) // self._symbol_size

--- a/elftools/elf/dynamic.py
+++ b/elftools/elf/dynamic.py
@@ -311,8 +311,8 @@ class DynamicSegment(Segment, Dynamic):
                             tab_ptr <= (segment['p_vaddr'] + segment['p_filesz'])):
                         nearest_ptr = segment['p_vaddr'] + segment['p_filesz']
 
-            end_ptr = nearest_ptr
-            self._num_symbols = (end_ptr - tab_ptr) // self._symbol_size
+            if nearest_ptr is not None:
+                self._num_symbols = (nearest_ptr - tab_ptr) // self._symbol_size
 
         if self._num_symbols is None:
             raise ELFError('Cannot determine the end of DT_SYMTAB.')

--- a/elftools/elf/dynamic.py
+++ b/elftools/elf/dynamic.py
@@ -357,4 +357,4 @@ class DynamicSegment(Segment, Dynamic):
             This method reads from the mandatory dynamic tag DT_SYMTAB.
         """
         for i in range(self.num_symbols()):
-            yield(self.get_symbol(i))
+            yield self.get_symbol(i)


### PR DESCRIPTION
Part of #652 to fix the error calculating the number of symbols for "ultra stripped binaries" introduced by #219: In `elftools/elf/dynamic.py`: `DynamicSegment.num_symbols()` there an `if nearest_ptr is not None:` missing before the `return (nearest_ptr - tab_ptr) // self._symbol_size`.

---

The fallback to "Use the end of segment that contains DT_SYMTAB." also looked fishy:

```python
# Use the end of segment that contains DT_SYMTAB.
for segment in self.elffile.iter_segments():
    if (segment['p_vaddr'] <= tab_ptr and
            tab_ptr <= (segment['p_vaddr'] + segment['p_filesz'])):
        nearest_ptr = segment['p_vaddr'] + segment['p_filesz']
```

`ptr <= end` is used here since  687baa0cd6be158a32756fc7dd475e0e7f98f4d2, so `nearest_ptr` may point exactly at/after the end of a segment. That's not my definition of "contains", but maybe someone other knows this to be correct.

The [ELF spec](https://refspecs.linuxbase.org/elf/gabi4+/ch5.pheader.html) only guarantees, that
> Loadable segment entries in the program header table appear in ascending order, sorted on the `p_vaddr` member.

But there is no guarantee, that _segments may not overlap_.
I hope that heuristic here is required seldom enough that the current implementation is okay and that `pyelftools` is not used to analyze malicious binaries.

---

Maybe `PT_LOAD` should also be checked for as `iter_segments()` will walk all segments, not just which are loadable only?