### PR TITLE
elf/section: Remove __hash__

### DIFF
--- a/elftools/elf/sections.py
+++ b/elftools/elf/sections.py
@@ -134,9 +134,6 @@ class Section:
     def __eq__(self, other: object) -> bool:
         return isinstance(other, Section) and self.header == other.header
 
-    def __hash__(self) -> int:
-        return hash(self.header)
-
 
 class NullSection(Section):
     """ ELF NULL section


### PR DESCRIPTION
`self.header: Container` is not hashable as it is modifiable. Remove `__hash__()` from `Section`.

Closes: #539