### PR TITLE
Typing `readelf` and `dwarfdump`

### DIFF
--- a/scripts/dwarfdump.py
+++ b/scripts/dwarfdump.py
@@ -13,10 +13,13 @@
 # Eli Bendersky (eliben@gmail.com)
 # This code is in the public domain
 #-------------------------------------------------------------------------------
+from __future__ import annotations
+
 import argparse
 import os
 import sys
 import traceback
+from typing import IO, TYPE_CHECKING, overload
 
 # For running from development directory. It should take precedence over the
 # installed pyelftools.
@@ -34,10 +37,15 @@ from elftools.dwarf.dwarf_expr import DWARFExprParser, DWARFExprOp
 from elftools.dwarf.datatype_cpp import describe_cpp_datatype
 from elftools.dwarf.descriptions import describe_reg_name
 
+if TYPE_CHECKING:
+    from elftools.dwarf.compileunit import CompileUnit
+    from elftools.dwarf.die import DIE
+
+
 # ------------------------------
 # ------------------------------
 
-def _get_cu_base(cu):
+def _get_cu_base(cu: CompileUnit):
     top_die = cu.get_top_DIE()
     attr = top_die.attributes
     if 'DW_AT_low_pc' in attr:
@@ -47,10 +55,10 @@ def _get_cu_base(cu):
     else:
         raise ValueError("Can't find the base IP (low_pc) for a CU")
 
-def _addr_str_length(die):
+def _addr_str_length(die: DIE) -> int:
     return die.cu.header.address_size*2
 
-def _DIE_name(die):
+def _DIE_name(die: DIE) -> str:
     if 'DW_AT_name' in die.attributes:
         return bytes2str(die.attributes['DW_AT_name'].value)
     elif 'DW_AT_linkage_name' in die.attributes:
@@ -58,7 +66,7 @@ def _DIE_name(die):
     else:
         raise DWARFError()
 
-def _DIE_linkage_name(die):
+def _DIE_linkage_name(die: DIE) -> str:
     if 'DW_AT_linkage_name' in die.attributes:
         return bytes2str(die.attributes['DW_AT_linkage_name'].value)
     elif 'DW_AT_name' in die.attributes:
@@ -66,7 +74,11 @@ def _DIE_linkage_name(die):
     else:
         raise DWARFError()
 
-def _safe_DIE_name(die, default=None):
+@overload
+def _safe_DIE_name(die: DIE, default: str) -> str: ...
+@overload
+def _safe_DIE_name(die: DIE) -> str | None: ...
+def _safe_DIE_name(die: DIE, default: str | None = None) -> str | None:
     if 'DW_AT_name' in die.attributes:
         return bytes2str(die.attributes['DW_AT_name'].value)
     elif 'DW_AT_linkage_name' in die.attributes:
@@ -74,7 +86,11 @@ def _safe_DIE_name(die, default=None):
     else:
         return default
 
-def _safe_DIE_linkage_name(die, default=None):
+@overload
+def _safe_DIE_linkage_name(die: DIE, default: str) -> str: ...
+@overload
+def _safe_DIE_linkage_name(die: DIE) -> str | None: ...
+def _safe_DIE_linkage_name(die: DIE, default: str | None = None) -> str | None:
     if 'DW_AT_linkage_name' in die.attributes:
         return bytes2str(die.attributes['DW_AT_linkage_name'].value)
     elif 'DW_AT_name' in die.attributes:
@@ -82,7 +98,7 @@ def _safe_DIE_linkage_name(die, default=None):
     else:
         return default
 
-def _desc_ref(attr, die, extra=''):
+def _desc_ref(attr, die: DIE, extra: str = '') -> str:
     if extra:
         extra = " \"%s\"" % extra
     if attr.form == 'DW_FORM_ref_addr':
@@ -96,13 +112,13 @@ def _desc_ref(attr, die, extra=''):
         die.cu.cu_offset + attr.raw_value,
         extra)
 
