### PR TITLE
Minor typing cleanups

### DIFF
--- a/elftools/dwarf/lineprogram.py
+++ b/elftools/dwarf/lineprogram.py
@@ -96,7 +96,7 @@ class LineProgram:
         stream: IO[bytes],
         structs: DWARFStructs,
         program_start_offset: int,
-            program_end_offset: int,
+        program_end_offset: int,
     ) -> None:
         """
             header:

--- a/elftools/elf/descriptions.py
+++ b/elftools/elf/descriptions.py
@@ -288,10 +288,11 @@ def describe_note_gnu_property_bitmap_and(
     prefix: str,
     value: int,
 ) -> str:
-    descs = []
-    for mask, desc in values:
-        if value & mask:
-            descs.append(desc)
+    descs = [
+        desc
+        for mask, desc in values
+        if value & mask
+    ]
     return '%s: %s' % (prefix, ', '.join(descs))
 
 def describe_note_gnu_properties(properties: list[Container], machine: str) -> str:

--- a/elftools/elf/dynamic.py
+++ b/elftools/elf/dynamic.py
@@ -273,12 +273,14 @@ class DynamicSegment(Segment, Dynamic):
         # So we must look for the dynamic section contained in the dynamic
         # segment, we do so by searching for the dynamic section whose content
         # is located at the same offset as the dynamic segment
-        stringtable = None
-        for section in elffile.iter_sections():
-            if (isinstance(section, DynamicSection) and
-                    section['sh_offset'] == header['p_offset']):
-                stringtable = elffile.get_section(section['sh_link'])
-                break
+        stringtable = next(
+            (
+                elffile.get_section(section['sh_link'])
+                for section in elffile.iter_sections()
+                if isinstance(section, DynamicSection) and section['sh_offset'] == header['p_offset']
+            ),
+            None,
+        )
         Segment.__init__(self, header, stream)
         Dynamic.__init__(self, stream, elffile, stringtable, self['p_offset'],
              self['p_filesz'] == 0)

--- a/elftools/elf/dynamic.py
+++ b/elftools/elf/dynamic.py
@@ -127,16 +127,17 @@ class Dynamic:
     def get_table_offset(self, tag_name: str) -> tuple[int | None, int | None]:
         """ Return the virtual address and file offset of a dynamic table.
         """
-        ptr: int | None = None
-        for tag in self._iter_tags(type=tag_name):
-            ptr = tag['d_ptr']
-            break
+        try:
+            ptr: int = next(
+                tag['d_ptr']
+                for tag in self._iter_tags(type=tag_name)
+            )
+        except StopIteration:
+            return (None, None)
 
         # If we found a virtual address, locate the offset in the file
         # by using the program headers.
-        offset: int | None = None
-        if ptr:
-            offset = next(self.elffile.address_offsets(ptr), None)
+        offset = next(self.elffile.address_offsets(ptr), None)
 
         return ptr, offset
 

--- a/elftools/elf/elffile.py
+++ b/elftools/elf/elffile.py
@@ -157,7 +157,6 @@ class ELFFile:
         # member of the initial entry contains 0)."
         if self['e_shnum'] == 0:
             section_header = self._get_section_header(0)
-            assert section_header is not None
             return section_header['sh_size']
         return self['e_shnum']
 
@@ -640,7 +639,6 @@ class ELFFile:
             return self['e_shstrndx']
         else:
             section_header = self._get_section_header(0)
-            assert section_header is not None
             return section_header['sh_link']
 
     #-------------------------------- PRIVATE --------------------------------#
@@ -705,13 +703,14 @@ class ELFFile:
         else:
             return Segment(segment_header, self.stream)
 
-    def _get_section_header(self, n: int) -> Container | None:
+    def _get_section_header(self, n: int) -> Container:
         """ Find the header of section #n, parse it and return the struct
         """
 
         stream_pos = self._section_offset(n)
         if stream_pos > self.stream_len:
-            return None
+            msg = f"Reading section {n} at offset {stream_pos} past EOF {self.stream_len}"
+            raise ELFParseError(msg)
 
         return struct_parse(
             self.structs.Elf_Shdr,
@@ -874,9 +873,10 @@ class ELFFile:
         """
         stringtable_section_num = self.get_shstrndx()
 
-        stringtable_section_header = self._get_section_header(stringtable_section_num)
-        if stringtable_section_header is None:
-            raise ELFParseError("String Table not found")
+        try:
+            stringtable_section_header = self._get_section_header(stringtable_section_num)
+        except ELFParseError as ex:
+            raise ELFParseError("String Table not found") from ex
 
         return StringTableSection(
                 header=stringtable_section_header,

--- a/examples/dwarf_location_info.py
+++ b/examples/dwarf_location_info.py
@@ -93,15 +93,11 @@ def show_loclist(loclist, dwarfinfo, indent, cu_offset):
     """ Display a location list nicely, decoding the DWARF expressions
         contained within.
     """
-    d = []
-    for loc_entity in loclist:
-        if isinstance(loc_entity, LocationEntry):
-            d.append('%s <<%s>>' % (
-                loc_entity,
-                describe_DWARF_expr(loc_entity.loc_expr, dwarfinfo.structs, cu_offset)))
-        else:
-            d.append(str(loc_entity))
-    return '\n'.join(indent + s for s in d)
+    return "\n".join(
+        f"{indent}{loc_entity}"
+        f"{f' <<{describe_DWARF_expr(loc_entity.loc_expr, dwarfinfo.structs, cu_offset)}>>' if isinstance(loc_entity, LocationEntry) else ''}"
+        for loc_entity in loclist
+    )
 
 if __name__ == '__main__':
     if sys.argv[1] == '--test':

--- a/scripts/readelf.py
+++ b/scripts/readelf.py
@@ -1581,14 +1581,14 @@ class ReadElf:
         # Scroll through DIEs once, list the known location list offsets.
         # Don't need this CU/DIE scan if all entries are absolute or prefixed by base,
         # but let's not optimize for that yet.
-        cu_map = dict() # Loc list offset => CU
-        for cu in di.iter_CUs():
-            for die in cu.iter_DIEs():
-                for key in die.attributes:
-                    attr = die.attributes[key]
-                    if (LocationParser.attribute_has_location(attr, cu['version']) and
-                        LocationParser._attribute_has_loc_list(attr, cu['version'])):
-                        cu_map[attr.value] = cu
+        cu_map = {  # Loc list offset => CU
+            attr.value: cu
+            for cu in di.iter_CUs()
+            for die in cu.iter_DIEs()
+            for attr in die.attributes.values()
+            if (LocationParser.attribute_has_location(attr, cu['version']) and
+                LocationParser._attribute_has_loc_list(attr, cu['version']))
+        }
 
         addr_size = di.config.default_address_size # In bytes, 4 or 8
         addr_width = addr_size * 2 # In hex digits, 8 or 16


### PR DESCRIPTION
1. I missed one wrong indentation from #649.
2. Otherwise several conversions to list-/dict-comprehensions and generator-expressions; this saves some explicit typing.
3. And using `next(…, None)` to get the 1st element instead of using `for … in …: …; break`
