### PR TITLE
Fix iter_notes crash on GNU build-ID notes in core dumps

### DIFF
--- a/elftools/elf/notes.py
+++ b/elftools/elf/notes.py
@@ -12,12 +12,23 @@ from typing import TYPE_CHECKING
 
 from ..common.utils import struct_parse, roundup, bytes2str
 from ..construct import CString
+from .enums import ENUM_NOTE_N_TYPE, ENUM_CORE_NOTE_N_TYPE
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
 
     from ..construct.lib.container import Container
     from .elffile import ELFFile
+
+
+# In ET_CORE files the note type is decoded with the core-note enum, but a note
+# named 'GNU' uses the generic GNU note types regardless of the ELF type (e.g.
+# type 3 is NT_GNU_BUILD_ID, not the core NT_PRPSINFO). These maps recover the
+# raw type value so such notes can be re-resolved against the generic enum.
+_CORE_NOTE_TYPE_VALUE = {name: value for name, value in ENUM_CORE_NOTE_N_TYPE.items()
+                         if isinstance(value, int)}
+_GNU_NOTE_TYPE_BY_VALUE = {value: name for name, value in ENUM_NOTE_N_TYPE.items()
+                           if isinstance(value, int)}
 
 
 def iter_notes(elffile: ELFFile, offset: int, size: int) -> Iterator[Container]:
@@ -43,6 +54,14 @@ def iter_notes(elffile: ELFFile, offset: int, size: int) -> Iterator[Container]:
             offset += disk_namesz
         else:
             note['n_name'] = None
+
+        if note['n_name'] == 'GNU' and elffile['e_type'] == 'ET_CORE':
+            # A GNU-named note carries a generic GNU type even inside a core
+            # dump, so re-resolve the type that was decoded with the core enum.
+            raw_type = (note['n_type'] if isinstance(note['n_type'], int)
+                        else _CORE_NOTE_TYPE_VALUE.get(note['n_type']))
+            if raw_type in _GNU_NOTE_TYPE_BY_VALUE:
+                note['n_type'] = _GNU_NOTE_TYPE_BY_VALUE[raw_type]
 
         desc_data: bytes = elffile.stream.read(note['n_descsz'])
         note['n_descdata'] = desc_data

--- a/test/test_notes.py
+++ b/test/test_notes.py
@@ -1,8 +1,28 @@
+import io
 import os
+import struct
 import unittest
 
 from elftools.elf.elffile import ELFFile
 from elftools.elf.sections import NoteSection
+from elftools.elf.segments import NoteSegment
+
+
+def _build_core_with_gnu_note(n_type, desc):
+    """ Build a minimal 32-bit LE ARM ET_CORE ELF with a single PT_NOTE segment
+        holding one note named 'GNU' with the given type and descriptor.
+    """
+    name = b'GNU\x00'
+    note = struct.pack('<III', len(b'GNU') + 1, len(desc), n_type) + name + desc
+    ehsize, phentsize = 52, 32
+    p_offset = ehsize + phentsize
+    ehdr = (b'\x7fELF\x01\x01\x01\x00' + b'\x00' * 8 +
+            struct.pack('<HHIIIIIHHHHHH',
+                        4, 40, 1, 0, ehsize, 0, 0,
+                        ehsize, phentsize, 1, 0, 0, 0))
+    phdr = struct.pack('<IIIIIIII',
+                       4, p_offset, p_offset, p_offset, len(note), len(note), 0, 4)
+    return io.BytesIO(ehdr + phdr + note)
 
 
 class TestNotes(unittest.TestCase):
@@ -27,6 +47,20 @@ class TestNotes(unittest.TestCase):
             notes = list(note_sections[0].iter_notes())
             # There's one note in this section:
             self.assertEqual(len(notes), 1)
+
+    def test_gnu_build_id_note_in_core(self):
+        # A GNU build ID note (type 3, name 'GNU') can appear inside an ET_CORE
+        # file, where type 3 otherwise means NT_PRPSINFO. It must be decoded as
+        # NT_GNU_BUILD_ID rather than parsed as a prpsinfo struct (issue #656).
+        stream = _build_core_with_gnu_note(3, b'\xde\xad\xc0\xde\xde\xad\xc0\xde')
+        elf = ELFFile(stream)
+        segments = [s for s in elf.iter_segments() if isinstance(s, NoteSegment)]
+        self.assertEqual(len(segments), 1)
+        notes = list(segments[0].iter_notes())
+        self.assertEqual(len(notes), 1)
+        self.assertEqual(notes[0]['n_name'], 'GNU')
+        self.assertEqual(notes[0]['n_type'], 'NT_GNU_BUILD_ID')
+        self.assertEqual(notes[0]['n_desc'], 'deadc0dedeadc0de')
 
     def test_note_tc3xx_blinky(self):
         with ELFFile.load_from_path(os.path.join('test', 'testfiles_for_unittests', 'note_tc3xxx_blinky.elf')) as elf:


### PR DESCRIPTION
Core dumps can carry a GNU build-ID note (type 3, name `GNU`). But in an `ET_CORE` file type 3 means `NT_PRPSINFO`, so `iter_notes()` reads the short build ID as a 124-byte prpsinfo struct and blows up with `ELFParseError`. readelf handles the same file fine.

Fix: if a note is named `GNU` in a core file, resolve its type against the generic GNU enum instead. Only touches core files.

Open question for you: the broader fix is to decode `n_type` as a raw int and pick the enum from `n_name` in `iter_notes`. More general, but it changes the shared struct, so I kept this contained. Your call.

Test builds a tiny ET_CORE ELF with a build-ID note. Fails before, passes after. Suite green, ruff clean.

Closes #656.