-def _desc_data(attr, die):
+def _desc_data(attr, die: DIE) -> str:
     """ Hex with length driven by form
     """
     len = int(attr.form[12:]) * 2
     return "0x%0*x" % (len, attr.value,)
 
-def _desc_strx(attr, die):
+def _desc_strx(attr, die: DIE) -> str:
     return "indexed (%08x) string = \"%s\"" % (attr.raw_value, bytes2str(attr.value).replace("\\", "\\\\"))
 
 FORM_DESCRIPTIONS = dict(
@@ -137,10 +153,10 @@ def _desc_enum(attr, enum: dict[str, int]) -> str:
     """
     return next((k for (k, v) in enum.items() if v == attr.value), str(attr.value))
 
-def _cu_comp_dir(cu):
+def _cu_comp_dir(cu: CompileUnit) -> str:
     return bytes2str(cu.get_top_DIE().attributes['DW_AT_comp_dir'].value)
 
-def _desc_decl_file(attr, die):
+def _desc_decl_file(attr, die: DIE) -> str:
     # Filename/dirname arrays are 0 based in DWARFv5
     cu = die.cu
     if not hasattr(cu, "_lineprogram"):
@@ -163,7 +179,7 @@ def _desc_decl_file(attr, die):
     return "\"%s\"" % (os.path.join(dir, file_name),)
 
 
-def _desc_ranges(attr, die):
+def _desc_ranges(attr, die: DIE) -> str:
     di = die.cu.dwarfinfo
     if not hasattr(di, '_rnglists'):
         di._rangelists = di.range_lists()
@@ -185,7 +201,7 @@ def _desc_ranges(attr, die):
     prefix = "indexed (0x%x) rangelist = " % attr.raw_value if attr.form == 'DW_FORM_rnglistx' else ''
     return ("%s0x%08x\n" % (prefix, attr.value)) + "\n".join(lines)
 
-def _desc_locations(attr, die):
+def _desc_locations(attr, die: DIE) -> str:
     cu = die.cu
     di = cu.dwarfinfo
     if not hasattr(di, '_loclists'):
@@ -215,7 +231,7 @@ def _desc_locations(attr, die):
         return ("%s0x%08x:\n" % (prefix, attr.value)) + "\n".join(lines)
 
 # By default, numeric arguments are spelled in hex with a leading 0x
-def _desc_operationarg(s, cu):
+def _desc_operationarg(s: str | int | list, cu: CompileUnit) -> str:
     if isinstance(s, str):
         return s
     elif isinstance(s, int):
@@ -226,14 +242,14 @@ def _desc_operationarg(s, cu):
         else:
             return " ".join((hex(len(s)), *("0x%02x" % b for b in s)))
 
-def _arch(cu):
+def _arch(cu: CompileUnit) -> str:
     return cu.dwarfinfo.config.machine_arch
 
-def _desc_reg(reg_no, cu):
+def _desc_reg(reg_no: int, cu: CompileUnit) -> str:
     reg_name = describe_reg_name(reg_no, _arch(cu), False)
     return reg_name.upper() if reg_name else ""
 
-def _desc_operation(op, op_name, args, cu):
+def _desc_operation(op, op_name: str, args, cu: CompileUnit) -> str:
     # Not sure about regx(regno) and bregx(regno, offset)
     if 0x50 <= op <= 0x6f: # reg0...reg31 - decode reg name
         return op_name + " " + _desc_reg(op - 0x50, cu)
@@ -276,7 +292,7 @@ UNSUPPORTED_OPS = (
     'DW_OP_GNU_convert',
     'DW_OP_GNU_regval_type')
 
-def _desc_expression(expr, die):
+def _desc_expression(expr, die: DIE) -> str:
     cu = die.cu
     if not hasattr(cu, '_exprparser'):
         cu._exprparser = DWARFExprParser(cu.structs)
@@ -292,12 +308,12 @@ def _desc_expression(expr, die):
         lines.append("<decoding error> " + " ".join("%02x" % b for b in expr[start_of_unparsed:]))
     return ", ".join(lines)
 
-def _desc_datatype(attr, die):
+def _desc_datatype(attr, die: DIE) -> str:
     """Oy vey
     """
     return _desc_ref(attr, die, describe_cpp_datatype(die))
 
-def _get_origin_name(die):
+def _get_origin_name(die: DIE) -> str:
     func_die = die.get_DIE_from_attribute('DW_AT_abstract_origin')
     name = _safe_DIE_linkage_name(func_die, '')
     if not name:
@@ -307,14 +323,14 @@ def _get_origin_name(die):
             return _get_origin_name(func_die)
     return name
 
-def _desc_origin(attr, die):
+def _desc_origin(attr, die: DIE) -> str:
     return _desc_ref(attr, die, _get_origin_name(die))
 
-def _desc_spec(attr, die):
+def _desc_spec(attr, die: DIE) -> str:
     return _desc_ref(attr, die,
         _DIE_linkage_name(die.get_DIE_from_attribute('DW_AT_specification')))
 
-def _desc_value(attr, die):
+def _desc_value(attr, die: DIE) -> str:
     return str(attr.value)
 
 ATTR_DESCRIPTIONS = dict(
@@ -342,7 +358,7 @@ class ReadElf:
     """ dump_xxx is used to dump the respective section.
     Mimics the output of dwarfdump with --verbose
     """
-    def __init__(self, filename, file, output):
+    def __init__(self, filename: str, file: IO[bytes], output: IO[str]) -> None:
         """ file:
                 stream object with the ELF file to read
 
@@ -408,7 +424,7 @@ class ReadElf:
                     parent = die.get_parent()
                 self._emitline()
 
-    def describe_attr_value(self, die, attr):
+    def describe_attr_value(self, die: DIE, attr) -> str:
         """This describes the attribute value in the way that's compatible
         with llvm_dwarfdump. Somewhat duplicates the work of describe_attr_value() in descriptions
         """
@@ -428,7 +444,7 @@ class ReadElf:
     def dump_ranges(self) -> None:
         pass
 
-    def dump_v4_rangelist(self, rangelist, cu_map):
+    def dump_v4_rangelist(self, rangelist, cu_map) -> None:
         cu = cu_map[rangelist[0].entry_offset]
         addr_str_len = cu.header.address_size*2
         base_ip = _get_cu_base(cu)
@@ -447,6 +463,7 @@ class ReadElf:
     def dump_rnglists(self) -> None:
         self._emitline(".debug_rnglists contents:")
         ranges_sec = self._dwarfinfo.range_lists()
+        assert ranges_sec is not None
         if ranges_sec.version < 5:
             return
 
@@ -511,7 +528,7 @@ class ReadElf:
 SCRIPT_DESCRIPTION = 'Display information about the contents of ELF format files'
 VERSION_STRING = '%%(prog)s: based on pyelftools %s' % __version__
 
-def main(stream=None):
+def main(stream: IO[str] | None = None) -> None:
     # parse the command-line arguments and invoke ReadElf
     argparser = argparse.ArgumentParser(
             usage='usage: %(prog)s [options] <elf-file>',

--- a/scripts/readelf.py
+++ b/scripts/readelf.py
@@ -16,7 +16,7 @@ import re
 import traceback
 import itertools
 from functools import cached_property
-from typing import TYPE_CHECKING, TypedDict
+from typing import IO, TYPE_CHECKING, TypedDict
 
 # For running from development directory. It should take precedence over the
 # installed pyelftools.
@@ -66,7 +66,9 @@ from elftools.dwarf.enums import ENUM_DW_UT
 
 if TYPE_CHECKING:
     from elftools.construct.lib.container import Container
+    from elftools.dwarf.compileunit import CompileUnit
     from elftools.dwarf.dwarfinfo import DWARFInfo
+    from elftools.elf.sections import Section
 
     class VersionInfo(TypedDict):
         versym: GNUVerSymSection | None
@@ -74,8 +76,14 @@ if TYPE_CHECKING:
         verneed: GNUVerNeedSection | None
         type: str | None
 
+    class SymbolVersion(TypedDict):
+        index: str | int | None
+        name: str | None
+        filename: str | None
+        hidden: bool | None
 
-def _get_cu_base(cu):
+
+def _get_cu_base(cu: CompileUnit):
     top_die = cu.get_top_DIE()
     attr = top_die.attributes
     if 'DW_AT_low_pc' in attr:
@@ -113,7 +121,7 @@ def _format_symbol_name(s: str) -> str:
 class ReadElf:
     """ display_* methods are used to emit output into the output stream
     """
-    def __init__(self, file, output):
+    def __init__(self, file: IO[bytes], output: IO[str]) -> None:
         """ file:
                 stream object with the ELF file to read
 
@@ -806,7 +814,7 @@ class ReadElf:
         elif self.elffile['e_machine'] == 'EM_RISCV':
             self._display_arch_specific_riscv()
 
-    def display_hex_dump(self, section_spec) -> None:
+    def display_hex_dump(self, section_spec: int | str) -> None:
         """ Display a hex dump of a section. section_spec is either a section
             number or a name.
         """
@@ -854,7 +862,7 @@ class ReadElf:
 
         self._emitline()
 
-    def display_string_dump(self, section_spec) -> None:
+    def display_string_dump(self, section_spec: int | str) -> None:
         """ Display a strings dump of a section. section_spec is either a
             section number or a name.
         """
@@ -973,8 +981,13 @@ class ReadElf:
             field = '%' + '0%sx' % fieldsize
         return s + field % addr
 
-    def _print_version_section_header(self, version_section, name, lead0x=True,
-                                      indent=1):
+    def _print_version_section_header(
+        self,
+        version_section,
+        name: str,
+        lead0x: bool = True,
+        indent: int = 1,
+    ) -> None:
         """ Print a section header of one version related section (versym,
             verneed or verdef) with some options to accomodate readelf
             little differences between each header (e.g. indentation
@@ -1025,7 +1038,7 @@ class ReadElf:
 
         return info
 
-    def _symbol_version(self, nsym):
+    def _symbol_version(self, nsym: int) -> SymbolVersion | None:
         """ Return a dict containing information on the
             or None if no version information is available
         """
@@ -1061,7 +1074,7 @@ class ReadElf:
         symbol_version['index'] = index
         return symbol_version
 
-    def _section_from_spec(self, spec):
+    def _section_from_spec(self, spec: int | str) -> Section | None:
         """ Retrieve a section given a "spec" (either number or name).
             Return None if no such section exists in the file.
         """
@@ -1094,7 +1107,7 @@ class ReadElf:
             if isinstance(sec, SymbolTableIndexSection)
         }
 
-    def _note_relocs_for_section(self, section):
+    def _note_relocs_for_section(self, section: Section) -> None:
         """ If there are relocation sections pointing to the givne section,
             emit a note about it.
         """
@@ -1451,7 +1464,7 @@ class ReadElf:
                 self._format_hex(0, fullhex=True, lead0x=False),
                 self._format_hex(0, fullhex=True, lead0x=False)))
 
