### PR TITLE
Minor typing fixes for dwarf

### DIFF
--- a/elftools/dwarf/callframe.py
+++ b/elftools/dwarf/callframe.py
@@ -14,6 +14,7 @@ from functools import cached_property
 from typing import IO, TYPE_CHECKING, Any, Literal, NamedTuple, cast
 from warnings import warn
 
+from ..common.exceptions import DWARFError
 from ..common.utils import (
     struct_parse, dwarf_assert, preserve_stream_pos)
 from ..construct import Struct, Switch
@@ -267,7 +268,7 @@ class CallFrameInfo:
                 case DW_CFA.GNU_args_size:
                     args = [struct_parse(structs.the_Dwarf_uleb128, self.stream)]
                 case _:
-                    dwarf_assert(False, f'Unknown CFI opcode: {raw_opcode:#04x}')
+                    raise DWARFError(f"Unknown CFI opcode: {raw_opcode:#04x}")
 
             instructions.append(CallFrameInstruction(opcode=opcode, args=args))
             offset = self.stream.tell()
@@ -670,7 +671,7 @@ class CFIEntry:
                 case DW_CFA.nop | DW_CFA.AARCH64_negate_ra_state:
                     pass
                 case _:
-                    dwarf_assert(False, f"Unknown CFI opcode: {instr.opcode:#02x}")
+                    raise DWARFError(f"Unknown CFI opcode: {instr.opcode:#02x}")
 
         # The current line is appended to the table after all instructions
         # have ended, if there were instructions.

--- a/elftools/dwarf/callframe.py
+++ b/elftools/dwarf/callframe.py
@@ -526,7 +526,7 @@ class CFIEntry:
         instructions: list[CallFrameInstruction],
         offset: int,
         augmentation_dict: Augmentation | None = None,
-        augmentation_bytes: bytes | None = b'',
+        augmentation_bytes: bytes = b"",
         cie: CIE | None = None,
     ) -> None:
         self.header = header
@@ -696,7 +696,7 @@ class FDE(CFIEntry):
         structs: DWARFStructs,
         instructions: list[CallFrameInstruction],
         offset: int,
-        augmentation_bytes: bytes | None = None,
+        augmentation_bytes: bytes = b"",
         cie: CIE | None = None,
         lsda_pointer: int | None = None,
     ) -> None:

--- a/elftools/dwarf/lineprogram.py
+++ b/elftools/dwarf/lineprogram.py
@@ -13,7 +13,8 @@ import copy
 from functools import cached_property
 from typing import IO, TYPE_CHECKING, Any, NamedTuple
 
-from ..common.utils import struct_parse, dwarf_assert
+from ..common.exceptions import DWARFError
+from ..common.utils import struct_parse
 from .constants import DW_LNE, DW_LNS
 
 if TYPE_CHECKING:
@@ -274,7 +275,6 @@ class LineProgram:
                     state.isa = operand
                     add_entry_old_state(opcode, [operand])
                 else:
-                    dwarf_assert(False, 'Invalid standard line program opcode: %s' % (
-                        opcode,))
+                    raise DWARFError(f"Invalid standard line program opcode: {opcode}")
             offset = self.stream.tell()
         return entries

--- a/elftools/dwarf/structs.py
+++ b/elftools/dwarf/structs.py
@@ -429,7 +429,7 @@ class DWARFStructs:
                     context[self.format_field + "_parser"] = parser
                 return parser._parse(stream, context)
 
-        def ver5(ctx):
+        def ver5(ctx: Container) -> bool:
             return ctx.version >= 5
 
         self.Dwarf_lineprog_header = Struct('Dwarf_lineprog_header',


### PR DESCRIPTION
:+1: to use `ruff`, but sadly you introduces one minor but by converting an _lambda_ into an _untyped function_.

I also had (another) look on how to remove the duplication of `{dwarf,elf}_assert()` vs. `assert`s required for typing. While doing that I stumbled over 3 `dwarf_assert(False, …)`, which should be replaced by an `raise DWARFError()` to make the error more obvious (and to reduce the length of the backtrace).

I also noticed, that `class FDE(CFIEntry)` has a slightly different type-annotation than its super-class, which I have fixed.