### PR TITLE
readelf: Always add one blank between columns

### DIFF
--- a/scripts/readelf.py
+++ b/scripts/readelf.py
@@ -1520,7 +1520,7 @@ class ReadElf:
                     if regnum == ra_regnum:
                         self._emit('ra      ')
                         continue
-                    self._emit('%-6s' % describe_reg_name(regnum))
+                    self._emit(' %-5s' % describe_reg_name(regnum))
             self._emitline()
 
             for line in decoded_table.table:
@@ -1538,7 +1538,7 @@ class ReadElf:
                         s = describe_CFI_register_rule(line[regnum])
                     else:
                         s = 'u'
-                    self._emit('%-6s' % s)
+                    self._emit(' %-5s' % s)
                 self._emitline()
         self._emitline()
 


### PR DESCRIPTION
While converting test tests to use [pytest](https://docs.pytest.org/) I stumbled over one difference, where `readelf.py` does not print at least one column separator:
```console
$ test/external_tools/readelf --debug-dump=frames-interp test/testfiles_for_dwarfdump/dwarf_v5ops.so.elf | grep 2d335
000000000002d335 rsp+10256 c-56  c-48  c-40  c-32  c-24  c-16  c-8
                          ^
$ scripts/readelf.py --debug-dump=frames-interp test/testfiles_for_dwarfdump/dwarf_v5ops.so.elf | grep 2d335 #broken
000000000002d335 rsp+10256c-56  c-48  c-40  c-32  c-24  c-16  c-8
                         ^^
$ scripts/readelf.py --debug-dump=frames-interp test/testfiles_for_dwarfdump/dwarf_v5ops.so.elf | grep 2d335 #fixed
000000000002d335 rsp+10256 c-56  c-48  c-40  c-32  c-24  c-16  c-8
                          ^
```
Insert at least one blank between each column; reduce the following column width by one character.