-    def _dump_frames_interp_info(self, section, cfi_entries):
+    def _dump_frames_interp_info(self, section, cfi_entries) -> None:
         """ Dump interpreted (decoded) frame information in a section.
 
         `section` is the Section instance that contains the call frame info
@@ -1571,7 +1584,7 @@ class ReadElf:
         else:
             self._dump_debug_locsection(di, loc_lists_sec)
 
-    def _dump_debug_locsection(self, di, loc_lists_sec):
+    def _dump_debug_locsection(self, di: DWARFInfo, loc_lists_sec) -> None:
         """ Dump the location lists from .debug_loc/.debug_loclists section
         """
         ver5 = loc_lists_sec.version >= 5
@@ -1626,7 +1639,7 @@ class ReadElf:
                 self._emitline('    Offset   Begin            End              Expression')
             self._dump_loclist(loc_list, line_template, cu_map)
 
-    def _dump_loclist(self, loc_list, line_template, cu_map):
+    def _dump_loclist(self, loc_list, line_template: str, cu_map: dict) -> None:
         in_views = False
         has_views = False
         base_ip = None
@@ -1688,7 +1701,7 @@ class ReadElf:
         last = loc_list[-1]
         self._emitline("    %08x <End of list>" % (last.entry_offset + last.entry_length))
 
-    def _dump_debug_loclists_CU_header(self, cu):
+    def _dump_debug_loclists_CU_header(self, cu: Container) -> None:
         # Header slightly different from that of v5 rangelist in-section CU header dump
         self._emitline('Table at Offset %s' % self._format_hex(cu.cu_offset, alternate=True))
         self._emitline('  Length:          %s' % self._format_hex(cu.unit_length, alternate=True))
@@ -1714,7 +1727,7 @@ class ReadElf:
         else:
             self._dump_debug_rangesection(di, range_lists_sec)
 
-    def _dump_debug_rnglists_CU_header(self, cu):
+    def _dump_debug_rnglists_CU_header(self, cu: CompileUnit) -> None:
         self._emitline(' Table at Offset: %s:' % self._format_hex(cu.cu_offset, alternate=True))
         self._emitline('  Length:          %s' % self._format_hex(cu.unit_length, alternate=True))
         self._emitline('  DWARF version:   %d' % cu.version)
@@ -1726,7 +1739,7 @@ class ReadElf:
             for i_offset in enumerate(cu.offsets):
                 self._emitline('    [%6d] 0x%x' % i_offset)
 
-    def _dump_debug_rangesection(self, di, range_lists_sec):
+    def _dump_debug_rangesection(self, di: DWARFInfo, range_lists_sec) -> None:
         # Last amended to match readelf 2.41
         ver5 = range_lists_sec.version >= 5
         section_name = (di.debug_rnglists_sec if ver5 else di.debug_ranges_sec).name
@@ -1770,7 +1783,16 @@ class ReadElf:
 
         # TODO: trailing empty CUs, if any?
 
-    def _dump_rangelist(self, range_list, cu_map, ver5, line_template, base_template, base_template_indexed, range_lists_sec):
+    def _dump_rangelist(
+        self,
+        range_list: list,
+        cu_map: dict,
+        ver5: bool,
+        line_template: str,
+        base_template: str,
+        base_template_indexed: str,
+        range_lists_sec,
+    ) -> None:
         # Weird discrepancy in binutils: for DWARFv5 it outputs entry offset,
         # for DWARF<=4 list offset.
         first = range_list[0]
@@ -1807,7 +1829,7 @@ class ReadElf:
         last = range_list[-1]
         self._emitline('    %08x <End of list>' % (last.entry_offset + last.entry_length if ver5 else first.entry_offset))
 
-    def _display_attributes(self, attr_sec, descriptor):
+    def _display_attributes(self, attr_sec, descriptor) -> None:
         """ Display the attributes contained in the section.
         """
         for s in attr_sec.iter_subsections():
@@ -1849,7 +1871,7 @@ SCRIPT_DESCRIPTION = 'Display information about the contents of ELF format files
 VERSION_STRING = '%%(prog)s: based on pyelftools %s' % __version__
 
 
-def main(stream=None):
+def main(stream: IO[str] | None = None) -> None:
     # parse the command-line arguments and invoke ReadElf
     argparser = argparse.ArgumentParser(
             usage='usage: %(prog)s [options] <elf-file>',


### PR DESCRIPTION
The last bits from #611 are extra as they do not type the API, but the `scripts/`. I have used this to develop the type-hints for the API, but this is not strictly required unless you consider them part of the API.

I find them very useful to understand, how the API is supposed to use. As some of their functions are large and complex, having some hint about the types being passed between those functions helps to understand their use.

Typing is not complete and `scripts/` is currently **not** checked: the path is missing in `pyproject.toml`.
1. The path cannot simply be added as both scripts define a `main()` function. Checking both files would required converting them into _modules_ so they can be `import`ed with different names.
2. There are many locations in both files, which requires more `assert isinstance(…)` or `assert … is not None` to be clean. IMHO that would clutter the code too much

If one or both is desired, I can have another look.